### PR TITLE
Added unused interrupt vectors as software interrupt

### DIFF
--- a/device.x
+++ b/device.x
@@ -24,4 +24,9 @@ PROVIDE(ADC_IRQ_FIFO = DefaultHandler);
 PROVIDE(I2C0_IRQ = DefaultHandler);
 PROVIDE(I2C1_IRQ = DefaultHandler);
 PROVIDE(RTC_IRQ = DefaultHandler);
-
+PROVIDE(SWI_IRQ_0 = DefaultHandler);
+PROVIDE(SWI_IRQ_1 = DefaultHandler);
+PROVIDE(SWI_IRQ_2 = DefaultHandler);
+PROVIDE(SWI_IRQ_3 = DefaultHandler);
+PROVIDE(SWI_IRQ_4 = DefaultHandler);
+PROVIDE(SWI_IRQ_5 = DefaultHandler);

--- a/src/_vectors.rs
+++ b/src/_vectors.rs
@@ -25,6 +25,12 @@ extern "C" {
     fn I2C0_IRQ();
     fn I2C1_IRQ();
     fn RTC_IRQ();
+    fn SWI_IRQ_0();
+    fn SWI_IRQ_1();
+    fn SWI_IRQ_2();
+    fn SWI_IRQ_3();
+    fn SWI_IRQ_4();
+    fn SWI_IRQ_5();
 }
 pub union Vector {
     _handler: unsafe extern "C" fn(),
@@ -32,7 +38,7 @@ pub union Vector {
 }
 #[link_section = ".vector_table.interrupts"]
 #[no_mangle]
-pub static __INTERRUPTS: [Vector; 26] = [
+pub static __INTERRUPTS: [Vector; 32] = [
     Vector {
         _handler: TIMER_IRQ_0,
     },
@@ -99,4 +105,22 @@ pub static __INTERRUPTS: [Vector; 26] = [
     Vector { _handler: I2C0_IRQ },
     Vector { _handler: I2C1_IRQ },
     Vector { _handler: RTC_IRQ },
+    Vector {
+        _handler: SWI_IRQ_0,
+    },
+    Vector {
+        _handler: SWI_IRQ_1,
+    },
+    Vector {
+        _handler: SWI_IRQ_2,
+    },
+    Vector {
+        _handler: SWI_IRQ_3,
+    },
+    Vector {
+        _handler: SWI_IRQ_4,
+    },
+    Vector {
+        _handler: SWI_IRQ_5,
+    },
 ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,18 @@ pub enum Interrupt {
     I2C1_IRQ = 24,
     #[doc = "25 - RTC_IRQ"]
     RTC_IRQ = 25,
+    #[doc = "26 - SWI_IRQ_0"]
+    SWI_IRQ_0 = 26,
+    #[doc = "27 - SWI_IRQ_1"]
+    SWI_IRQ_1 = 27,
+    #[doc = "28 - SWI_IRQ_2"]
+    SWI_IRQ_2 = 28,
+    #[doc = "29 - SWI_IRQ_3"]
+    SWI_IRQ_3 = 29,
+    #[doc = "30 - SWI_IRQ_4"]
+    SWI_IRQ_4 = 30,
+    #[doc = "31 - SWI_IRQ_5"]
+    SWI_IRQ_5 = 31,
 }
 unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline(always)]

--- a/svd/rp2040.svd
+++ b/svd/rp2040.svd
@@ -46383,5 +46383,35 @@
       <size>32</size>
       <version>1</version>
     </peripheral>
+    <peripheral>
+      <name>SWI_IRQ</name>
+      <description>Virtual Peripheral to access unused NVIC software interrupts</description>
+      <baseAddress>0</baseAddress>
+      <registers></registers>
+      <interrupt>
+        <name>SWI_IRQ_0</name>
+        <value>26</value>
+      </interrupt>
+      <interrupt>
+        <name>SWI_IRQ_1</name>
+        <value>27</value>
+      </interrupt>
+      <interrupt>
+        <name>SWI_IRQ_2</name>
+        <value>28</value>
+      </interrupt>
+      <interrupt>
+        <name>SWI_IRQ_3</name>
+        <value>29</value>
+      </interrupt>
+      <interrupt>
+        <name>SWI_IRQ_4</name>
+        <value>30</value>
+      </interrupt>
+      <interrupt>
+        <name>SWI_IRQ_5</name>
+        <value>31</value>
+      </interrupt>
+    </peripheral>
   </peripherals>
 </device>

--- a/svd/rp2040.yaml
+++ b/svd/rp2040.yaml
@@ -379,5 +379,7 @@ transforms:
   - Delete:
       from: io_qspi::.*
   - Delete:
+      from: swi_irq::.*
+  - Delete:
       from: pads_qspi::.*
   - Sanitize: {}


### PR DESCRIPTION
The rp2040 has 6 more interrupts that are not wired to any peripherals, but can be used as software interrupts. THis PR adds those to the pac.

(This is bascially like https://github.com/rp-rs/rp2040-pac/pull/60 )

Caveat: I edited the svd file, which probably is not the correct way to do this, but it was the easiest way, without altering embassy-rs/chiptool . 