### PR TITLE
Add Debug and defmt::Format impls for fieldsets and interrupt enums.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ description = "Peripheral Access Crate (PAC) for Raspberry Pi Silicon chips."
 [dependencies]
 cortex-m = "0.7.1"
 cortex-m-rt = { version = ">=0.6.15,<0.8", optional = true }
+defmt = { version = "0.3.10", optional = true }
 
 [features]
 default = []
 rt = ["cortex-m-rt/device"]
 rp2040 = []
 rp235x = []
+defmt = ["dep:defmt"]
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/rp-pac/blob/v$VERSION/src/"

--- a/src/rp2040/adc/regs.rs
+++ b/src/rp2040/adc/regs.rs
@@ -109,6 +109,50 @@ impl Default for Cs {
         Cs(0)
     }
 }
+impl core::fmt::Debug for Cs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cs")
+            .field("en", &self.en())
+            .field("ts_en", &self.ts_en())
+            .field("start_once", &self.start_once())
+            .field("start_many", &self.start_many())
+            .field("ready", &self.ready())
+            .field("err", &self.err())
+            .field("err_sticky", &self.err_sticky())
+            .field("ainsel", &self.ainsel())
+            .field("rrobin", &self.rrobin())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cs {
+            en: bool,
+            ts_en: bool,
+            start_once: bool,
+            start_many: bool,
+            ready: bool,
+            err: bool,
+            err_sticky: bool,
+            ainsel: u8,
+            rrobin: u8,
+        }
+        let proxy = Cs {
+            en: self.en(),
+            ts_en: self.ts_en(),
+            start_once: self.start_once(),
+            start_many: self.start_many(),
+            ready: self.ready(),
+            err: self.err(),
+            err_sticky: self.err_sticky(),
+            ainsel: self.ainsel(),
+            rrobin: self.rrobin(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divider. If non-zero, CS_START_MANY will start conversions at regular intervals rather than back-to-back. The divider is reset when either of these fields are written. Total period is 1 + INT + FRAC / 256"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -141,6 +185,29 @@ impl Default for Div {
     #[inline(always)]
     fn default() -> Div {
         Div(0)
+    }
+}
+impl core::fmt::Debug for Div {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Div")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Div {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Div {
+            frac: u8,
+            int: u16,
+        }
+        let proxy = Div {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "FIFO control and status"]
@@ -261,6 +328,53 @@ impl Default for Fcs {
         Fcs(0)
     }
 }
+impl core::fmt::Debug for Fcs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fcs")
+            .field("en", &self.en())
+            .field("shift", &self.shift())
+            .field("err", &self.err())
+            .field("dreq_en", &self.dreq_en())
+            .field("empty", &self.empty())
+            .field("full", &self.full())
+            .field("under", &self.under())
+            .field("over", &self.over())
+            .field("level", &self.level())
+            .field("thresh", &self.thresh())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fcs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fcs {
+            en: bool,
+            shift: bool,
+            err: bool,
+            dreq_en: bool,
+            empty: bool,
+            full: bool,
+            under: bool,
+            over: bool,
+            level: u8,
+            thresh: u8,
+        }
+        let proxy = Fcs {
+            en: self.en(),
+            shift: self.shift(),
+            err: self.err(),
+            dreq_en: self.dreq_en(),
+            empty: self.empty(),
+            full: self.full(),
+            under: self.under(),
+            over: self.over(),
+            level: self.level(),
+            thresh: self.thresh(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Conversion result FIFO"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -293,6 +407,29 @@ impl Default for Fifo {
         Fifo(0)
     }
 }
+impl core::fmt::Debug for Fifo {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fifo")
+            .field("val", &self.val())
+            .field("err", &self.err())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fifo {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fifo {
+            val: u16,
+            err: bool,
+        }
+        let proxy = Fifo {
+            val: self.val(),
+            err: self.err(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -316,6 +453,22 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int").field("fifo", &self.fifo()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            fifo: bool,
+        }
+        let proxy = Int { fifo: self.fifo() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Result of most recent ADC conversion"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -335,5 +488,25 @@ impl Default for Result {
     #[inline(always)]
     fn default() -> Result {
         Result(0)
+    }
+}
+impl core::fmt::Debug for Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Result")
+            .field("result", &self.result())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Result {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Result {
+            result: u16,
+        }
+        let proxy = Result {
+            result: self.result(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/busctrl/regs.rs
+++ b/src/rp2040/busctrl/regs.rs
@@ -54,6 +54,35 @@ impl Default for BusPriority {
         BusPriority(0)
     }
 }
+impl core::fmt::Debug for BusPriority {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BusPriority")
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .field("dma_r", &self.dma_r())
+            .field("dma_w", &self.dma_w())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BusPriority {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BusPriority {
+            proc0: bool,
+            proc1: bool,
+            dma_r: bool,
+            dma_w: bool,
+        }
+        let proxy = BusPriority {
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+            dma_r: self.dma_r(),
+            dma_w: self.dma_w(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Bus priority acknowledge"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -77,18 +106,38 @@ impl Default for BusPriorityAck {
         BusPriorityAck(0)
     }
 }
-#[doc = "Bus fabric performance counter 2"]
+impl core::fmt::Debug for BusPriorityAck {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BusPriorityAck")
+            .field("bus_priority_ack", &self.bus_priority_ack())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BusPriorityAck {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BusPriorityAck {
+            bus_priority_ack: bool,
+        }
+        let proxy = BusPriorityAck {
+            bus_priority_ack: self.bus_priority_ack(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Bus fabric performance counter 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Perfctr(pub u32);
 impl Perfctr {
-    #[doc = "Busfabric saturating performance counter 2 Count some event signal from the busfabric arbiters. Write any value to clear. Select an event to count using PERFSEL2"]
+    #[doc = "Busfabric saturating performance counter 0 Count some event signal from the busfabric arbiters. Write any value to clear. Select an event to count using PERFSEL0"]
     #[inline(always)]
     pub const fn perfctr(&self) -> u32 {
         let val = (self.0 >> 0usize) & 0x00ff_ffff;
         val as u32
     }
-    #[doc = "Busfabric saturating performance counter 2 Count some event signal from the busfabric arbiters. Write any value to clear. Select an event to count using PERFSEL2"]
+    #[doc = "Busfabric saturating performance counter 0 Count some event signal from the busfabric arbiters. Write any value to clear. Select an event to count using PERFSEL0"]
     #[inline(always)]
     pub fn set_perfctr(&mut self, val: u32) {
         self.0 = (self.0 & !(0x00ff_ffff << 0usize)) | (((val as u32) & 0x00ff_ffff) << 0usize);
@@ -98,6 +147,26 @@ impl Default for Perfctr {
     #[inline(always)]
     fn default() -> Perfctr {
         Perfctr(0)
+    }
+}
+impl core::fmt::Debug for Perfctr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Perfctr")
+            .field("perfctr", &self.perfctr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Perfctr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Perfctr {
+            perfctr: u32,
+        }
+        let proxy = Perfctr {
+            perfctr: self.perfctr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Bus fabric performance event select for PERFCTR0"]
@@ -121,5 +190,25 @@ impl Default for Perfsel {
     #[inline(always)]
     fn default() -> Perfsel {
         Perfsel(0)
+    }
+}
+impl core::fmt::Debug for Perfsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Perfsel")
+            .field("perfsel", &self.perfsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Perfsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Perfsel {
+            perfsel: super::vals::Perfsel,
+        }
+        let proxy = Perfsel {
+            perfsel: self.perfsel(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/busctrl/vals.rs
+++ b/src/rp2040/busctrl/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Perfsel {
     APB_CONTESTED = 0x0,
     APB = 0x01,

--- a/src/rp2040/clocks/regs.rs
+++ b/src/rp2040/clocks/regs.rs
@@ -65,6 +65,38 @@ impl Default for ClkAdcCtrl {
         ClkAdcCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkAdcCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkAdcCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkAdcCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkAdcCtrl {
+            auxsrc: super::vals::ClkAdcCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            phase: u8,
+            nudge: bool,
+        }
+        let proxy = ClkAdcCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -86,6 +118,24 @@ impl Default for ClkAdcDiv {
     #[inline(always)]
     fn default() -> ClkAdcDiv {
         ClkAdcDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkAdcDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkAdcDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkAdcDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkAdcDiv {
+            int: u8,
+        }
+        let proxy = ClkAdcDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -166,6 +216,41 @@ impl Default for ClkGpoutCtrl {
         ClkGpoutCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkGpoutCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpoutCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("dc50", &self.dc50())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpoutCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpoutCtrl {
+            auxsrc: super::vals::ClkGpoutCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            dc50: bool,
+            phase: u8,
+            nudge: bool,
+        }
+        let proxy = ClkGpoutCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            dc50: self.dc50(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -198,6 +283,29 @@ impl Default for ClkGpoutDiv {
     #[inline(always)]
     fn default() -> ClkGpoutDiv {
         ClkGpoutDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkGpoutDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpoutDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpoutDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpoutDiv {
+            frac: u8,
+            int: u32,
+        }
+        let proxy = ClkGpoutDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -245,6 +353,32 @@ impl Default for ClkPeriCtrl {
         ClkPeriCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkPeriCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkPeriCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkPeriCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkPeriCtrl {
+            auxsrc: super::vals::ClkPeriCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+        }
+        let proxy = ClkPeriCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -277,6 +411,29 @@ impl Default for ClkPeriDiv {
     #[inline(always)]
     fn default() -> ClkPeriDiv {
         ClkPeriDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkPeriDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkPeriDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkPeriDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkPeriDiv {
+            frac: u8,
+            int: u32,
+        }
+        let proxy = ClkPeriDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -313,6 +470,29 @@ impl Default for ClkRefCtrl {
         ClkRefCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkRefCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRefCtrl")
+            .field("src", &self.src())
+            .field("auxsrc", &self.auxsrc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRefCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRefCtrl {
+            src: super::vals::ClkRefCtrlSrc,
+            auxsrc: super::vals::ClkRefCtrlAuxsrc,
+        }
+        let proxy = ClkRefCtrl {
+            src: self.src(),
+            auxsrc: self.auxsrc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -334,6 +514,24 @@ impl Default for ClkRefDiv {
     #[inline(always)]
     fn default() -> ClkRefDiv {
         ClkRefDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkRefDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRefDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRefDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRefDiv {
+            int: u8,
+        }
+        let proxy = ClkRefDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -403,6 +601,38 @@ impl Default for ClkRtcCtrl {
         ClkRtcCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkRtcCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRtcCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRtcCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRtcCtrl {
+            auxsrc: super::vals::ClkRtcCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            phase: u8,
+            nudge: bool,
+        }
+        let proxy = ClkRtcCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -435,6 +665,29 @@ impl Default for ClkRtcDiv {
     #[inline(always)]
     fn default() -> ClkRtcDiv {
         ClkRtcDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkRtcDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRtcDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRtcDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRtcDiv {
+            frac: u8,
+            int: u32,
+        }
+        let proxy = ClkRtcDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -471,6 +724,29 @@ impl Default for ClkSysCtrl {
         ClkSysCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkSysCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysCtrl")
+            .field("src", &self.src())
+            .field("auxsrc", &self.auxsrc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysCtrl {
+            src: super::vals::ClkSysCtrlSrc,
+            auxsrc: super::vals::ClkSysCtrlAuxsrc,
+        }
+        let proxy = ClkSysCtrl {
+            src: self.src(),
+            auxsrc: self.auxsrc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -503,6 +779,29 @@ impl Default for ClkSysDiv {
     #[inline(always)]
     fn default() -> ClkSysDiv {
         ClkSysDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkSysDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysDiv {
+            frac: u8,
+            int: u32,
+        }
+        let proxy = ClkSysDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -560,6 +859,35 @@ impl Default for ClkSysResusCtrl {
         ClkSysResusCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkSysResusCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysResusCtrl")
+            .field("timeout", &self.timeout())
+            .field("enable", &self.enable())
+            .field("frce", &self.frce())
+            .field("clear", &self.clear())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysResusCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysResusCtrl {
+            timeout: u8,
+            enable: bool,
+            frce: bool,
+            clear: bool,
+        }
+        let proxy = ClkSysResusCtrl {
+            timeout: self.timeout(),
+            enable: self.enable(),
+            frce: self.frce(),
+            clear: self.clear(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkSysResusStatus(pub u32);
@@ -580,6 +908,26 @@ impl Default for ClkSysResusStatus {
     #[inline(always)]
     fn default() -> ClkSysResusStatus {
         ClkSysResusStatus(0)
+    }
+}
+impl core::fmt::Debug for ClkSysResusStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysResusStatus")
+            .field("resussed", &self.resussed())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysResusStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysResusStatus {
+            resussed: bool,
+        }
+        let proxy = ClkSysResusStatus {
+            resussed: self.resussed(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -649,6 +997,38 @@ impl Default for ClkUsbCtrl {
         ClkUsbCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkUsbCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkUsbCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkUsbCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkUsbCtrl {
+            auxsrc: super::vals::ClkUsbCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            phase: u8,
+            nudge: bool,
+        }
+        let proxy = ClkUsbCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divisor, can be changed on-the-fly"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -670,6 +1050,24 @@ impl Default for ClkUsbDiv {
     #[inline(always)]
     fn default() -> ClkUsbDiv {
         ClkUsbDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkUsbDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkUsbDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkUsbDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkUsbDiv {
+            int: u8,
+        }
+        let proxy = ClkUsbDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "indicates the state of the clock enable"]
@@ -972,6 +1370,122 @@ impl Default for Enabled0 {
         Enabled0(0)
     }
 }
+impl core::fmt::Debug for Enabled0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Enabled0")
+            .field("clk_sys_clocks", &self.clk_sys_clocks())
+            .field("clk_adc_adc", &self.clk_adc_adc())
+            .field("clk_sys_adc", &self.clk_sys_adc())
+            .field("clk_sys_busctrl", &self.clk_sys_busctrl())
+            .field("clk_sys_busfabric", &self.clk_sys_busfabric())
+            .field("clk_sys_dma", &self.clk_sys_dma())
+            .field("clk_sys_i2c0", &self.clk_sys_i2c0())
+            .field("clk_sys_i2c1", &self.clk_sys_i2c1())
+            .field("clk_sys_io", &self.clk_sys_io())
+            .field("clk_sys_jtag", &self.clk_sys_jtag())
+            .field(
+                "clk_sys_vreg_and_chip_reset",
+                &self.clk_sys_vreg_and_chip_reset(),
+            )
+            .field("clk_sys_pads", &self.clk_sys_pads())
+            .field("clk_sys_pio0", &self.clk_sys_pio0())
+            .field("clk_sys_pio1", &self.clk_sys_pio1())
+            .field("clk_sys_pll_sys", &self.clk_sys_pll_sys())
+            .field("clk_sys_pll_usb", &self.clk_sys_pll_usb())
+            .field("clk_sys_psm", &self.clk_sys_psm())
+            .field("clk_sys_pwm", &self.clk_sys_pwm())
+            .field("clk_sys_resets", &self.clk_sys_resets())
+            .field("clk_sys_rom", &self.clk_sys_rom())
+            .field("clk_sys_rosc", &self.clk_sys_rosc())
+            .field("clk_rtc_rtc", &self.clk_rtc_rtc())
+            .field("clk_sys_rtc", &self.clk_sys_rtc())
+            .field("clk_sys_sio", &self.clk_sys_sio())
+            .field("clk_peri_spi0", &self.clk_peri_spi0())
+            .field("clk_sys_spi0", &self.clk_sys_spi0())
+            .field("clk_peri_spi1", &self.clk_peri_spi1())
+            .field("clk_sys_spi1", &self.clk_sys_spi1())
+            .field("clk_sys_sram0", &self.clk_sys_sram0())
+            .field("clk_sys_sram1", &self.clk_sys_sram1())
+            .field("clk_sys_sram2", &self.clk_sys_sram2())
+            .field("clk_sys_sram3", &self.clk_sys_sram3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enabled0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Enabled0 {
+            clk_sys_clocks: bool,
+            clk_adc_adc: bool,
+            clk_sys_adc: bool,
+            clk_sys_busctrl: bool,
+            clk_sys_busfabric: bool,
+            clk_sys_dma: bool,
+            clk_sys_i2c0: bool,
+            clk_sys_i2c1: bool,
+            clk_sys_io: bool,
+            clk_sys_jtag: bool,
+            clk_sys_vreg_and_chip_reset: bool,
+            clk_sys_pads: bool,
+            clk_sys_pio0: bool,
+            clk_sys_pio1: bool,
+            clk_sys_pll_sys: bool,
+            clk_sys_pll_usb: bool,
+            clk_sys_psm: bool,
+            clk_sys_pwm: bool,
+            clk_sys_resets: bool,
+            clk_sys_rom: bool,
+            clk_sys_rosc: bool,
+            clk_rtc_rtc: bool,
+            clk_sys_rtc: bool,
+            clk_sys_sio: bool,
+            clk_peri_spi0: bool,
+            clk_sys_spi0: bool,
+            clk_peri_spi1: bool,
+            clk_sys_spi1: bool,
+            clk_sys_sram0: bool,
+            clk_sys_sram1: bool,
+            clk_sys_sram2: bool,
+            clk_sys_sram3: bool,
+        }
+        let proxy = Enabled0 {
+            clk_sys_clocks: self.clk_sys_clocks(),
+            clk_adc_adc: self.clk_adc_adc(),
+            clk_sys_adc: self.clk_sys_adc(),
+            clk_sys_busctrl: self.clk_sys_busctrl(),
+            clk_sys_busfabric: self.clk_sys_busfabric(),
+            clk_sys_dma: self.clk_sys_dma(),
+            clk_sys_i2c0: self.clk_sys_i2c0(),
+            clk_sys_i2c1: self.clk_sys_i2c1(),
+            clk_sys_io: self.clk_sys_io(),
+            clk_sys_jtag: self.clk_sys_jtag(),
+            clk_sys_vreg_and_chip_reset: self.clk_sys_vreg_and_chip_reset(),
+            clk_sys_pads: self.clk_sys_pads(),
+            clk_sys_pio0: self.clk_sys_pio0(),
+            clk_sys_pio1: self.clk_sys_pio1(),
+            clk_sys_pll_sys: self.clk_sys_pll_sys(),
+            clk_sys_pll_usb: self.clk_sys_pll_usb(),
+            clk_sys_psm: self.clk_sys_psm(),
+            clk_sys_pwm: self.clk_sys_pwm(),
+            clk_sys_resets: self.clk_sys_resets(),
+            clk_sys_rom: self.clk_sys_rom(),
+            clk_sys_rosc: self.clk_sys_rosc(),
+            clk_rtc_rtc: self.clk_rtc_rtc(),
+            clk_sys_rtc: self.clk_sys_rtc(),
+            clk_sys_sio: self.clk_sys_sio(),
+            clk_peri_spi0: self.clk_peri_spi0(),
+            clk_sys_spi0: self.clk_sys_spi0(),
+            clk_peri_spi1: self.clk_peri_spi1(),
+            clk_sys_spi1: self.clk_sys_spi1(),
+            clk_sys_sram0: self.clk_sys_sram0(),
+            clk_sys_sram1: self.clk_sys_sram1(),
+            clk_sys_sram2: self.clk_sys_sram2(),
+            clk_sys_sram3: self.clk_sys_sram3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "indicates the state of the clock enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1119,6 +1633,68 @@ impl Default for Enabled1 {
         Enabled1(0)
     }
 }
+impl core::fmt::Debug for Enabled1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Enabled1")
+            .field("clk_sys_sram4", &self.clk_sys_sram4())
+            .field("clk_sys_sram5", &self.clk_sys_sram5())
+            .field("clk_sys_syscfg", &self.clk_sys_syscfg())
+            .field("clk_sys_sysinfo", &self.clk_sys_sysinfo())
+            .field("clk_sys_tbman", &self.clk_sys_tbman())
+            .field("clk_sys_timer", &self.clk_sys_timer())
+            .field("clk_peri_uart0", &self.clk_peri_uart0())
+            .field("clk_sys_uart0", &self.clk_sys_uart0())
+            .field("clk_peri_uart1", &self.clk_peri_uart1())
+            .field("clk_sys_uart1", &self.clk_sys_uart1())
+            .field("clk_sys_usbctrl", &self.clk_sys_usbctrl())
+            .field("clk_usb_usbctrl", &self.clk_usb_usbctrl())
+            .field("clk_sys_watchdog", &self.clk_sys_watchdog())
+            .field("clk_sys_xip", &self.clk_sys_xip())
+            .field("clk_sys_xosc", &self.clk_sys_xosc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enabled1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Enabled1 {
+            clk_sys_sram4: bool,
+            clk_sys_sram5: bool,
+            clk_sys_syscfg: bool,
+            clk_sys_sysinfo: bool,
+            clk_sys_tbman: bool,
+            clk_sys_timer: bool,
+            clk_peri_uart0: bool,
+            clk_sys_uart0: bool,
+            clk_peri_uart1: bool,
+            clk_sys_uart1: bool,
+            clk_sys_usbctrl: bool,
+            clk_usb_usbctrl: bool,
+            clk_sys_watchdog: bool,
+            clk_sys_xip: bool,
+            clk_sys_xosc: bool,
+        }
+        let proxy = Enabled1 {
+            clk_sys_sram4: self.clk_sys_sram4(),
+            clk_sys_sram5: self.clk_sys_sram5(),
+            clk_sys_syscfg: self.clk_sys_syscfg(),
+            clk_sys_sysinfo: self.clk_sys_sysinfo(),
+            clk_sys_tbman: self.clk_sys_tbman(),
+            clk_sys_timer: self.clk_sys_timer(),
+            clk_peri_uart0: self.clk_peri_uart0(),
+            clk_sys_uart0: self.clk_sys_uart0(),
+            clk_peri_uart1: self.clk_peri_uart1(),
+            clk_sys_uart1: self.clk_sys_uart1(),
+            clk_sys_usbctrl: self.clk_sys_usbctrl(),
+            clk_usb_usbctrl: self.clk_usb_usbctrl(),
+            clk_sys_watchdog: self.clk_sys_watchdog(),
+            clk_sys_xip: self.clk_sys_xip(),
+            clk_sys_xosc: self.clk_sys_xosc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Delays the start of frequency counting to allow the mux to settle Delay is measured in multiples of the reference clock period"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1138,6 +1714,26 @@ impl Default for Fc0delay {
     #[inline(always)]
     fn default() -> Fc0delay {
         Fc0delay(0)
+    }
+}
+impl core::fmt::Debug for Fc0delay {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0delay")
+            .field("fc0_delay", &self.fc0_delay())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0delay {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0delay {
+            fc0_delay: u8,
+        }
+        let proxy = Fc0delay {
+            fc0_delay: self.fc0_delay(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "The test interval is 0.98us * 2**interval, but let's call it 1us * 2**interval The default gives a test interval of 250us"]
@@ -1161,6 +1757,26 @@ impl Default for Fc0interval {
         Fc0interval(0)
     }
 }
+impl core::fmt::Debug for Fc0interval {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0interval")
+            .field("fc0_interval", &self.fc0_interval())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0interval {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0interval {
+            fc0_interval: u8,
+        }
+        let proxy = Fc0interval {
+            fc0_interval: self.fc0_interval(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Maximum pass frequency in kHz. This is optional. Set to 0x1ffffff if you are not using the pass/fail flags"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1180,6 +1796,26 @@ impl Default for Fc0maxKhz {
     #[inline(always)]
     fn default() -> Fc0maxKhz {
         Fc0maxKhz(0)
+    }
+}
+impl core::fmt::Debug for Fc0maxKhz {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0maxKhz")
+            .field("fc0_max_khz", &self.fc0_max_khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0maxKhz {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0maxKhz {
+            fc0_max_khz: u32,
+        }
+        let proxy = Fc0maxKhz {
+            fc0_max_khz: self.fc0_max_khz(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Minimum pass frequency in kHz. This is optional. Set to 0 if you are not using the pass/fail flags"]
@@ -1203,6 +1839,26 @@ impl Default for Fc0minKhz {
         Fc0minKhz(0)
     }
 }
+impl core::fmt::Debug for Fc0minKhz {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0minKhz")
+            .field("fc0_min_khz", &self.fc0_min_khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0minKhz {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0minKhz {
+            fc0_min_khz: u32,
+        }
+        let proxy = Fc0minKhz {
+            fc0_min_khz: self.fc0_min_khz(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Reference clock frequency in kHz"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1222,6 +1878,26 @@ impl Default for Fc0refKhz {
     #[inline(always)]
     fn default() -> Fc0refKhz {
         Fc0refKhz(0)
+    }
+}
+impl core::fmt::Debug for Fc0refKhz {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0refKhz")
+            .field("fc0_ref_khz", &self.fc0_ref_khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0refKhz {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0refKhz {
+            fc0_ref_khz: u32,
+        }
+        let proxy = Fc0refKhz {
+            fc0_ref_khz: self.fc0_ref_khz(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Result of frequency measurement, only valid when status_done=1"]
@@ -1254,6 +1930,29 @@ impl Default for Fc0result {
         Fc0result(0)
     }
 }
+impl core::fmt::Debug for Fc0result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0result")
+            .field("frac", &self.frac())
+            .field("khz", &self.khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0result {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0result {
+            frac: u8,
+            khz: u32,
+        }
+        let proxy = Fc0result {
+            frac: self.frac(),
+            khz: self.khz(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock sent to frequency counter, set to 0 when not required Writing to this register initiates the frequency count"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1273,6 +1972,26 @@ impl Default for Fc0src {
     #[inline(always)]
     fn default() -> Fc0src {
         Fc0src(0)
+    }
+}
+impl core::fmt::Debug for Fc0src {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0src")
+            .field("fc0_src", &self.fc0_src())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0src {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0src {
+            fc0_src: super::vals::Fc0src,
+        }
+        let proxy = Fc0src {
+            fc0_src: self.fc0_src(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Frequency counter status"]
@@ -1375,7 +2094,48 @@ impl Default for Fc0status {
         Fc0status(0)
     }
 }
-#[doc = "Interrupt Force"]
+impl core::fmt::Debug for Fc0status {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0status")
+            .field("pass", &self.pass())
+            .field("done", &self.done())
+            .field("running", &self.running())
+            .field("waiting", &self.waiting())
+            .field("fail", &self.fail())
+            .field("slow", &self.slow())
+            .field("fast", &self.fast())
+            .field("died", &self.died())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0status {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0status {
+            pass: bool,
+            done: bool,
+            running: bool,
+            waiting: bool,
+            fail: bool,
+            slow: bool,
+            fast: bool,
+            died: bool,
+        }
+        let proxy = Fc0status {
+            pass: self.pass(),
+            done: self.done(),
+            running: self.running(),
+            waiting: self.waiting(),
+            fail: self.fail(),
+            slow: self.slow(),
+            fast: self.fast(),
+            died: self.died(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -1394,6 +2154,26 @@ impl Default for Int {
     #[inline(always)]
     fn default() -> Int {
         Int(0)
+    }
+}
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field("clk_sys_resus", &self.clk_sys_resus())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            clk_sys_resus: bool,
+        }
+        let proxy = Int {
+            clk_sys_resus: self.clk_sys_resus(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "enable clock in sleep mode"]
@@ -1696,6 +2476,122 @@ impl Default for SleepEn0 {
         SleepEn0(0)
     }
 }
+impl core::fmt::Debug for SleepEn0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SleepEn0")
+            .field("clk_sys_clocks", &self.clk_sys_clocks())
+            .field("clk_adc_adc", &self.clk_adc_adc())
+            .field("clk_sys_adc", &self.clk_sys_adc())
+            .field("clk_sys_busctrl", &self.clk_sys_busctrl())
+            .field("clk_sys_busfabric", &self.clk_sys_busfabric())
+            .field("clk_sys_dma", &self.clk_sys_dma())
+            .field("clk_sys_i2c0", &self.clk_sys_i2c0())
+            .field("clk_sys_i2c1", &self.clk_sys_i2c1())
+            .field("clk_sys_io", &self.clk_sys_io())
+            .field("clk_sys_jtag", &self.clk_sys_jtag())
+            .field(
+                "clk_sys_vreg_and_chip_reset",
+                &self.clk_sys_vreg_and_chip_reset(),
+            )
+            .field("clk_sys_pads", &self.clk_sys_pads())
+            .field("clk_sys_pio0", &self.clk_sys_pio0())
+            .field("clk_sys_pio1", &self.clk_sys_pio1())
+            .field("clk_sys_pll_sys", &self.clk_sys_pll_sys())
+            .field("clk_sys_pll_usb", &self.clk_sys_pll_usb())
+            .field("clk_sys_psm", &self.clk_sys_psm())
+            .field("clk_sys_pwm", &self.clk_sys_pwm())
+            .field("clk_sys_resets", &self.clk_sys_resets())
+            .field("clk_sys_rom", &self.clk_sys_rom())
+            .field("clk_sys_rosc", &self.clk_sys_rosc())
+            .field("clk_rtc_rtc", &self.clk_rtc_rtc())
+            .field("clk_sys_rtc", &self.clk_sys_rtc())
+            .field("clk_sys_sio", &self.clk_sys_sio())
+            .field("clk_peri_spi0", &self.clk_peri_spi0())
+            .field("clk_sys_spi0", &self.clk_sys_spi0())
+            .field("clk_peri_spi1", &self.clk_peri_spi1())
+            .field("clk_sys_spi1", &self.clk_sys_spi1())
+            .field("clk_sys_sram0", &self.clk_sys_sram0())
+            .field("clk_sys_sram1", &self.clk_sys_sram1())
+            .field("clk_sys_sram2", &self.clk_sys_sram2())
+            .field("clk_sys_sram3", &self.clk_sys_sram3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SleepEn0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SleepEn0 {
+            clk_sys_clocks: bool,
+            clk_adc_adc: bool,
+            clk_sys_adc: bool,
+            clk_sys_busctrl: bool,
+            clk_sys_busfabric: bool,
+            clk_sys_dma: bool,
+            clk_sys_i2c0: bool,
+            clk_sys_i2c1: bool,
+            clk_sys_io: bool,
+            clk_sys_jtag: bool,
+            clk_sys_vreg_and_chip_reset: bool,
+            clk_sys_pads: bool,
+            clk_sys_pio0: bool,
+            clk_sys_pio1: bool,
+            clk_sys_pll_sys: bool,
+            clk_sys_pll_usb: bool,
+            clk_sys_psm: bool,
+            clk_sys_pwm: bool,
+            clk_sys_resets: bool,
+            clk_sys_rom: bool,
+            clk_sys_rosc: bool,
+            clk_rtc_rtc: bool,
+            clk_sys_rtc: bool,
+            clk_sys_sio: bool,
+            clk_peri_spi0: bool,
+            clk_sys_spi0: bool,
+            clk_peri_spi1: bool,
+            clk_sys_spi1: bool,
+            clk_sys_sram0: bool,
+            clk_sys_sram1: bool,
+            clk_sys_sram2: bool,
+            clk_sys_sram3: bool,
+        }
+        let proxy = SleepEn0 {
+            clk_sys_clocks: self.clk_sys_clocks(),
+            clk_adc_adc: self.clk_adc_adc(),
+            clk_sys_adc: self.clk_sys_adc(),
+            clk_sys_busctrl: self.clk_sys_busctrl(),
+            clk_sys_busfabric: self.clk_sys_busfabric(),
+            clk_sys_dma: self.clk_sys_dma(),
+            clk_sys_i2c0: self.clk_sys_i2c0(),
+            clk_sys_i2c1: self.clk_sys_i2c1(),
+            clk_sys_io: self.clk_sys_io(),
+            clk_sys_jtag: self.clk_sys_jtag(),
+            clk_sys_vreg_and_chip_reset: self.clk_sys_vreg_and_chip_reset(),
+            clk_sys_pads: self.clk_sys_pads(),
+            clk_sys_pio0: self.clk_sys_pio0(),
+            clk_sys_pio1: self.clk_sys_pio1(),
+            clk_sys_pll_sys: self.clk_sys_pll_sys(),
+            clk_sys_pll_usb: self.clk_sys_pll_usb(),
+            clk_sys_psm: self.clk_sys_psm(),
+            clk_sys_pwm: self.clk_sys_pwm(),
+            clk_sys_resets: self.clk_sys_resets(),
+            clk_sys_rom: self.clk_sys_rom(),
+            clk_sys_rosc: self.clk_sys_rosc(),
+            clk_rtc_rtc: self.clk_rtc_rtc(),
+            clk_sys_rtc: self.clk_sys_rtc(),
+            clk_sys_sio: self.clk_sys_sio(),
+            clk_peri_spi0: self.clk_peri_spi0(),
+            clk_sys_spi0: self.clk_sys_spi0(),
+            clk_peri_spi1: self.clk_peri_spi1(),
+            clk_sys_spi1: self.clk_sys_spi1(),
+            clk_sys_sram0: self.clk_sys_sram0(),
+            clk_sys_sram1: self.clk_sys_sram1(),
+            clk_sys_sram2: self.clk_sys_sram2(),
+            clk_sys_sram3: self.clk_sys_sram3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "enable clock in sleep mode"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1841,6 +2737,68 @@ impl Default for SleepEn1 {
     #[inline(always)]
     fn default() -> SleepEn1 {
         SleepEn1(0)
+    }
+}
+impl core::fmt::Debug for SleepEn1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SleepEn1")
+            .field("clk_sys_sram4", &self.clk_sys_sram4())
+            .field("clk_sys_sram5", &self.clk_sys_sram5())
+            .field("clk_sys_syscfg", &self.clk_sys_syscfg())
+            .field("clk_sys_sysinfo", &self.clk_sys_sysinfo())
+            .field("clk_sys_tbman", &self.clk_sys_tbman())
+            .field("clk_sys_timer", &self.clk_sys_timer())
+            .field("clk_peri_uart0", &self.clk_peri_uart0())
+            .field("clk_sys_uart0", &self.clk_sys_uart0())
+            .field("clk_peri_uart1", &self.clk_peri_uart1())
+            .field("clk_sys_uart1", &self.clk_sys_uart1())
+            .field("clk_sys_usbctrl", &self.clk_sys_usbctrl())
+            .field("clk_usb_usbctrl", &self.clk_usb_usbctrl())
+            .field("clk_sys_watchdog", &self.clk_sys_watchdog())
+            .field("clk_sys_xip", &self.clk_sys_xip())
+            .field("clk_sys_xosc", &self.clk_sys_xosc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SleepEn1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SleepEn1 {
+            clk_sys_sram4: bool,
+            clk_sys_sram5: bool,
+            clk_sys_syscfg: bool,
+            clk_sys_sysinfo: bool,
+            clk_sys_tbman: bool,
+            clk_sys_timer: bool,
+            clk_peri_uart0: bool,
+            clk_sys_uart0: bool,
+            clk_peri_uart1: bool,
+            clk_sys_uart1: bool,
+            clk_sys_usbctrl: bool,
+            clk_usb_usbctrl: bool,
+            clk_sys_watchdog: bool,
+            clk_sys_xip: bool,
+            clk_sys_xosc: bool,
+        }
+        let proxy = SleepEn1 {
+            clk_sys_sram4: self.clk_sys_sram4(),
+            clk_sys_sram5: self.clk_sys_sram5(),
+            clk_sys_syscfg: self.clk_sys_syscfg(),
+            clk_sys_sysinfo: self.clk_sys_sysinfo(),
+            clk_sys_tbman: self.clk_sys_tbman(),
+            clk_sys_timer: self.clk_sys_timer(),
+            clk_peri_uart0: self.clk_peri_uart0(),
+            clk_sys_uart0: self.clk_sys_uart0(),
+            clk_peri_uart1: self.clk_peri_uart1(),
+            clk_sys_uart1: self.clk_sys_uart1(),
+            clk_sys_usbctrl: self.clk_sys_usbctrl(),
+            clk_usb_usbctrl: self.clk_usb_usbctrl(),
+            clk_sys_watchdog: self.clk_sys_watchdog(),
+            clk_sys_xip: self.clk_sys_xip(),
+            clk_sys_xosc: self.clk_sys_xosc(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "enable clock in wake mode"]
@@ -2143,6 +3101,122 @@ impl Default for WakeEn0 {
         WakeEn0(0)
     }
 }
+impl core::fmt::Debug for WakeEn0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WakeEn0")
+            .field("clk_sys_clocks", &self.clk_sys_clocks())
+            .field("clk_adc_adc", &self.clk_adc_adc())
+            .field("clk_sys_adc", &self.clk_sys_adc())
+            .field("clk_sys_busctrl", &self.clk_sys_busctrl())
+            .field("clk_sys_busfabric", &self.clk_sys_busfabric())
+            .field("clk_sys_dma", &self.clk_sys_dma())
+            .field("clk_sys_i2c0", &self.clk_sys_i2c0())
+            .field("clk_sys_i2c1", &self.clk_sys_i2c1())
+            .field("clk_sys_io", &self.clk_sys_io())
+            .field("clk_sys_jtag", &self.clk_sys_jtag())
+            .field(
+                "clk_sys_vreg_and_chip_reset",
+                &self.clk_sys_vreg_and_chip_reset(),
+            )
+            .field("clk_sys_pads", &self.clk_sys_pads())
+            .field("clk_sys_pio0", &self.clk_sys_pio0())
+            .field("clk_sys_pio1", &self.clk_sys_pio1())
+            .field("clk_sys_pll_sys", &self.clk_sys_pll_sys())
+            .field("clk_sys_pll_usb", &self.clk_sys_pll_usb())
+            .field("clk_sys_psm", &self.clk_sys_psm())
+            .field("clk_sys_pwm", &self.clk_sys_pwm())
+            .field("clk_sys_resets", &self.clk_sys_resets())
+            .field("clk_sys_rom", &self.clk_sys_rom())
+            .field("clk_sys_rosc", &self.clk_sys_rosc())
+            .field("clk_rtc_rtc", &self.clk_rtc_rtc())
+            .field("clk_sys_rtc", &self.clk_sys_rtc())
+            .field("clk_sys_sio", &self.clk_sys_sio())
+            .field("clk_peri_spi0", &self.clk_peri_spi0())
+            .field("clk_sys_spi0", &self.clk_sys_spi0())
+            .field("clk_peri_spi1", &self.clk_peri_spi1())
+            .field("clk_sys_spi1", &self.clk_sys_spi1())
+            .field("clk_sys_sram0", &self.clk_sys_sram0())
+            .field("clk_sys_sram1", &self.clk_sys_sram1())
+            .field("clk_sys_sram2", &self.clk_sys_sram2())
+            .field("clk_sys_sram3", &self.clk_sys_sram3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WakeEn0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WakeEn0 {
+            clk_sys_clocks: bool,
+            clk_adc_adc: bool,
+            clk_sys_adc: bool,
+            clk_sys_busctrl: bool,
+            clk_sys_busfabric: bool,
+            clk_sys_dma: bool,
+            clk_sys_i2c0: bool,
+            clk_sys_i2c1: bool,
+            clk_sys_io: bool,
+            clk_sys_jtag: bool,
+            clk_sys_vreg_and_chip_reset: bool,
+            clk_sys_pads: bool,
+            clk_sys_pio0: bool,
+            clk_sys_pio1: bool,
+            clk_sys_pll_sys: bool,
+            clk_sys_pll_usb: bool,
+            clk_sys_psm: bool,
+            clk_sys_pwm: bool,
+            clk_sys_resets: bool,
+            clk_sys_rom: bool,
+            clk_sys_rosc: bool,
+            clk_rtc_rtc: bool,
+            clk_sys_rtc: bool,
+            clk_sys_sio: bool,
+            clk_peri_spi0: bool,
+            clk_sys_spi0: bool,
+            clk_peri_spi1: bool,
+            clk_sys_spi1: bool,
+            clk_sys_sram0: bool,
+            clk_sys_sram1: bool,
+            clk_sys_sram2: bool,
+            clk_sys_sram3: bool,
+        }
+        let proxy = WakeEn0 {
+            clk_sys_clocks: self.clk_sys_clocks(),
+            clk_adc_adc: self.clk_adc_adc(),
+            clk_sys_adc: self.clk_sys_adc(),
+            clk_sys_busctrl: self.clk_sys_busctrl(),
+            clk_sys_busfabric: self.clk_sys_busfabric(),
+            clk_sys_dma: self.clk_sys_dma(),
+            clk_sys_i2c0: self.clk_sys_i2c0(),
+            clk_sys_i2c1: self.clk_sys_i2c1(),
+            clk_sys_io: self.clk_sys_io(),
+            clk_sys_jtag: self.clk_sys_jtag(),
+            clk_sys_vreg_and_chip_reset: self.clk_sys_vreg_and_chip_reset(),
+            clk_sys_pads: self.clk_sys_pads(),
+            clk_sys_pio0: self.clk_sys_pio0(),
+            clk_sys_pio1: self.clk_sys_pio1(),
+            clk_sys_pll_sys: self.clk_sys_pll_sys(),
+            clk_sys_pll_usb: self.clk_sys_pll_usb(),
+            clk_sys_psm: self.clk_sys_psm(),
+            clk_sys_pwm: self.clk_sys_pwm(),
+            clk_sys_resets: self.clk_sys_resets(),
+            clk_sys_rom: self.clk_sys_rom(),
+            clk_sys_rosc: self.clk_sys_rosc(),
+            clk_rtc_rtc: self.clk_rtc_rtc(),
+            clk_sys_rtc: self.clk_sys_rtc(),
+            clk_sys_sio: self.clk_sys_sio(),
+            clk_peri_spi0: self.clk_peri_spi0(),
+            clk_sys_spi0: self.clk_sys_spi0(),
+            clk_peri_spi1: self.clk_peri_spi1(),
+            clk_sys_spi1: self.clk_sys_spi1(),
+            clk_sys_sram0: self.clk_sys_sram0(),
+            clk_sys_sram1: self.clk_sys_sram1(),
+            clk_sys_sram2: self.clk_sys_sram2(),
+            clk_sys_sram3: self.clk_sys_sram3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "enable clock in wake mode"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2288,5 +3362,67 @@ impl Default for WakeEn1 {
     #[inline(always)]
     fn default() -> WakeEn1 {
         WakeEn1(0)
+    }
+}
+impl core::fmt::Debug for WakeEn1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WakeEn1")
+            .field("clk_sys_sram4", &self.clk_sys_sram4())
+            .field("clk_sys_sram5", &self.clk_sys_sram5())
+            .field("clk_sys_syscfg", &self.clk_sys_syscfg())
+            .field("clk_sys_sysinfo", &self.clk_sys_sysinfo())
+            .field("clk_sys_tbman", &self.clk_sys_tbman())
+            .field("clk_sys_timer", &self.clk_sys_timer())
+            .field("clk_peri_uart0", &self.clk_peri_uart0())
+            .field("clk_sys_uart0", &self.clk_sys_uart0())
+            .field("clk_peri_uart1", &self.clk_peri_uart1())
+            .field("clk_sys_uart1", &self.clk_sys_uart1())
+            .field("clk_sys_usbctrl", &self.clk_sys_usbctrl())
+            .field("clk_usb_usbctrl", &self.clk_usb_usbctrl())
+            .field("clk_sys_watchdog", &self.clk_sys_watchdog())
+            .field("clk_sys_xip", &self.clk_sys_xip())
+            .field("clk_sys_xosc", &self.clk_sys_xosc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WakeEn1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WakeEn1 {
+            clk_sys_sram4: bool,
+            clk_sys_sram5: bool,
+            clk_sys_syscfg: bool,
+            clk_sys_sysinfo: bool,
+            clk_sys_tbman: bool,
+            clk_sys_timer: bool,
+            clk_peri_uart0: bool,
+            clk_sys_uart0: bool,
+            clk_peri_uart1: bool,
+            clk_sys_uart1: bool,
+            clk_sys_usbctrl: bool,
+            clk_usb_usbctrl: bool,
+            clk_sys_watchdog: bool,
+            clk_sys_xip: bool,
+            clk_sys_xosc: bool,
+        }
+        let proxy = WakeEn1 {
+            clk_sys_sram4: self.clk_sys_sram4(),
+            clk_sys_sram5: self.clk_sys_sram5(),
+            clk_sys_syscfg: self.clk_sys_syscfg(),
+            clk_sys_sysinfo: self.clk_sys_sysinfo(),
+            clk_sys_tbman: self.clk_sys_tbman(),
+            clk_sys_timer: self.clk_sys_timer(),
+            clk_peri_uart0: self.clk_peri_uart0(),
+            clk_sys_uart0: self.clk_sys_uart0(),
+            clk_peri_uart1: self.clk_peri_uart1(),
+            clk_sys_uart1: self.clk_sys_uart1(),
+            clk_sys_usbctrl: self.clk_sys_usbctrl(),
+            clk_usb_usbctrl: self.clk_usb_usbctrl(),
+            clk_sys_watchdog: self.clk_sys_watchdog(),
+            clk_sys_xip: self.clk_sys_xip(),
+            clk_sys_xosc: self.clk_sys_xosc(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/clocks/vals.rs
+++ b/src/rp2040/clocks/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkAdcCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -33,7 +34,8 @@ impl From<ClkAdcCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkGpoutCtrlAuxsrc {
     CLKSRC_PLL_SYS = 0x0,
     CLKSRC_GPIN0 = 0x01,
@@ -75,7 +77,8 @@ impl From<ClkGpoutCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkPeriCtrlAuxsrc {
     CLK_SYS = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -109,7 +112,8 @@ impl From<ClkPeriCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkRefCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_GPIN0 = 0x01,
@@ -139,7 +143,8 @@ impl From<ClkRefCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkRefCtrlSrc {
     ROSC_CLKSRC_PH = 0x0,
     CLKSRC_CLK_REF_AUX = 0x01,
@@ -169,7 +174,8 @@ impl From<ClkRefCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkRtcCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -203,7 +209,8 @@ impl From<ClkRtcCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkSysCtrlAuxsrc {
     CLKSRC_PLL_SYS = 0x0,
     CLKSRC_PLL_USB = 0x01,
@@ -237,7 +244,8 @@ impl From<ClkSysCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkSysCtrlSrc {
     CLK_REF = 0x0,
     CLKSRC_CLK_SYS_AUX = 0x01,
@@ -265,7 +273,8 @@ impl From<ClkSysCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkUsbCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -299,7 +308,8 @@ impl From<ClkUsbCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Fc0src {
     NULL = 0x0,
     PLL_SYS_CLKSRC_PRIMARY = 0x01,

--- a/src/rp2040/dma.rs
+++ b/src/rp2040/dma.rs
@@ -13,82 +13,82 @@ impl Channel {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "DMA Channel 5 Read Address pointer"]
+    #[doc = "DMA Channel 9 Read Address pointer"]
     #[inline(always)]
     pub const fn read_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "DMA Channel 5 Write Address pointer"]
+    #[doc = "DMA Channel 9 Write Address pointer"]
     #[inline(always)]
     pub const fn write_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
-    #[doc = "DMA Channel 5 Transfer Count"]
+    #[doc = "DMA Channel 9 Transfer Count"]
     #[inline(always)]
     pub const fn trans_count(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
-    #[doc = "DMA Channel 5 Control and Status"]
+    #[doc = "DMA Channel 9 Control and Status"]
     #[inline(always)]
     pub const fn ctrl_trig(self) -> crate::common::Reg<regs::CtrlTrig, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0cusize) as _) }
     }
-    #[doc = "Alias for channel 5 CTRL register"]
+    #[doc = "Alias for channel 9 CTRL register"]
     #[inline(always)]
     pub const fn al1_ctrl(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x10usize) as _) }
     }
-    #[doc = "Alias for channel 5 READ_ADDR register"]
+    #[doc = "Alias for channel 9 READ_ADDR register"]
     #[inline(always)]
     pub const fn al1_read_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x14usize) as _) }
     }
-    #[doc = "Alias for channel 5 WRITE_ADDR register"]
+    #[doc = "Alias for channel 9 WRITE_ADDR register"]
     #[inline(always)]
     pub const fn al1_write_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x18usize) as _) }
     }
-    #[doc = "Alias for channel 5 TRANS_COUNT register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
+    #[doc = "Alias for channel 9 TRANS_COUNT register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
     #[inline(always)]
     pub const fn al1_trans_count_trig(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x1cusize) as _) }
     }
-    #[doc = "Alias for channel 5 CTRL register"]
+    #[doc = "Alias for channel 9 CTRL register"]
     #[inline(always)]
     pub const fn al2_ctrl(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x20usize) as _) }
     }
-    #[doc = "Alias for channel 5 TRANS_COUNT register"]
+    #[doc = "Alias for channel 9 TRANS_COUNT register"]
     #[inline(always)]
     pub const fn al2_trans_count(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x24usize) as _) }
     }
-    #[doc = "Alias for channel 5 READ_ADDR register"]
+    #[doc = "Alias for channel 9 READ_ADDR register"]
     #[inline(always)]
     pub const fn al2_read_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x28usize) as _) }
     }
-    #[doc = "Alias for channel 5 WRITE_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
+    #[doc = "Alias for channel 9 WRITE_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
     #[inline(always)]
     pub const fn al2_write_addr_trig(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x2cusize) as _) }
     }
-    #[doc = "Alias for channel 5 CTRL register"]
+    #[doc = "Alias for channel 9 CTRL register"]
     #[inline(always)]
     pub const fn al3_ctrl(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x30usize) as _) }
     }
-    #[doc = "Alias for channel 5 WRITE_ADDR register"]
+    #[doc = "Alias for channel 9 WRITE_ADDR register"]
     #[inline(always)]
     pub const fn al3_write_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x34usize) as _) }
     }
-    #[doc = "Alias for channel 5 TRANS_COUNT register"]
+    #[doc = "Alias for channel 9 TRANS_COUNT register"]
     #[inline(always)]
     pub const fn al3_trans_count(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x38usize) as _) }
     }
-    #[doc = "Alias for channel 5 READ_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
+    #[doc = "Alias for channel 9 READ_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
     #[inline(always)]
     pub const fn al3_read_addr_trig(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x3cusize) as _) }

--- a/src/rp2040/dma/regs.rs
+++ b/src/rp2040/dma/regs.rs
@@ -21,7 +21,27 @@ impl Default for ChanAbort {
         ChanAbort(0)
     }
 }
-#[doc = "DMA Channel 5 Control and Status"]
+impl core::fmt::Debug for ChanAbort {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChanAbort")
+            .field("chan_abort", &self.chan_abort())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChanAbort {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChanAbort {
+            chan_abort: u16,
+        }
+        let proxy = ChanAbort {
+            chan_abort: self.chan_abort(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "DMA Channel 0 Control and Status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct CtrlTrig(pub u32);
@@ -209,6 +229,71 @@ impl Default for CtrlTrig {
         CtrlTrig(0)
     }
 }
+impl core::fmt::Debug for CtrlTrig {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CtrlTrig")
+            .field("en", &self.en())
+            .field("high_priority", &self.high_priority())
+            .field("data_size", &self.data_size())
+            .field("incr_read", &self.incr_read())
+            .field("incr_write", &self.incr_write())
+            .field("ring_size", &self.ring_size())
+            .field("ring_sel", &self.ring_sel())
+            .field("chain_to", &self.chain_to())
+            .field("treq_sel", &self.treq_sel())
+            .field("irq_quiet", &self.irq_quiet())
+            .field("bswap", &self.bswap())
+            .field("sniff_en", &self.sniff_en())
+            .field("busy", &self.busy())
+            .field("write_error", &self.write_error())
+            .field("read_error", &self.read_error())
+            .field("ahb_error", &self.ahb_error())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CtrlTrig {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct CtrlTrig {
+            en: bool,
+            high_priority: bool,
+            data_size: super::vals::DataSize,
+            incr_read: bool,
+            incr_write: bool,
+            ring_size: u8,
+            ring_sel: bool,
+            chain_to: u8,
+            treq_sel: super::vals::TreqSel,
+            irq_quiet: bool,
+            bswap: bool,
+            sniff_en: bool,
+            busy: bool,
+            write_error: bool,
+            read_error: bool,
+            ahb_error: bool,
+        }
+        let proxy = CtrlTrig {
+            en: self.en(),
+            high_priority: self.high_priority(),
+            data_size: self.data_size(),
+            incr_read: self.incr_read(),
+            incr_write: self.incr_write(),
+            ring_size: self.ring_size(),
+            ring_sel: self.ring_sel(),
+            chain_to: self.chain_to(),
+            treq_sel: self.treq_sel(),
+            irq_quiet: self.irq_quiet(),
+            bswap: self.bswap(),
+            sniff_en: self.sniff_en(),
+            busy: self.busy(),
+            write_error: self.write_error(),
+            read_error: self.read_error(),
+            ahb_error: self.ahb_error(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Read: get channel DREQ counter (i.e. how many accesses the DMA expects it can perform on the peripheral without overflow/underflow. Write any value: clears the counter, and cause channel to re-initiate DREQ handshake."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -228,6 +313,26 @@ impl Default for DbgCtdreq {
     #[inline(always)]
     fn default() -> DbgCtdreq {
         DbgCtdreq(0)
+    }
+}
+impl core::fmt::Debug for DbgCtdreq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DbgCtdreq")
+            .field("dbg_ctdreq", &self.dbg_ctdreq())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DbgCtdreq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DbgCtdreq {
+            dbg_ctdreq: u8,
+        }
+        let proxy = DbgCtdreq {
+            dbg_ctdreq: self.dbg_ctdreq(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Debug RAF, WAF, TDF levels"]
@@ -275,6 +380,32 @@ impl Default for FifoLevels {
         FifoLevels(0)
     }
 }
+impl core::fmt::Debug for FifoLevels {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FifoLevels")
+            .field("tdf_lvl", &self.tdf_lvl())
+            .field("waf_lvl", &self.waf_lvl())
+            .field("raf_lvl", &self.raf_lvl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FifoLevels {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FifoLevels {
+            tdf_lvl: u8,
+            waf_lvl: u8,
+            raf_lvl: u8,
+        }
+        let proxy = FifoLevels {
+            tdf_lvl: self.tdf_lvl(),
+            waf_lvl: self.waf_lvl(),
+            raf_lvl: self.raf_lvl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Trigger one or more channels simultaneously"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -298,6 +429,26 @@ impl Default for MultiChanTrigger {
         MultiChanTrigger(0)
     }
 }
+impl core::fmt::Debug for MultiChanTrigger {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MultiChanTrigger")
+            .field("multi_chan_trigger", &self.multi_chan_trigger())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for MultiChanTrigger {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct MultiChanTrigger {
+            multi_chan_trigger: u16,
+        }
+        let proxy = MultiChanTrigger {
+            multi_chan_trigger: self.multi_chan_trigger(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "The number of channels this DMA instance is equipped with. This DMA supports up to 16 hardware channels, but can be configured with as few as one, to minimise silicon area."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -317,6 +468,26 @@ impl Default for Nchannels {
     #[inline(always)]
     fn default() -> Nchannels {
         Nchannels(0)
+    }
+}
+impl core::fmt::Debug for Nchannels {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Nchannels")
+            .field("n_channels", &self.n_channels())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Nchannels {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Nchannels {
+            n_channels: u8,
+        }
+        let proxy = Nchannels {
+            n_channels: self.n_channels(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Sniffer Control"]
@@ -395,6 +566,41 @@ impl Default for SniffCtrl {
         SniffCtrl(0)
     }
 }
+impl core::fmt::Debug for SniffCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SniffCtrl")
+            .field("en", &self.en())
+            .field("dmach", &self.dmach())
+            .field("calc", &self.calc())
+            .field("bswap", &self.bswap())
+            .field("out_rev", &self.out_rev())
+            .field("out_inv", &self.out_inv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SniffCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SniffCtrl {
+            en: bool,
+            dmach: u8,
+            calc: super::vals::Calc,
+            bswap: bool,
+            out_rev: bool,
+            out_inv: bool,
+        }
+        let proxy = SniffCtrl {
+            en: self.en(),
+            dmach: self.dmach(),
+            calc: self.calc(),
+            bswap: self.bswap(),
+            out_rev: self.out_rev(),
+            out_inv: self.out_inv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Pacing (X/Y) Fractional Timer The pacing timer produces TREQ assertions at a rate set by ((X/Y) * sys_clk). This equation is evaluated every sys_clk cycles and therefore can only generate TREQs at a rate of 1 per sys_clk (i.e. permanent TREQ) or less."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -427,5 +633,28 @@ impl Default for Timer {
     #[inline(always)]
     fn default() -> Timer {
         Timer(0)
+    }
+}
+impl core::fmt::Debug for Timer {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer")
+            .field("y", &self.y())
+            .field("x", &self.x())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer {
+            y: u16,
+            x: u16,
+        }
+        let proxy = Timer {
+            y: self.y(),
+            x: self.x(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/dma/vals.rs
+++ b/src/rp2040/dma/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Calc {
     #[doc = "Calculate a CRC-32 (IEEE802.3 polynomial)"]
     CRC32 = 0x0,
@@ -47,7 +48,8 @@ impl From<Calc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataSize {
     SIZE_BYTE = 0x0,
     SIZE_HALFWORD = 0x01,
@@ -77,7 +79,8 @@ impl From<DataSize> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TreqSel {
     #[doc = "Select PIO0's TX FIFO 0 as TREQ"]
     PIO0_TX0 = 0x0,

--- a/src/rp2040/i2c/regs.rs
+++ b/src/rp2040/i2c/regs.rs
@@ -21,6 +21,26 @@ impl Default for IcAckGeneralCall {
         IcAckGeneralCall(0)
     }
 }
+impl core::fmt::Debug for IcAckGeneralCall {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcAckGeneralCall")
+            .field("ack_gen_call", &self.ack_gen_call())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcAckGeneralCall {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcAckGeneralCall {
+            ack_gen_call: bool,
+        }
+        let proxy = IcAckGeneralCall {
+            ack_gen_call: self.ack_gen_call(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear ACTIVITY Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42,6 +62,26 @@ impl Default for IcClrActivity {
     #[inline(always)]
     fn default() -> IcClrActivity {
         IcClrActivity(0)
+    }
+}
+impl core::fmt::Debug for IcClrActivity {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrActivity")
+            .field("clr_activity", &self.clr_activity())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrActivity {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrActivity {
+            clr_activity: bool,
+        }
+        let proxy = IcClrActivity {
+            clr_activity: self.clr_activity(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear GEN_CALL Interrupt Register"]
@@ -67,6 +107,26 @@ impl Default for IcClrGenCall {
         IcClrGenCall(0)
     }
 }
+impl core::fmt::Debug for IcClrGenCall {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrGenCall")
+            .field("clr_gen_call", &self.clr_gen_call())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrGenCall {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrGenCall {
+            clr_gen_call: bool,
+        }
+        let proxy = IcClrGenCall {
+            clr_gen_call: self.clr_gen_call(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear Combined and Individual Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +148,26 @@ impl Default for IcClrIntr {
     #[inline(always)]
     fn default() -> IcClrIntr {
         IcClrIntr(0)
+    }
+}
+impl core::fmt::Debug for IcClrIntr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrIntr")
+            .field("clr_intr", &self.clr_intr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrIntr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrIntr {
+            clr_intr: bool,
+        }
+        let proxy = IcClrIntr {
+            clr_intr: self.clr_intr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear RD_REQ Interrupt Register"]
@@ -113,6 +193,26 @@ impl Default for IcClrRdReq {
         IcClrRdReq(0)
     }
 }
+impl core::fmt::Debug for IcClrRdReq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRdReq")
+            .field("clr_rd_req", &self.clr_rd_req())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRdReq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRdReq {
+            clr_rd_req: bool,
+        }
+        let proxy = IcClrRdReq {
+            clr_rd_req: self.clr_rd_req(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear RESTART_DET Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -134,6 +234,26 @@ impl Default for IcClrRestartDet {
     #[inline(always)]
     fn default() -> IcClrRestartDet {
         IcClrRestartDet(0)
+    }
+}
+impl core::fmt::Debug for IcClrRestartDet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRestartDet")
+            .field("clr_restart_det", &self.clr_restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRestartDet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRestartDet {
+            clr_restart_det: bool,
+        }
+        let proxy = IcClrRestartDet {
+            clr_restart_det: self.clr_restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear RX_DONE Interrupt Register"]
@@ -159,6 +279,26 @@ impl Default for IcClrRxDone {
         IcClrRxDone(0)
     }
 }
+impl core::fmt::Debug for IcClrRxDone {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRxDone")
+            .field("clr_rx_done", &self.clr_rx_done())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRxDone {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRxDone {
+            clr_rx_done: bool,
+        }
+        let proxy = IcClrRxDone {
+            clr_rx_done: self.clr_rx_done(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear RX_OVER Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -180,6 +320,26 @@ impl Default for IcClrRxOver {
     #[inline(always)]
     fn default() -> IcClrRxOver {
         IcClrRxOver(0)
+    }
+}
+impl core::fmt::Debug for IcClrRxOver {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRxOver")
+            .field("clr_rx_over", &self.clr_rx_over())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRxOver {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRxOver {
+            clr_rx_over: bool,
+        }
+        let proxy = IcClrRxOver {
+            clr_rx_over: self.clr_rx_over(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear RX_UNDER Interrupt Register"]
@@ -205,6 +365,26 @@ impl Default for IcClrRxUnder {
         IcClrRxUnder(0)
     }
 }
+impl core::fmt::Debug for IcClrRxUnder {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRxUnder")
+            .field("clr_rx_under", &self.clr_rx_under())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRxUnder {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRxUnder {
+            clr_rx_under: bool,
+        }
+        let proxy = IcClrRxUnder {
+            clr_rx_under: self.clr_rx_under(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear START_DET Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -226,6 +406,26 @@ impl Default for IcClrStartDet {
     #[inline(always)]
     fn default() -> IcClrStartDet {
         IcClrStartDet(0)
+    }
+}
+impl core::fmt::Debug for IcClrStartDet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrStartDet")
+            .field("clr_start_det", &self.clr_start_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrStartDet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrStartDet {
+            clr_start_det: bool,
+        }
+        let proxy = IcClrStartDet {
+            clr_start_det: self.clr_start_det(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear STOP_DET Interrupt Register"]
@@ -251,6 +451,26 @@ impl Default for IcClrStopDet {
         IcClrStopDet(0)
     }
 }
+impl core::fmt::Debug for IcClrStopDet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrStopDet")
+            .field("clr_stop_det", &self.clr_stop_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrStopDet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrStopDet {
+            clr_stop_det: bool,
+        }
+        let proxy = IcClrStopDet {
+            clr_stop_det: self.clr_stop_det(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear TX_ABRT Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -274,6 +494,26 @@ impl Default for IcClrTxAbrt {
         IcClrTxAbrt(0)
     }
 }
+impl core::fmt::Debug for IcClrTxAbrt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrTxAbrt")
+            .field("clr_tx_abrt", &self.clr_tx_abrt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrTxAbrt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrTxAbrt {
+            clr_tx_abrt: bool,
+        }
+        let proxy = IcClrTxAbrt {
+            clr_tx_abrt: self.clr_tx_abrt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear TX_OVER Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -295,6 +535,26 @@ impl Default for IcClrTxOver {
     #[inline(always)]
     fn default() -> IcClrTxOver {
         IcClrTxOver(0)
+    }
+}
+impl core::fmt::Debug for IcClrTxOver {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrTxOver")
+            .field("clr_tx_over", &self.clr_tx_over())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrTxOver {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrTxOver {
+            clr_tx_over: bool,
+        }
+        let proxy = IcClrTxOver {
+            clr_tx_over: self.clr_tx_over(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Component Parameter Register 1 Note This register is not implemented and therefore reads as 0. If it was implemented it would be a constant read-only register that contains encoded information about the component's parameter settings. Fields shown below are the settings for those parameters"]
@@ -395,6 +655,47 @@ impl Default for IcCompParam1 {
     #[inline(always)]
     fn default() -> IcCompParam1 {
         IcCompParam1(0)
+    }
+}
+impl core::fmt::Debug for IcCompParam1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcCompParam1")
+            .field("apb_data_width", &self.apb_data_width())
+            .field("max_speed_mode", &self.max_speed_mode())
+            .field("hc_count_values", &self.hc_count_values())
+            .field("intr_io", &self.intr_io())
+            .field("has_dma", &self.has_dma())
+            .field("add_encoded_params", &self.add_encoded_params())
+            .field("rx_buffer_depth", &self.rx_buffer_depth())
+            .field("tx_buffer_depth", &self.tx_buffer_depth())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcCompParam1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcCompParam1 {
+            apb_data_width: u8,
+            max_speed_mode: u8,
+            hc_count_values: bool,
+            intr_io: bool,
+            has_dma: bool,
+            add_encoded_params: bool,
+            rx_buffer_depth: u8,
+            tx_buffer_depth: u8,
+        }
+        let proxy = IcCompParam1 {
+            apb_data_width: self.apb_data_width(),
+            max_speed_mode: self.max_speed_mode(),
+            hc_count_values: self.hc_count_values(),
+            intr_io: self.intr_io(),
+            has_dma: self.has_dma(),
+            add_encoded_params: self.add_encoded_params(),
+            rx_buffer_depth: self.rx_buffer_depth(),
+            tx_buffer_depth: self.tx_buffer_depth(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Control Register. This register can be written only when the DW_apb_i2c is disabled, which corresponds to the IC_ENABLE\\[0\\] register being set to 0. Writes at other times have no effect. Read/Write Access: - bit 10 is read only. - bit 11 is read only - bit 16 is read only - bit 17 is read only - bits 18 and 19 are read only."]
@@ -519,6 +820,56 @@ impl Default for IcCon {
         IcCon(0)
     }
 }
+impl core::fmt::Debug for IcCon {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcCon")
+            .field("master_mode", &self.master_mode())
+            .field("speed", &self.speed())
+            .field("ic_10bitaddr_slave", &self.ic_10bitaddr_slave())
+            .field("ic_10bitaddr_master", &self.ic_10bitaddr_master())
+            .field("ic_restart_en", &self.ic_restart_en())
+            .field("ic_slave_disable", &self.ic_slave_disable())
+            .field("stop_det_ifaddressed", &self.stop_det_ifaddressed())
+            .field("tx_empty_ctrl", &self.tx_empty_ctrl())
+            .field("rx_fifo_full_hld_ctrl", &self.rx_fifo_full_hld_ctrl())
+            .field(
+                "stop_det_if_master_active",
+                &self.stop_det_if_master_active(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcCon {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcCon {
+            master_mode: bool,
+            speed: super::vals::Speed,
+            ic_10bitaddr_slave: bool,
+            ic_10bitaddr_master: bool,
+            ic_restart_en: bool,
+            ic_slave_disable: bool,
+            stop_det_ifaddressed: bool,
+            tx_empty_ctrl: bool,
+            rx_fifo_full_hld_ctrl: bool,
+            stop_det_if_master_active: bool,
+        }
+        let proxy = IcCon {
+            master_mode: self.master_mode(),
+            speed: self.speed(),
+            ic_10bitaddr_slave: self.ic_10bitaddr_slave(),
+            ic_10bitaddr_master: self.ic_10bitaddr_master(),
+            ic_restart_en: self.ic_restart_en(),
+            ic_slave_disable: self.ic_slave_disable(),
+            stop_det_ifaddressed: self.stop_det_ifaddressed(),
+            tx_empty_ctrl: self.tx_empty_ctrl(),
+            rx_fifo_full_hld_ctrl: self.rx_fifo_full_hld_ctrl(),
+            stop_det_if_master_active: self.stop_det_if_master_active(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Rx/Tx Data Buffer and Command Register; this is the register the CPU writes to when filling the TX FIFO and the CPU reads from when retrieving bytes from RX FIFO. The size of the register changes as follows: Write: - 11 bits when IC_EMPTYFIFO_HOLD_MASTER_EN=1 - 9 bits when IC_EMPTYFIFO_HOLD_MASTER_EN=0 Read: - 12 bits when IC_FIRST_DATA_BYTE_STATUS = 1 - 8 bits when IC_FIRST_DATA_BYTE_STATUS = 0 Note: In order for the DW_apb_i2c to continue acknowledging reads, a read command should be written for every byte that is to be received; otherwise the DW_apb_i2c will stop acknowledging."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -586,6 +937,38 @@ impl Default for IcDataCmd {
         IcDataCmd(0)
     }
 }
+impl core::fmt::Debug for IcDataCmd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDataCmd")
+            .field("dat", &self.dat())
+            .field("cmd", &self.cmd())
+            .field("stop", &self.stop())
+            .field("restart", &self.restart())
+            .field("first_data_byte", &self.first_data_byte())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDataCmd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDataCmd {
+            dat: u8,
+            cmd: bool,
+            stop: bool,
+            restart: bool,
+            first_data_byte: bool,
+        }
+        let proxy = IcDataCmd {
+            dat: self.dat(),
+            cmd: self.cmd(),
+            stop: self.stop(),
+            restart: self.restart(),
+            first_data_byte: self.first_data_byte(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA Control Register The register is used to enable the DMA Controller interface operation. There is a separate bit for transmit and receive. This can be programmed regardless of the state of IC_ENABLE."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -620,6 +1003,29 @@ impl Default for IcDmaCr {
         IcDmaCr(0)
     }
 }
+impl core::fmt::Debug for IcDmaCr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDmaCr")
+            .field("rdmae", &self.rdmae())
+            .field("tdmae", &self.tdmae())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDmaCr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDmaCr {
+            rdmae: bool,
+            tdmae: bool,
+        }
+        let proxy = IcDmaCr {
+            rdmae: self.rdmae(),
+            tdmae: self.tdmae(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Receive Data Level Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -643,6 +1049,26 @@ impl Default for IcDmaRdlr {
         IcDmaRdlr(0)
     }
 }
+impl core::fmt::Debug for IcDmaRdlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDmaRdlr")
+            .field("dmardl", &self.dmardl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDmaRdlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDmaRdlr {
+            dmardl: u8,
+        }
+        let proxy = IcDmaRdlr {
+            dmardl: self.dmardl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA Transmit Data Level Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -664,6 +1090,26 @@ impl Default for IcDmaTdlr {
     #[inline(always)]
     fn default() -> IcDmaTdlr {
         IcDmaTdlr(0)
+    }
+}
+impl core::fmt::Debug for IcDmaTdlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDmaTdlr")
+            .field("dmatdl", &self.dmatdl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDmaTdlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDmaTdlr {
+            dmatdl: u8,
+        }
+        let proxy = IcDmaTdlr {
+            dmatdl: self.dmatdl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Enable Register"]
@@ -711,6 +1157,32 @@ impl Default for IcEnable {
         IcEnable(0)
     }
 }
+impl core::fmt::Debug for IcEnable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcEnable")
+            .field("enable", &self.enable())
+            .field("abort", &self.abort())
+            .field("tx_cmd_block", &self.tx_cmd_block())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcEnable {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcEnable {
+            enable: bool,
+            abort: bool,
+            tx_cmd_block: bool,
+        }
+        let proxy = IcEnable {
+            enable: self.enable(),
+            abort: self.abort(),
+            tx_cmd_block: self.tx_cmd_block(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Enable Status Register The register is used to report the DW_apb_i2c hardware status when the IC_ENABLE\\[0\\] register is set from 1 to 0; that is, when DW_apb_i2c is disabled. If IC_ENABLE\\[0\\] has been set to 1, bits 2:1 are forced to 0, and bit 0 is forced to 1. If IC_ENABLE\\[0\\] has been set to 0, bits 2:1 is only be valid as soon as bit 0 is read as '0'. Note: When IC_ENABLE\\[0\\] has been set to 0, a delay occurs for bit 0 to be read as 0 because disabling the DW_apb_i2c depends on I2C bus activities."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -756,6 +1228,32 @@ impl Default for IcEnableStatus {
         IcEnableStatus(0)
     }
 }
+impl core::fmt::Debug for IcEnableStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcEnableStatus")
+            .field("ic_en", &self.ic_en())
+            .field("slv_disabled_while_busy", &self.slv_disabled_while_busy())
+            .field("slv_rx_data_lost", &self.slv_rx_data_lost())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcEnableStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcEnableStatus {
+            ic_en: bool,
+            slv_disabled_while_busy: bool,
+            slv_rx_data_lost: bool,
+        }
+        let proxy = IcEnableStatus {
+            ic_en: self.ic_en(),
+            slv_disabled_while_busy: self.slv_disabled_while_busy(),
+            slv_rx_data_lost: self.slv_rx_data_lost(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Fast Mode or Fast Mode Plus I2C Clock SCL High Count Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -777,6 +1275,26 @@ impl Default for IcFsSclHcnt {
     #[inline(always)]
     fn default() -> IcFsSclHcnt {
         IcFsSclHcnt(0)
+    }
+}
+impl core::fmt::Debug for IcFsSclHcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcFsSclHcnt")
+            .field("ic_fs_scl_hcnt", &self.ic_fs_scl_hcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcFsSclHcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcFsSclHcnt {
+            ic_fs_scl_hcnt: u16,
+        }
+        let proxy = IcFsSclHcnt {
+            ic_fs_scl_hcnt: self.ic_fs_scl_hcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Fast Mode or Fast Mode Plus I2C Clock SCL Low Count Register"]
@@ -802,6 +1320,26 @@ impl Default for IcFsSclLcnt {
         IcFsSclLcnt(0)
     }
 }
+impl core::fmt::Debug for IcFsSclLcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcFsSclLcnt")
+            .field("ic_fs_scl_lcnt", &self.ic_fs_scl_lcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcFsSclLcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcFsSclLcnt {
+            ic_fs_scl_lcnt: u16,
+        }
+        let proxy = IcFsSclLcnt {
+            ic_fs_scl_lcnt: self.ic_fs_scl_lcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C SS, FS or FM+ spike suppression limit This register is used to store the duration, measured in ic_clk cycles, of the longest spike that is filtered out by the spike suppression logic when the component is operating in SS, FS or FM+ modes. The relevant I2C requirement is tSP (table 4) as detailed in the I2C Bus Specification. This register must be programmed with a minimum value of 1."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -823,6 +1361,26 @@ impl Default for IcFsSpklen {
     #[inline(always)]
     fn default() -> IcFsSpklen {
         IcFsSpklen(0)
+    }
+}
+impl core::fmt::Debug for IcFsSpklen {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcFsSpklen")
+            .field("ic_fs_spklen", &self.ic_fs_spklen())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcFsSpklen {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcFsSpklen {
+            ic_fs_spklen: u8,
+        }
+        let proxy = IcFsSpklen {
+            ic_fs_spklen: self.ic_fs_spklen(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Interrupt Mask Register. These bits mask their corresponding interrupt status bits. This register is active low; a value of 0 masks the interrupt, whereas a value of 1 unmasks the interrupt."]
@@ -980,6 +1538,62 @@ impl Default for IcIntrMask {
         IcIntrMask(0)
     }
 }
+impl core::fmt::Debug for IcIntrMask {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcIntrMask")
+            .field("m_rx_under", &self.m_rx_under())
+            .field("m_rx_over", &self.m_rx_over())
+            .field("m_rx_full", &self.m_rx_full())
+            .field("m_tx_over", &self.m_tx_over())
+            .field("m_tx_empty", &self.m_tx_empty())
+            .field("m_rd_req", &self.m_rd_req())
+            .field("m_tx_abrt", &self.m_tx_abrt())
+            .field("m_rx_done", &self.m_rx_done())
+            .field("m_activity", &self.m_activity())
+            .field("m_stop_det", &self.m_stop_det())
+            .field("m_start_det", &self.m_start_det())
+            .field("m_gen_call", &self.m_gen_call())
+            .field("m_restart_det", &self.m_restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcIntrMask {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcIntrMask {
+            m_rx_under: bool,
+            m_rx_over: bool,
+            m_rx_full: bool,
+            m_tx_over: bool,
+            m_tx_empty: bool,
+            m_rd_req: bool,
+            m_tx_abrt: bool,
+            m_rx_done: bool,
+            m_activity: bool,
+            m_stop_det: bool,
+            m_start_det: bool,
+            m_gen_call: bool,
+            m_restart_det: bool,
+        }
+        let proxy = IcIntrMask {
+            m_rx_under: self.m_rx_under(),
+            m_rx_over: self.m_rx_over(),
+            m_rx_full: self.m_rx_full(),
+            m_tx_over: self.m_tx_over(),
+            m_tx_empty: self.m_tx_empty(),
+            m_rd_req: self.m_rd_req(),
+            m_tx_abrt: self.m_tx_abrt(),
+            m_rx_done: self.m_rx_done(),
+            m_activity: self.m_activity(),
+            m_stop_det: self.m_stop_det(),
+            m_start_det: self.m_start_det(),
+            m_gen_call: self.m_gen_call(),
+            m_restart_det: self.m_restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Interrupt Status Register Each bit in this register has a corresponding mask bit in the IC_INTR_MASK register. These bits are cleared by reading the matching interrupt clear register. The unmasked raw versions of these bits are available in the IC_RAW_INTR_STAT register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1133,6 +1747,62 @@ impl Default for IcIntrStat {
     #[inline(always)]
     fn default() -> IcIntrStat {
         IcIntrStat(0)
+    }
+}
+impl core::fmt::Debug for IcIntrStat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcIntrStat")
+            .field("r_rx_under", &self.r_rx_under())
+            .field("r_rx_over", &self.r_rx_over())
+            .field("r_rx_full", &self.r_rx_full())
+            .field("r_tx_over", &self.r_tx_over())
+            .field("r_tx_empty", &self.r_tx_empty())
+            .field("r_rd_req", &self.r_rd_req())
+            .field("r_tx_abrt", &self.r_tx_abrt())
+            .field("r_rx_done", &self.r_rx_done())
+            .field("r_activity", &self.r_activity())
+            .field("r_stop_det", &self.r_stop_det())
+            .field("r_start_det", &self.r_start_det())
+            .field("r_gen_call", &self.r_gen_call())
+            .field("r_restart_det", &self.r_restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcIntrStat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcIntrStat {
+            r_rx_under: bool,
+            r_rx_over: bool,
+            r_rx_full: bool,
+            r_tx_over: bool,
+            r_tx_empty: bool,
+            r_rd_req: bool,
+            r_tx_abrt: bool,
+            r_rx_done: bool,
+            r_activity: bool,
+            r_stop_det: bool,
+            r_start_det: bool,
+            r_gen_call: bool,
+            r_restart_det: bool,
+        }
+        let proxy = IcIntrStat {
+            r_rx_under: self.r_rx_under(),
+            r_rx_over: self.r_rx_over(),
+            r_rx_full: self.r_rx_full(),
+            r_tx_over: self.r_tx_over(),
+            r_tx_empty: self.r_tx_empty(),
+            r_rd_req: self.r_rd_req(),
+            r_tx_abrt: self.r_tx_abrt(),
+            r_rx_done: self.r_rx_done(),
+            r_activity: self.r_activity(),
+            r_stop_det: self.r_stop_det(),
+            r_start_det: self.r_start_det(),
+            r_gen_call: self.r_gen_call(),
+            r_restart_det: self.r_restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Raw Interrupt Status Register Unlike the IC_INTR_STAT register, these bits are not masked so they always show the true status of the DW_apb_i2c."]
@@ -1290,6 +1960,62 @@ impl Default for IcRawIntrStat {
         IcRawIntrStat(0)
     }
 }
+impl core::fmt::Debug for IcRawIntrStat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcRawIntrStat")
+            .field("rx_under", &self.rx_under())
+            .field("rx_over", &self.rx_over())
+            .field("rx_full", &self.rx_full())
+            .field("tx_over", &self.tx_over())
+            .field("tx_empty", &self.tx_empty())
+            .field("rd_req", &self.rd_req())
+            .field("tx_abrt", &self.tx_abrt())
+            .field("rx_done", &self.rx_done())
+            .field("activity", &self.activity())
+            .field("stop_det", &self.stop_det())
+            .field("start_det", &self.start_det())
+            .field("gen_call", &self.gen_call())
+            .field("restart_det", &self.restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcRawIntrStat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcRawIntrStat {
+            rx_under: bool,
+            rx_over: bool,
+            rx_full: bool,
+            tx_over: bool,
+            tx_empty: bool,
+            rd_req: bool,
+            tx_abrt: bool,
+            rx_done: bool,
+            activity: bool,
+            stop_det: bool,
+            start_det: bool,
+            gen_call: bool,
+            restart_det: bool,
+        }
+        let proxy = IcRawIntrStat {
+            rx_under: self.rx_under(),
+            rx_over: self.rx_over(),
+            rx_full: self.rx_full(),
+            tx_over: self.tx_over(),
+            tx_empty: self.tx_empty(),
+            rd_req: self.rd_req(),
+            tx_abrt: self.tx_abrt(),
+            rx_done: self.rx_done(),
+            activity: self.activity(),
+            stop_det: self.stop_det(),
+            start_det: self.start_det(),
+            gen_call: self.gen_call(),
+            restart_det: self.restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Receive FIFO Threshold Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1311,6 +2037,26 @@ impl Default for IcRxTl {
     #[inline(always)]
     fn default() -> IcRxTl {
         IcRxTl(0)
+    }
+}
+impl core::fmt::Debug for IcRxTl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcRxTl")
+            .field("rx_tl", &self.rx_tl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcRxTl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcRxTl {
+            rx_tl: u8,
+        }
+        let proxy = IcRxTl {
+            rx_tl: self.rx_tl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Receive FIFO Level Register This register contains the number of valid data entries in the receive FIFO buffer. It is cleared whenever: - The I2C is disabled - Whenever there is a transmit abort caused by any of the events tracked in IC_TX_ABRT_SOURCE The register increments whenever data is placed into the receive FIFO and decrements when data is taken from the receive FIFO."]
@@ -1336,6 +2082,26 @@ impl Default for IcRxflr {
         IcRxflr(0)
     }
 }
+impl core::fmt::Debug for IcRxflr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcRxflr")
+            .field("rxflr", &self.rxflr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcRxflr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcRxflr {
+            rxflr: u8,
+        }
+        let proxy = IcRxflr {
+            rxflr: self.rxflr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Slave Address Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1357,6 +2123,26 @@ impl Default for IcSar {
     #[inline(always)]
     fn default() -> IcSar {
         IcSar(0)
+    }
+}
+impl core::fmt::Debug for IcSar {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSar")
+            .field("ic_sar", &self.ic_sar())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSar {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSar {
+            ic_sar: u16,
+        }
+        let proxy = IcSar {
+            ic_sar: self.ic_sar(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C SDA Hold Time Length Register The bits \\[15:0\\] of this register are used to control the hold time of SDA during transmit in both slave and master mode (after SCL goes from HIGH to LOW). The bits \\[23:16\\] of this register are used to extend the SDA transition (if any) whenever SCL is HIGH in the receiver in either master or slave mode. Writes to this register succeed only when IC_ENABLE\\[0\\]=0. The values in this register are in units of ic_clk period. The value programmed in IC_SDA_TX_HOLD must be greater than the minimum hold time in each mode (one cycle in master mode, seven cycles in slave mode) for the value to be implemented. The programmed SDA hold time during transmit (IC_SDA_TX_HOLD) cannot exceed at any time the duration of the low part of scl. Therefore the programmed value cannot be larger than N_SCL_LOW-2, where N_SCL_LOW is the duration of the low part of the scl period measured in ic_clk cycles."]
@@ -1393,6 +2179,29 @@ impl Default for IcSdaHold {
         IcSdaHold(0)
     }
 }
+impl core::fmt::Debug for IcSdaHold {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSdaHold")
+            .field("ic_sda_tx_hold", &self.ic_sda_tx_hold())
+            .field("ic_sda_rx_hold", &self.ic_sda_rx_hold())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSdaHold {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSdaHold {
+            ic_sda_tx_hold: u16,
+            ic_sda_rx_hold: u8,
+        }
+        let proxy = IcSdaHold {
+            ic_sda_tx_hold: self.ic_sda_tx_hold(),
+            ic_sda_rx_hold: self.ic_sda_rx_hold(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C SDA Setup Register This register controls the amount of time delay (in terms of number of ic_clk clock periods) introduced in the rising edge of SCL - relative to SDA changing - when DW_apb_i2c services a read request in a slave-transmitter operation. The relevant I2C requirement is tSU:DAT (note 4) as detailed in the I2C Bus Specification. This register must be programmed with a value equal to or greater than 2. Writes to this register succeed only when IC_ENABLE\\[0\\] = 0. Note: The length of setup time is calculated using \\[(IC_SDA_SETUP - 1) * (ic_clk_period)\\], so if the user requires 10 ic_clk periods of setup time, they should program a value of 11. The IC_SDA_SETUP register is only used by the DW_apb_i2c when operating as a slave transmitter."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1414,6 +2223,26 @@ impl Default for IcSdaSetup {
     #[inline(always)]
     fn default() -> IcSdaSetup {
         IcSdaSetup(0)
+    }
+}
+impl core::fmt::Debug for IcSdaSetup {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSdaSetup")
+            .field("sda_setup", &self.sda_setup())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSdaSetup {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSdaSetup {
+            sda_setup: u8,
+        }
+        let proxy = IcSdaSetup {
+            sda_setup: self.sda_setup(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Generate Slave Data NACK Register The register is used to generate a NACK for the data part of a transfer when DW_apb_i2c is acting as a slave-receiver. This register only exists when the IC_SLV_DATA_NACK_ONLY parameter is set to 1. When this parameter disabled, this register does not exist and writing to the register's address has no effect. A write can occur on this register if both of the following conditions are met: - DW_apb_i2c is disabled (IC_ENABLE\\[0\\] = 0) - Slave part is inactive (IC_STATUS\\[6\\] = 0) Note: The IC_STATUS\\[6\\] is a register read-back location for the internal slv_activity signal; the user should poll this before writing the ic_slv_data_nack_only bit."]
@@ -1439,6 +2268,24 @@ impl Default for IcSlvDataNackOnly {
         IcSlvDataNackOnly(0)
     }
 }
+impl core::fmt::Debug for IcSlvDataNackOnly {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSlvDataNackOnly")
+            .field("nack", &self.nack())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSlvDataNackOnly {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSlvDataNackOnly {
+            nack: bool,
+        }
+        let proxy = IcSlvDataNackOnly { nack: self.nack() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Standard Speed I2C Clock SCL High Count Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1462,6 +2309,26 @@ impl Default for IcSsSclHcnt {
         IcSsSclHcnt(0)
     }
 }
+impl core::fmt::Debug for IcSsSclHcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSsSclHcnt")
+            .field("ic_ss_scl_hcnt", &self.ic_ss_scl_hcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSsSclHcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSsSclHcnt {
+            ic_ss_scl_hcnt: u16,
+        }
+        let proxy = IcSsSclHcnt {
+            ic_ss_scl_hcnt: self.ic_ss_scl_hcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Standard Speed I2C Clock SCL Low Count Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1483,6 +2350,26 @@ impl Default for IcSsSclLcnt {
     #[inline(always)]
     fn default() -> IcSsSclLcnt {
         IcSsSclLcnt(0)
+    }
+}
+impl core::fmt::Debug for IcSsSclLcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSsSclLcnt")
+            .field("ic_ss_scl_lcnt", &self.ic_ss_scl_lcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSsSclLcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSsSclLcnt {
+            ic_ss_scl_lcnt: u16,
+        }
+        let proxy = IcSsSclLcnt {
+            ic_ss_scl_lcnt: self.ic_ss_scl_lcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Status Register This is a read-only register used to indicate the current transfer status and FIFO status. The status register may be read at any time. None of the bits in this register request an interrupt. When the I2C is disabled by writing 0 in bit 0 of the IC_ENABLE register: - Bits 1 and 2 are set to 1 - Bits 3 and 10 are set to 0 When the master or slave state machines goes to idle and ic_en=0: - Bits 5 and 6 are set to 0"]
@@ -1574,6 +2461,44 @@ impl Default for IcStatus {
         IcStatus(0)
     }
 }
+impl core::fmt::Debug for IcStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcStatus")
+            .field("activity", &self.activity())
+            .field("tfnf", &self.tfnf())
+            .field("tfe", &self.tfe())
+            .field("rfne", &self.rfne())
+            .field("rff", &self.rff())
+            .field("mst_activity", &self.mst_activity())
+            .field("slv_activity", &self.slv_activity())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcStatus {
+            activity: bool,
+            tfnf: bool,
+            tfe: bool,
+            rfne: bool,
+            rff: bool,
+            mst_activity: bool,
+            slv_activity: bool,
+        }
+        let proxy = IcStatus {
+            activity: self.activity(),
+            tfnf: self.tfnf(),
+            tfe: self.tfe(),
+            rfne: self.rfne(),
+            rff: self.rff(),
+            mst_activity: self.mst_activity(),
+            slv_activity: self.slv_activity(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Target Address Register This register is 12 bits wide, and bits 31:12 are reserved. This register can be written to only when IC_ENABLE\\[0\\] is set to 0. Note: If the software or application is aware that the DW_apb_i2c is not using the TAR address for the pending commands in the Tx FIFO, then it is possible to update the TAR address even while the Tx FIFO has entries (IC_STATUS\\[2\\]= 0). - It is not necessary to perform any write to this register if DW_apb_i2c is enabled as an I2C slave only."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1617,6 +2542,32 @@ impl Default for IcTar {
     #[inline(always)]
     fn default() -> IcTar {
         IcTar(0)
+    }
+}
+impl core::fmt::Debug for IcTar {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTar")
+            .field("ic_tar", &self.ic_tar())
+            .field("gc_or_start", &self.gc_or_start())
+            .field("special", &self.special())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTar {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTar {
+            ic_tar: u16,
+            gc_or_start: bool,
+            special: bool,
+        }
+        let proxy = IcTar {
+            ic_tar: self.ic_tar(),
+            gc_or_start: self.gc_or_start(),
+            special: self.special(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Transmit Abort Source Register This register has 32 bits that indicate the source of the TX_ABRT bit. Except for Bit 9, this register is cleared whenever the IC_CLR_TX_ABRT register or the IC_CLR_INTR register is read. To clear Bit 9, the source of the ABRT_SBYTE_NORSTRT must be fixed first; RESTART must be enabled (IC_CON\\[5\\]=1), the SPECIAL bit must be cleared (IC_TAR\\[11\\]), or the GC_OR_START bit must be cleared (IC_TAR\\[10\\]). Once the source of the ABRT_SBYTE_NORSTRT is fixed, then this bit can be cleared in the same manner as other bits in this register. If the source of the ABRT_SBYTE_NORSTRT is not fixed before attempting to clear this bit, Bit 9 clears for one cycle and is then re-asserted."]
@@ -1829,6 +2780,77 @@ impl Default for IcTxAbrtSource {
         IcTxAbrtSource(0)
     }
 }
+impl core::fmt::Debug for IcTxAbrtSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTxAbrtSource")
+            .field("abrt_7b_addr_noack", &self.abrt_7b_addr_noack())
+            .field("abrt_10addr1_noack", &self.abrt_10addr1_noack())
+            .field("abrt_10addr2_noack", &self.abrt_10addr2_noack())
+            .field("abrt_txdata_noack", &self.abrt_txdata_noack())
+            .field("abrt_gcall_noack", &self.abrt_gcall_noack())
+            .field("abrt_gcall_read", &self.abrt_gcall_read())
+            .field("abrt_hs_ackdet", &self.abrt_hs_ackdet())
+            .field("abrt_sbyte_ackdet", &self.abrt_sbyte_ackdet())
+            .field("abrt_hs_norstrt", &self.abrt_hs_norstrt())
+            .field("abrt_sbyte_norstrt", &self.abrt_sbyte_norstrt())
+            .field("abrt_10b_rd_norstrt", &self.abrt_10b_rd_norstrt())
+            .field("abrt_master_dis", &self.abrt_master_dis())
+            .field("arb_lost", &self.arb_lost())
+            .field("abrt_slvflush_txfifo", &self.abrt_slvflush_txfifo())
+            .field("abrt_slv_arblost", &self.abrt_slv_arblost())
+            .field("abrt_slvrd_intx", &self.abrt_slvrd_intx())
+            .field("abrt_user_abrt", &self.abrt_user_abrt())
+            .field("tx_flush_cnt", &self.tx_flush_cnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTxAbrtSource {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTxAbrtSource {
+            abrt_7b_addr_noack: bool,
+            abrt_10addr1_noack: bool,
+            abrt_10addr2_noack: bool,
+            abrt_txdata_noack: bool,
+            abrt_gcall_noack: bool,
+            abrt_gcall_read: bool,
+            abrt_hs_ackdet: bool,
+            abrt_sbyte_ackdet: bool,
+            abrt_hs_norstrt: bool,
+            abrt_sbyte_norstrt: bool,
+            abrt_10b_rd_norstrt: bool,
+            abrt_master_dis: bool,
+            arb_lost: bool,
+            abrt_slvflush_txfifo: bool,
+            abrt_slv_arblost: bool,
+            abrt_slvrd_intx: bool,
+            abrt_user_abrt: bool,
+            tx_flush_cnt: u16,
+        }
+        let proxy = IcTxAbrtSource {
+            abrt_7b_addr_noack: self.abrt_7b_addr_noack(),
+            abrt_10addr1_noack: self.abrt_10addr1_noack(),
+            abrt_10addr2_noack: self.abrt_10addr2_noack(),
+            abrt_txdata_noack: self.abrt_txdata_noack(),
+            abrt_gcall_noack: self.abrt_gcall_noack(),
+            abrt_gcall_read: self.abrt_gcall_read(),
+            abrt_hs_ackdet: self.abrt_hs_ackdet(),
+            abrt_sbyte_ackdet: self.abrt_sbyte_ackdet(),
+            abrt_hs_norstrt: self.abrt_hs_norstrt(),
+            abrt_sbyte_norstrt: self.abrt_sbyte_norstrt(),
+            abrt_10b_rd_norstrt: self.abrt_10b_rd_norstrt(),
+            abrt_master_dis: self.abrt_master_dis(),
+            arb_lost: self.arb_lost(),
+            abrt_slvflush_txfifo: self.abrt_slvflush_txfifo(),
+            abrt_slv_arblost: self.abrt_slv_arblost(),
+            abrt_slvrd_intx: self.abrt_slvrd_intx(),
+            abrt_user_abrt: self.abrt_user_abrt(),
+            tx_flush_cnt: self.tx_flush_cnt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Transmit FIFO Threshold Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1852,6 +2874,26 @@ impl Default for IcTxTl {
         IcTxTl(0)
     }
 }
+impl core::fmt::Debug for IcTxTl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTxTl")
+            .field("tx_tl", &self.tx_tl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTxTl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTxTl {
+            tx_tl: u8,
+        }
+        let proxy = IcTxTl {
+            tx_tl: self.tx_tl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Transmit FIFO Level Register This register contains the number of valid data entries in the transmit FIFO buffer. It is cleared whenever: - The I2C is disabled - There is a transmit abort - that is, TX_ABRT bit is set in the IC_RAW_INTR_STAT register - The slave bulk transmit mode is aborted The register increments whenever data is placed into the transmit FIFO and decrements when data is taken from the transmit FIFO."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1873,5 +2915,25 @@ impl Default for IcTxflr {
     #[inline(always)]
     fn default() -> IcTxflr {
         IcTxflr(0)
+    }
+}
+impl core::fmt::Debug for IcTxflr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTxflr")
+            .field("txflr", &self.txflr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTxflr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTxflr {
+            txflr: u8,
+        }
+        let proxy = IcTxflr {
+            txflr: self.txflr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/i2c/vals.rs
+++ b/src/rp2040/i2c/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Speed {
     _RESERVED_0 = 0x0,
     #[doc = "Standard Speed mode of operation"]

--- a/src/rp2040/io/regs.rs
+++ b/src/rp2040/io/regs.rs
@@ -57,6 +57,38 @@ impl Default for GpioCtrl {
         GpioCtrl(0)
     }
 }
+impl core::fmt::Debug for GpioCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioCtrl")
+            .field("funcsel", &self.funcsel())
+            .field("outover", &self.outover())
+            .field("oeover", &self.oeover())
+            .field("inover", &self.inover())
+            .field("irqover", &self.irqover())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioCtrl {
+            funcsel: u8,
+            outover: super::vals::Outover,
+            oeover: super::vals::Oeover,
+            inover: super::vals::Inover,
+            irqover: super::vals::Irqover,
+        }
+        let proxy = GpioCtrl {
+            funcsel: self.funcsel(),
+            outover: self.outover(),
+            oeover: self.oeover(),
+            inover: self.inover(),
+            irqover: self.irqover(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "GPIO status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -157,7 +189,48 @@ impl Default for GpioStatus {
         GpioStatus(0)
     }
 }
-#[doc = "Interrupt status after masking & forcing for proc1"]
+impl core::fmt::Debug for GpioStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioStatus")
+            .field("outfromperi", &self.outfromperi())
+            .field("outtopad", &self.outtopad())
+            .field("oefromperi", &self.oefromperi())
+            .field("oetopad", &self.oetopad())
+            .field("infrompad", &self.infrompad())
+            .field("intoperi", &self.intoperi())
+            .field("irqfrompad", &self.irqfrompad())
+            .field("irqtoproc", &self.irqtoproc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioStatus {
+            outfromperi: bool,
+            outtopad: bool,
+            oefromperi: bool,
+            oetopad: bool,
+            infrompad: bool,
+            intoperi: bool,
+            irqfrompad: bool,
+            irqtoproc: bool,
+        }
+        let proxy = GpioStatus {
+            outfromperi: self.outfromperi(),
+            outtopad: self.outtopad(),
+            oefromperi: self.oefromperi(),
+            oetopad: self.oetopad(),
+            infrompad: self.infrompad(),
+            intoperi: self.intoperi(),
+            irqfrompad: self.irqfrompad(),
+            irqtoproc: self.irqtoproc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable for dormant_wake"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -219,5 +292,118 @@ impl Default for Int {
     #[inline(always)]
     fn default() -> Int {
         Int(0)
+    }
+}
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field(
+                "level_low",
+                &[
+                    self.level_low(0usize),
+                    self.level_low(1usize),
+                    self.level_low(2usize),
+                    self.level_low(3usize),
+                    self.level_low(4usize),
+                    self.level_low(5usize),
+                    self.level_low(6usize),
+                    self.level_low(7usize),
+                ],
+            )
+            .field(
+                "level_high",
+                &[
+                    self.level_high(0usize),
+                    self.level_high(1usize),
+                    self.level_high(2usize),
+                    self.level_high(3usize),
+                    self.level_high(4usize),
+                    self.level_high(5usize),
+                    self.level_high(6usize),
+                    self.level_high(7usize),
+                ],
+            )
+            .field(
+                "edge_low",
+                &[
+                    self.edge_low(0usize),
+                    self.edge_low(1usize),
+                    self.edge_low(2usize),
+                    self.edge_low(3usize),
+                    self.edge_low(4usize),
+                    self.edge_low(5usize),
+                    self.edge_low(6usize),
+                    self.edge_low(7usize),
+                ],
+            )
+            .field(
+                "edge_high",
+                &[
+                    self.edge_high(0usize),
+                    self.edge_high(1usize),
+                    self.edge_high(2usize),
+                    self.edge_high(3usize),
+                    self.edge_high(4usize),
+                    self.edge_high(5usize),
+                    self.edge_high(6usize),
+                    self.edge_high(7usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            level_low: [bool; 8usize],
+            level_high: [bool; 8usize],
+            edge_low: [bool; 8usize],
+            edge_high: [bool; 8usize],
+        }
+        let proxy = Int {
+            level_low: [
+                self.level_low(0usize),
+                self.level_low(1usize),
+                self.level_low(2usize),
+                self.level_low(3usize),
+                self.level_low(4usize),
+                self.level_low(5usize),
+                self.level_low(6usize),
+                self.level_low(7usize),
+            ],
+            level_high: [
+                self.level_high(0usize),
+                self.level_high(1usize),
+                self.level_high(2usize),
+                self.level_high(3usize),
+                self.level_high(4usize),
+                self.level_high(5usize),
+                self.level_high(6usize),
+                self.level_high(7usize),
+            ],
+            edge_low: [
+                self.edge_low(0usize),
+                self.edge_low(1usize),
+                self.edge_low(2usize),
+                self.edge_low(3usize),
+                self.edge_low(4usize),
+                self.edge_low(5usize),
+                self.edge_low(6usize),
+                self.edge_low(7usize),
+            ],
+            edge_high: [
+                self.edge_high(0usize),
+                self.edge_high(1usize),
+                self.edge_high(2usize),
+                self.edge_high(3usize),
+                self.edge_high(4usize),
+                self.edge_high(5usize),
+                self.edge_high(6usize),
+                self.edge_high(7usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/io/vals.rs
+++ b/src/rp2040/io/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio0ctrlFuncsel {
     JTAG_TCK = 0x0,
     SPI0_RX = 0x01,
@@ -57,7 +58,8 @@ impl From<Gpio0ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio10ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -115,7 +117,8 @@ impl From<Gpio10ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio11ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -173,7 +176,8 @@ impl From<Gpio11ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio12ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -231,7 +235,8 @@ impl From<Gpio12ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio13ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -289,7 +294,8 @@ impl From<Gpio13ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio14ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -347,7 +353,8 @@ impl From<Gpio14ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio15ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -405,7 +412,8 @@ impl From<Gpio15ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio16ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -463,7 +471,8 @@ impl From<Gpio16ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio17ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -521,7 +530,8 @@ impl From<Gpio17ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio18ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -579,7 +589,8 @@ impl From<Gpio18ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio19ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -637,7 +648,8 @@ impl From<Gpio19ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio1ctrlFuncsel {
     JTAG_TMS = 0x0,
     SPI0_SS_N = 0x01,
@@ -695,7 +707,8 @@ impl From<Gpio1ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio20ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -753,7 +766,8 @@ impl From<Gpio20ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio21ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -811,7 +825,8 @@ impl From<Gpio21ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio22ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -869,7 +884,8 @@ impl From<Gpio22ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio23ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -927,7 +943,8 @@ impl From<Gpio23ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio24ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -985,7 +1002,8 @@ impl From<Gpio24ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio25ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -1043,7 +1061,8 @@ impl From<Gpio25ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio26ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -1101,7 +1120,8 @@ impl From<Gpio26ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio27ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -1159,7 +1179,8 @@ impl From<Gpio27ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio28ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -1217,7 +1238,8 @@ impl From<Gpio28ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio29ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -1275,7 +1297,8 @@ impl From<Gpio29ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio2ctrlFuncsel {
     JTAG_TDI = 0x0,
     SPI0_SCLK = 0x01,
@@ -1333,7 +1356,8 @@ impl From<Gpio2ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio3ctrlFuncsel {
     JTAG_TDO = 0x0,
     SPI0_TX = 0x01,
@@ -1391,7 +1415,8 @@ impl From<Gpio3ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio4ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -1449,7 +1474,8 @@ impl From<Gpio4ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio5ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -1507,7 +1533,8 @@ impl From<Gpio5ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio6ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -1565,7 +1592,8 @@ impl From<Gpio6ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio7ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -1623,7 +1651,8 @@ impl From<Gpio7ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio8ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -1681,7 +1710,8 @@ impl From<Gpio8ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio9ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -1739,7 +1769,8 @@ impl From<Gpio9ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Inover {
     #[doc = "don't invert the peri input"]
     NORMAL = 0x0,
@@ -1773,7 +1804,8 @@ impl From<Inover> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Irqover {
     #[doc = "don't invert the interrupt"]
     NORMAL = 0x0,
@@ -1807,7 +1839,8 @@ impl From<Irqover> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Oeover {
     #[doc = "drive output enable from peripheral signal selected by funcsel"]
     NORMAL = 0x0,
@@ -1841,7 +1874,8 @@ impl From<Oeover> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Outover {
     #[doc = "drive output from peripheral signal selected by funcsel"]
     NORMAL = 0x0,

--- a/src/rp2040/mod.rs
+++ b/src/rp2040/mod.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (689341a 2024-02-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - TIMER_IRQ_0"]
     TIMER_IRQ_0 = 0,

--- a/src/rp2040/pads/regs.rs
+++ b/src/rp2040/pads/regs.rs
@@ -87,6 +87,44 @@ impl Default for GpioCtrl {
         GpioCtrl(0)
     }
 }
+impl core::fmt::Debug for GpioCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioCtrl")
+            .field("slewfast", &self.slewfast())
+            .field("schmitt", &self.schmitt())
+            .field("pde", &self.pde())
+            .field("pue", &self.pue())
+            .field("drive", &self.drive())
+            .field("ie", &self.ie())
+            .field("od", &self.od())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioCtrl {
+            slewfast: bool,
+            schmitt: bool,
+            pde: bool,
+            pue: bool,
+            drive: super::vals::Drive,
+            ie: bool,
+            od: bool,
+        }
+        let proxy = GpioCtrl {
+            slewfast: self.slewfast(),
+            schmitt: self.schmitt(),
+            pde: self.pde(),
+            pue: self.pue(),
+            drive: self.drive(),
+            ie: self.ie(),
+            od: self.od(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Voltage select. Per bank control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -106,5 +144,25 @@ impl Default for VoltageSelect {
     #[inline(always)]
     fn default() -> VoltageSelect {
         VoltageSelect(0)
+    }
+}
+impl core::fmt::Debug for VoltageSelect {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VoltageSelect")
+            .field("voltage_select", &self.voltage_select())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VoltageSelect {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct VoltageSelect {
+            voltage_select: super::vals::VoltageSelect,
+        }
+        let proxy = VoltageSelect {
+            voltage_select: self.voltage_select(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/pads/vals.rs
+++ b/src/rp2040/pads/vals.rs
@@ -1,10 +1,11 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Drive {
-    _2MA = 0x0,
-    _4MA = 0x01,
-    _8MA = 0x02,
-    _12MA = 0x03,
+    _2M_A = 0x0,
+    _4M_A = 0x01,
+    _8M_A = 0x02,
+    _12M_A = 0x03,
 }
 impl Drive {
     #[inline(always)]
@@ -29,7 +30,8 @@ impl From<Drive> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum VoltageSelect {
     #[doc = "Set voltage to 3.3V (DVDD >= 2V5)"]
     _3V3 = 0x0,

--- a/src/rp2040/pio/regs.rs
+++ b/src/rp2040/pio/regs.rs
@@ -43,6 +43,32 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("sm_enable", &self.sm_enable())
+            .field("sm_restart", &self.sm_restart())
+            .field("clkdiv_restart", &self.clkdiv_restart())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            sm_enable: u8,
+            sm_restart: u8,
+            clkdiv_restart: u8,
+        }
+        let proxy = Ctrl {
+            sm_enable: self.sm_enable(),
+            sm_restart: self.sm_restart(),
+            clkdiv_restart: self.clkdiv_restart(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "The PIO hardware has some free parameters that may vary between chip products. These should be provided in the chip datasheet, but are also exposed here."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -86,6 +112,32 @@ impl Default for DbgCfginfo {
     #[inline(always)]
     fn default() -> DbgCfginfo {
         DbgCfginfo(0)
+    }
+}
+impl core::fmt::Debug for DbgCfginfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DbgCfginfo")
+            .field("fifo_depth", &self.fifo_depth())
+            .field("sm_count", &self.sm_count())
+            .field("imem_size", &self.imem_size())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DbgCfginfo {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DbgCfginfo {
+            fifo_depth: u8,
+            sm_count: u8,
+            imem_size: u8,
+        }
+        let proxy = DbgCfginfo {
+            fifo_depth: self.fifo_depth(),
+            sm_count: self.sm_count(),
+            imem_size: self.imem_size(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "FIFO debug register"]
@@ -142,6 +194,35 @@ impl Default for Fdebug {
     #[inline(always)]
     fn default() -> Fdebug {
         Fdebug(0)
+    }
+}
+impl core::fmt::Debug for Fdebug {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fdebug")
+            .field("rxstall", &self.rxstall())
+            .field("rxunder", &self.rxunder())
+            .field("txover", &self.txover())
+            .field("txstall", &self.txstall())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fdebug {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fdebug {
+            rxstall: u8,
+            rxunder: u8,
+            txover: u8,
+            txstall: u8,
+        }
+        let proxy = Fdebug {
+            rxstall: self.rxstall(),
+            rxunder: self.rxunder(),
+            txover: self.txover(),
+            txstall: self.txstall(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "FIFO levels"]
@@ -228,6 +309,47 @@ impl Default for Flevel {
         Flevel(0)
     }
 }
+impl core::fmt::Debug for Flevel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Flevel")
+            .field("tx0", &self.tx0())
+            .field("rx0", &self.rx0())
+            .field("tx1", &self.tx1())
+            .field("rx1", &self.rx1())
+            .field("tx2", &self.tx2())
+            .field("rx2", &self.rx2())
+            .field("tx3", &self.tx3())
+            .field("rx3", &self.rx3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Flevel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Flevel {
+            tx0: u8,
+            rx0: u8,
+            tx1: u8,
+            rx1: u8,
+            tx2: u8,
+            rx2: u8,
+            tx3: u8,
+            rx3: u8,
+        }
+        let proxy = Flevel {
+            tx0: self.tx0(),
+            rx0: self.rx0(),
+            tx1: self.tx1(),
+            rx1: self.rx1(),
+            tx2: self.tx2(),
+            rx2: self.rx2(),
+            tx3: self.tx3(),
+            rx3: self.rx3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -284,7 +406,36 @@ impl Default for Fstat {
         Fstat(0)
     }
 }
-#[doc = "Write-only access to instruction memory location 30"]
+impl core::fmt::Debug for Fstat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fstat")
+            .field("rxfull", &self.rxfull())
+            .field("rxempty", &self.rxempty())
+            .field("txfull", &self.txfull())
+            .field("txempty", &self.txempty())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fstat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fstat {
+            rxfull: u8,
+            rxempty: u8,
+            txfull: u8,
+            txempty: u8,
+        }
+        let proxy = Fstat {
+            rxfull: self.rxfull(),
+            rxempty: self.rxempty(),
+            txfull: self.txfull(),
+            txempty: self.txempty(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Write-only access to instruction memory location 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct InstrMem(pub u32);
@@ -305,7 +456,27 @@ impl Default for InstrMem {
         InstrMem(0)
     }
 }
-#[doc = "Interrupt status after masking & forcing for irq0"]
+impl core::fmt::Debug for InstrMem {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("InstrMem")
+            .field("instr_mem", &self.instr_mem())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for InstrMem {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct InstrMem {
+            instr_mem: u16,
+        }
+        let proxy = InstrMem {
+            instr_mem: self.instr_mem(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Raw Interrupts"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Intr(pub u32);
@@ -425,6 +596,59 @@ impl Default for Intr {
         Intr(0)
     }
 }
+impl core::fmt::Debug for Intr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intr")
+            .field("sm0_rxnempty", &self.sm0_rxnempty())
+            .field("sm1_rxnempty", &self.sm1_rxnempty())
+            .field("sm2_rxnempty", &self.sm2_rxnempty())
+            .field("sm3_rxnempty", &self.sm3_rxnempty())
+            .field("sm0_txnfull", &self.sm0_txnfull())
+            .field("sm1_txnfull", &self.sm1_txnfull())
+            .field("sm2_txnfull", &self.sm2_txnfull())
+            .field("sm3_txnfull", &self.sm3_txnfull())
+            .field("sm0", &self.sm0())
+            .field("sm1", &self.sm1())
+            .field("sm2", &self.sm2())
+            .field("sm3", &self.sm3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intr {
+            sm0_rxnempty: bool,
+            sm1_rxnempty: bool,
+            sm2_rxnempty: bool,
+            sm3_rxnempty: bool,
+            sm0_txnfull: bool,
+            sm1_txnfull: bool,
+            sm2_txnfull: bool,
+            sm3_txnfull: bool,
+            sm0: bool,
+            sm1: bool,
+            sm2: bool,
+            sm3: bool,
+        }
+        let proxy = Intr {
+            sm0_rxnempty: self.sm0_rxnempty(),
+            sm1_rxnempty: self.sm1_rxnempty(),
+            sm2_rxnempty: self.sm2_rxnempty(),
+            sm3_rxnempty: self.sm3_rxnempty(),
+            sm0_txnfull: self.sm0_txnfull(),
+            sm1_txnfull: self.sm1_txnfull(),
+            sm2_txnfull: self.sm2_txnfull(),
+            sm3_txnfull: self.sm3_txnfull(),
+            sm0: self.sm0(),
+            sm1: self.sm1(),
+            sm2: self.sm2(),
+            sm3: self.sm3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "State machine IRQ flags register. Write 1 to clear. There are 8 state machine IRQ flags, which can be set, cleared, and waited on by the state machines. There's no fixed association between flags and state machines -- any state machine can use any flag. Any of the 8 flags can be used for timing synchronisation between state machines, using IRQ and WAIT instructions. The lower four of these flags are also routed out to system-level interrupt requests, alongside FIFO status interrupts -- see e.g. IRQ0_INTE."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -444,6 +668,22 @@ impl Default for Irq {
     #[inline(always)]
     fn default() -> Irq {
         Irq(0)
+    }
+}
+impl core::fmt::Debug for Irq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq").field("irq", &self.irq()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq {
+            irq: u8,
+        }
+        let proxy = Irq { irq: self.irq() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Writing a 1 to each of these bits will forcibly assert the corresponding IRQ. Note this is different to the INTF register: writing here affects PIO internal state. INTF just asserts the processor-facing IRQ signal for testing ISRs, and is not visible to the state machines."]
@@ -467,7 +707,27 @@ impl Default for IrqForce {
         IrqForce(0)
     }
 }
-#[doc = "Current instruction address of state machine 3"]
+impl core::fmt::Debug for IrqForce {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IrqForce")
+            .field("irq_force", &self.irq_force())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IrqForce {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IrqForce {
+            irq_force: u8,
+        }
+        let proxy = IrqForce {
+            irq_force: self.irq_force(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Current instruction address of state machine 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SmAddr(pub u32);
@@ -486,6 +746,24 @@ impl Default for SmAddr {
     #[inline(always)]
     fn default() -> SmAddr {
         SmAddr(0)
+    }
+}
+impl core::fmt::Debug for SmAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmAddr")
+            .field("addr", &self.addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmAddr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmAddr {
+            addr: u8,
+        }
+        let proxy = SmAddr { addr: self.addr() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock divisor register for state machine 0 Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)"]
@@ -520,6 +798,29 @@ impl Default for SmClkdiv {
     #[inline(always)]
     fn default() -> SmClkdiv {
         SmClkdiv(0)
+    }
+}
+impl core::fmt::Debug for SmClkdiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmClkdiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmClkdiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmClkdiv {
+            frac: u8,
+            int: u16,
+        }
+        let proxy = SmClkdiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Execution/behavioural settings for state machine 0"]
@@ -655,7 +956,57 @@ impl Default for SmExecctrl {
         SmExecctrl(0)
     }
 }
-#[doc = "Read to see the instruction currently addressed by state machine 3's program counter Write to execute an instruction immediately (including jumps) and then resume execution."]
+impl core::fmt::Debug for SmExecctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmExecctrl")
+            .field("status_n", &self.status_n())
+            .field("status_sel", &self.status_sel())
+            .field("wrap_bottom", &self.wrap_bottom())
+            .field("wrap_top", &self.wrap_top())
+            .field("out_sticky", &self.out_sticky())
+            .field("inline_out_en", &self.inline_out_en())
+            .field("out_en_sel", &self.out_en_sel())
+            .field("jmp_pin", &self.jmp_pin())
+            .field("side_pindir", &self.side_pindir())
+            .field("side_en", &self.side_en())
+            .field("exec_stalled", &self.exec_stalled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmExecctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmExecctrl {
+            status_n: u8,
+            status_sel: super::vals::SmExecctrlStatusSel,
+            wrap_bottom: u8,
+            wrap_top: u8,
+            out_sticky: bool,
+            inline_out_en: bool,
+            out_en_sel: u8,
+            jmp_pin: u8,
+            side_pindir: bool,
+            side_en: bool,
+            exec_stalled: bool,
+        }
+        let proxy = SmExecctrl {
+            status_n: self.status_n(),
+            status_sel: self.status_sel(),
+            wrap_bottom: self.wrap_bottom(),
+            wrap_top: self.wrap_top(),
+            out_sticky: self.out_sticky(),
+            inline_out_en: self.inline_out_en(),
+            out_en_sel: self.out_en_sel(),
+            jmp_pin: self.jmp_pin(),
+            side_pindir: self.side_pindir(),
+            side_en: self.side_en(),
+            exec_stalled: self.exec_stalled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Read to see the instruction currently addressed by state machine 0's program counter Write to execute an instruction immediately (including jumps) and then resume execution."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SmInstr(pub u32);
@@ -674,6 +1025,26 @@ impl Default for SmInstr {
     #[inline(always)]
     fn default() -> SmInstr {
         SmInstr(0)
+    }
+}
+impl core::fmt::Debug for SmInstr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmInstr")
+            .field("instr", &self.instr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmInstr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmInstr {
+            instr: u16,
+        }
+        let proxy = SmInstr {
+            instr: self.instr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "State machine pin control"]
@@ -763,6 +1134,44 @@ impl Default for SmPinctrl {
     #[inline(always)]
     fn default() -> SmPinctrl {
         SmPinctrl(0)
+    }
+}
+impl core::fmt::Debug for SmPinctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmPinctrl")
+            .field("out_base", &self.out_base())
+            .field("set_base", &self.set_base())
+            .field("sideset_base", &self.sideset_base())
+            .field("in_base", &self.in_base())
+            .field("out_count", &self.out_count())
+            .field("set_count", &self.set_count())
+            .field("sideset_count", &self.sideset_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmPinctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmPinctrl {
+            out_base: u8,
+            set_base: u8,
+            sideset_base: u8,
+            in_base: u8,
+            out_count: u8,
+            set_count: u8,
+            sideset_count: u8,
+        }
+        let proxy = SmPinctrl {
+            out_base: self.out_base(),
+            set_base: self.set_base(),
+            sideset_base: self.sideset_base(),
+            in_base: self.in_base(),
+            out_count: self.out_count(),
+            set_count: self.set_count(),
+            sideset_count: self.sideset_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control behaviour of the input/output shift registers for state machine 0"]
@@ -863,5 +1272,46 @@ impl Default for SmShiftctrl {
     #[inline(always)]
     fn default() -> SmShiftctrl {
         SmShiftctrl(0)
+    }
+}
+impl core::fmt::Debug for SmShiftctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmShiftctrl")
+            .field("autopush", &self.autopush())
+            .field("autopull", &self.autopull())
+            .field("in_shiftdir", &self.in_shiftdir())
+            .field("out_shiftdir", &self.out_shiftdir())
+            .field("push_thresh", &self.push_thresh())
+            .field("pull_thresh", &self.pull_thresh())
+            .field("fjoin_tx", &self.fjoin_tx())
+            .field("fjoin_rx", &self.fjoin_rx())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmShiftctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmShiftctrl {
+            autopush: bool,
+            autopull: bool,
+            in_shiftdir: bool,
+            out_shiftdir: bool,
+            push_thresh: u8,
+            pull_thresh: u8,
+            fjoin_tx: bool,
+            fjoin_rx: bool,
+        }
+        let proxy = SmShiftctrl {
+            autopush: self.autopush(),
+            autopull: self.autopull(),
+            in_shiftdir: self.in_shiftdir(),
+            out_shiftdir: self.out_shiftdir(),
+            push_thresh: self.push_thresh(),
+            pull_thresh: self.pull_thresh(),
+            fjoin_tx: self.fjoin_tx(),
+            fjoin_rx: self.fjoin_rx(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/pio/vals.rs
+++ b/src/rp2040/pio/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SmExecctrlStatusSel {
     #[doc = "All-ones if TX FIFO level < N, otherwise all-zeroes"]
     TXLEVEL = 0x0,

--- a/src/rp2040/pll/regs.rs
+++ b/src/rp2040/pll/regs.rs
@@ -43,6 +43,32 @@ impl Default for Cs {
         Cs(0)
     }
 }
+impl core::fmt::Debug for Cs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cs")
+            .field("refdiv", &self.refdiv())
+            .field("bypass", &self.bypass())
+            .field("lock", &self.lock())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cs {
+            refdiv: u8,
+            bypass: bool,
+            lock: bool,
+        }
+        let proxy = Cs {
+            refdiv: self.refdiv(),
+            bypass: self.bypass(),
+            lock: self.lock(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Feedback divisor (note: this PLL does not support fractional division)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -64,6 +90,26 @@ impl Default for FbdivInt {
     #[inline(always)]
     fn default() -> FbdivInt {
         FbdivInt(0)
+    }
+}
+impl core::fmt::Debug for FbdivInt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FbdivInt")
+            .field("fbdiv_int", &self.fbdiv_int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FbdivInt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FbdivInt {
+            fbdiv_int: u16,
+        }
+        let proxy = FbdivInt {
+            fbdiv_int: self.fbdiv_int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the PLL post dividers for the primary output (note: this PLL does not have a secondary output) the primary output is driven from VCO divided by postdiv1*postdiv2"]
@@ -98,6 +144,29 @@ impl Default for Prim {
     #[inline(always)]
     fn default() -> Prim {
         Prim(0)
+    }
+}
+impl core::fmt::Debug for Prim {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Prim")
+            .field("postdiv2", &self.postdiv2())
+            .field("postdiv1", &self.postdiv1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Prim {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Prim {
+            postdiv2: u8,
+            postdiv1: u8,
+        }
+        let proxy = Prim {
+            postdiv2: self.postdiv2(),
+            postdiv1: self.postdiv1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the PLL power modes."]
@@ -154,5 +223,34 @@ impl Default for Pwr {
     #[inline(always)]
     fn default() -> Pwr {
         Pwr(0)
+    }
+}
+impl core::fmt::Debug for Pwr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pwr")
+            .field("pd", &self.pd())
+            .field("dsmpd", &self.dsmpd())
+            .field("postdivpd", &self.postdivpd())
+            .field("vcopd", &self.vcopd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pwr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pwr {
+            pd: bool,
+            dsmpd: bool,
+            postdivpd: bool,
+            vcopd: bool,
+        }
+        let proxy = Pwr {
+            pd: self.pd(),
+            dsmpd: self.dsmpd(),
+            postdivpd: self.postdivpd(),
+            vcopd: self.vcopd(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/psm/regs.rs
+++ b/src/rp2040/psm/regs.rs
@@ -163,6 +163,74 @@ impl Default for Done {
         Done(0)
     }
 }
+impl core::fmt::Debug for Done {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Done")
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("clocks", &self.clocks())
+            .field("resets", &self.resets())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("xip", &self.xip())
+            .field("vreg_and_chip_reset", &self.vreg_and_chip_reset())
+            .field("sio", &self.sio())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Done {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Done {
+            rosc: bool,
+            xosc: bool,
+            clocks: bool,
+            resets: bool,
+            busfabric: bool,
+            rom: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            xip: bool,
+            vreg_and_chip_reset: bool,
+            sio: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = Done {
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            clocks: self.clocks(),
+            resets: self.resets(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            xip: self.xip(),
+            vreg_and_chip_reset: self.vreg_and_chip_reset(),
+            sio: self.sio(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Force into reset (i.e. power it off)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -326,6 +394,74 @@ impl Default for FrceOff {
     #[inline(always)]
     fn default() -> FrceOff {
         FrceOff(0)
+    }
+}
+impl core::fmt::Debug for FrceOff {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FrceOff")
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("clocks", &self.clocks())
+            .field("resets", &self.resets())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("xip", &self.xip())
+            .field("vreg_and_chip_reset", &self.vreg_and_chip_reset())
+            .field("sio", &self.sio())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FrceOff {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FrceOff {
+            rosc: bool,
+            xosc: bool,
+            clocks: bool,
+            resets: bool,
+            busfabric: bool,
+            rom: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            xip: bool,
+            vreg_and_chip_reset: bool,
+            sio: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = FrceOff {
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            clocks: self.clocks(),
+            resets: self.resets(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            xip: self.xip(),
+            vreg_and_chip_reset: self.vreg_and_chip_reset(),
+            sio: self.sio(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Force block out of reset (i.e. power it on)"]
@@ -493,6 +629,74 @@ impl Default for FrceOn {
         FrceOn(0)
     }
 }
+impl core::fmt::Debug for FrceOn {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FrceOn")
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("clocks", &self.clocks())
+            .field("resets", &self.resets())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("xip", &self.xip())
+            .field("vreg_and_chip_reset", &self.vreg_and_chip_reset())
+            .field("sio", &self.sio())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FrceOn {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FrceOn {
+            rosc: bool,
+            xosc: bool,
+            clocks: bool,
+            resets: bool,
+            busfabric: bool,
+            rom: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            xip: bool,
+            vreg_and_chip_reset: bool,
+            sio: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = FrceOn {
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            clocks: self.clocks(),
+            resets: self.resets(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            xip: self.xip(),
+            vreg_and_chip_reset: self.vreg_and_chip_reset(),
+            sio: self.sio(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set to 1 if this peripheral should be reset when the watchdog fires."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -656,5 +860,73 @@ impl Default for Wdsel {
     #[inline(always)]
     fn default() -> Wdsel {
         Wdsel(0)
+    }
+}
+impl core::fmt::Debug for Wdsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wdsel")
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("clocks", &self.clocks())
+            .field("resets", &self.resets())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("xip", &self.xip())
+            .field("vreg_and_chip_reset", &self.vreg_and_chip_reset())
+            .field("sio", &self.sio())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wdsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wdsel {
+            rosc: bool,
+            xosc: bool,
+            clocks: bool,
+            resets: bool,
+            busfabric: bool,
+            rom: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            xip: bool,
+            vreg_and_chip_reset: bool,
+            sio: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = Wdsel {
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            clocks: self.clocks(),
+            resets: self.resets(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            xip: self.xip(),
+            vreg_and_chip_reset: self.vreg_and_chip_reset(),
+            sio: self.sio(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/pwm/regs.rs
+++ b/src/rp2040/pwm/regs.rs
@@ -28,6 +28,29 @@ impl Default for ChCc {
         ChCc(0)
     }
 }
+impl core::fmt::Debug for ChCc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChCc")
+            .field("a", &self.a())
+            .field("b", &self.b())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChCc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChCc {
+            a: u16,
+            b: u16,
+        }
+        let proxy = ChCc {
+            a: self.a(),
+            b: self.b(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control and status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -115,6 +138,44 @@ impl Default for ChCsr {
         ChCsr(0)
     }
 }
+impl core::fmt::Debug for ChCsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChCsr")
+            .field("en", &self.en())
+            .field("ph_correct", &self.ph_correct())
+            .field("a_inv", &self.a_inv())
+            .field("b_inv", &self.b_inv())
+            .field("divmode", &self.divmode())
+            .field("ph_ret", &self.ph_ret())
+            .field("ph_adv", &self.ph_adv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChCsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChCsr {
+            en: bool,
+            ph_correct: bool,
+            a_inv: bool,
+            b_inv: bool,
+            divmode: super::vals::Divmode,
+            ph_ret: bool,
+            ph_adv: bool,
+        }
+        let proxy = ChCsr {
+            en: self.en(),
+            ph_correct: self.ph_correct(),
+            a_inv: self.a_inv(),
+            b_inv: self.b_inv(),
+            divmode: self.divmode(),
+            ph_ret: self.ph_ret(),
+            ph_adv: self.ph_adv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Direct access to the PWM counter"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -134,6 +195,22 @@ impl Default for ChCtr {
     #[inline(always)]
     fn default() -> ChCtr {
         ChCtr(0)
+    }
+}
+impl core::fmt::Debug for ChCtr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChCtr").field("ctr", &self.ctr()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChCtr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChCtr {
+            ctr: u16,
+        }
+        let proxy = ChCtr { ctr: self.ctr() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "INT and FRAC form a fixed-point fractional number. Counting rate is system clock frequency divided by this number. Fractional division uses simple 1st-order sigma-delta."]
@@ -166,6 +243,29 @@ impl Default for ChDiv {
         ChDiv(0)
     }
 }
+impl core::fmt::Debug for ChDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChDiv {
+            frac: u8,
+            int: u8,
+        }
+        let proxy = ChDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Counter wrap value"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -185,6 +285,22 @@ impl Default for ChTop {
     #[inline(always)]
     fn default() -> ChTop {
         ChTop(0)
+    }
+}
+impl core::fmt::Debug for ChTop {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChTop").field("top", &self.top()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChTop {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChTop {
+            top: u16,
+        }
+        let proxy = ChTop { top: self.top() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "This register aliases the CSR_EN bits for all channels. Writing to this register allows multiple channels to be enabled or disabled simultaneously, so they can run in perfect sync. For each channel, there is only one physical EN register bit, which can be accessed through here or CHx_CSR."]
@@ -271,6 +387,47 @@ impl Default for En {
         En(0)
     }
 }
+impl core::fmt::Debug for En {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("En")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for En {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct En {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+        }
+        let proxy = En {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -353,6 +510,47 @@ impl Default for Inte {
     #[inline(always)]
     fn default() -> Inte {
         Inte(0)
+    }
+}
+impl core::fmt::Debug for Inte {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Inte")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Inte {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Inte {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+        }
+        let proxy = Inte {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Force"]
@@ -439,6 +637,47 @@ impl Default for Intf {
         Intf(0)
     }
 }
+impl core::fmt::Debug for Intf {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intf")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intf {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intf {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+        }
+        let proxy = Intf {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Raw Interrupts"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -523,6 +762,47 @@ impl Default for Intr {
         Intr(0)
     }
 }
+impl core::fmt::Debug for Intr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intr")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intr {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+        }
+        let proxy = Intr {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt status after masking & forcing"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -605,5 +885,46 @@ impl Default for Ints {
     #[inline(always)]
     fn default() -> Ints {
         Ints(0)
+    }
+}
+impl core::fmt::Debug for Ints {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ints")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ints {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ints {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+        }
+        let proxy = Ints {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/pwm/vals.rs
+++ b/src/rp2040/pwm/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Divmode {
     #[doc = "Free-running counting at rate dictated by fractional divider"]
     DIV = 0x0,

--- a/src/rp2040/resets/regs.rs
+++ b/src/rp2040/resets/regs.rs
@@ -235,6 +235,98 @@ impl Default for Peripherals {
         Peripherals(0)
     }
 }
+impl core::fmt::Debug for Peripherals {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Peripherals")
+            .field("adc", &self.adc())
+            .field("busctrl", &self.busctrl())
+            .field("dma", &self.dma())
+            .field("i2c0", &self.i2c0())
+            .field("i2c1", &self.i2c1())
+            .field("io_bank0", &self.io_bank0())
+            .field("io_qspi", &self.io_qspi())
+            .field("jtag", &self.jtag())
+            .field("pads_bank0", &self.pads_bank0())
+            .field("pads_qspi", &self.pads_qspi())
+            .field("pio0", &self.pio0())
+            .field("pio1", &self.pio1())
+            .field("pll_sys", &self.pll_sys())
+            .field("pll_usb", &self.pll_usb())
+            .field("pwm", &self.pwm())
+            .field("rtc", &self.rtc())
+            .field("spi0", &self.spi0())
+            .field("spi1", &self.spi1())
+            .field("syscfg", &self.syscfg())
+            .field("sysinfo", &self.sysinfo())
+            .field("tbman", &self.tbman())
+            .field("timer", &self.timer())
+            .field("uart0", &self.uart0())
+            .field("uart1", &self.uart1())
+            .field("usbctrl", &self.usbctrl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Peripherals {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Peripherals {
+            adc: bool,
+            busctrl: bool,
+            dma: bool,
+            i2c0: bool,
+            i2c1: bool,
+            io_bank0: bool,
+            io_qspi: bool,
+            jtag: bool,
+            pads_bank0: bool,
+            pads_qspi: bool,
+            pio0: bool,
+            pio1: bool,
+            pll_sys: bool,
+            pll_usb: bool,
+            pwm: bool,
+            rtc: bool,
+            spi0: bool,
+            spi1: bool,
+            syscfg: bool,
+            sysinfo: bool,
+            tbman: bool,
+            timer: bool,
+            uart0: bool,
+            uart1: bool,
+            usbctrl: bool,
+        }
+        let proxy = Peripherals {
+            adc: self.adc(),
+            busctrl: self.busctrl(),
+            dma: self.dma(),
+            i2c0: self.i2c0(),
+            i2c1: self.i2c1(),
+            io_bank0: self.io_bank0(),
+            io_qspi: self.io_qspi(),
+            jtag: self.jtag(),
+            pads_bank0: self.pads_bank0(),
+            pads_qspi: self.pads_qspi(),
+            pio0: self.pio0(),
+            pio1: self.pio1(),
+            pll_sys: self.pll_sys(),
+            pll_usb: self.pll_usb(),
+            pwm: self.pwm(),
+            rtc: self.rtc(),
+            spi0: self.spi0(),
+            spi1: self.spi1(),
+            syscfg: self.syscfg(),
+            sysinfo: self.sysinfo(),
+            tbman: self.tbman(),
+            timer: self.timer(),
+            uart0: self.uart0(),
+            uart1: self.uart1(),
+            usbctrl: self.usbctrl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Watchdog select. If a bit is set then the watchdog will reset this peripheral when the watchdog fires."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -470,5 +562,97 @@ impl Default for Wdsel {
     #[inline(always)]
     fn default() -> Wdsel {
         Wdsel(0)
+    }
+}
+impl core::fmt::Debug for Wdsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wdsel")
+            .field("adc", &self.adc())
+            .field("busctrl", &self.busctrl())
+            .field("dma", &self.dma())
+            .field("i2c0", &self.i2c0())
+            .field("i2c1", &self.i2c1())
+            .field("io_bank0", &self.io_bank0())
+            .field("io_qspi", &self.io_qspi())
+            .field("jtag", &self.jtag())
+            .field("pads_bank0", &self.pads_bank0())
+            .field("pads_qspi", &self.pads_qspi())
+            .field("pio0", &self.pio0())
+            .field("pio1", &self.pio1())
+            .field("pll_sys", &self.pll_sys())
+            .field("pll_usb", &self.pll_usb())
+            .field("pwm", &self.pwm())
+            .field("rtc", &self.rtc())
+            .field("spi0", &self.spi0())
+            .field("spi1", &self.spi1())
+            .field("syscfg", &self.syscfg())
+            .field("sysinfo", &self.sysinfo())
+            .field("tbman", &self.tbman())
+            .field("timer", &self.timer())
+            .field("uart0", &self.uart0())
+            .field("uart1", &self.uart1())
+            .field("usbctrl", &self.usbctrl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wdsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wdsel {
+            adc: bool,
+            busctrl: bool,
+            dma: bool,
+            i2c0: bool,
+            i2c1: bool,
+            io_bank0: bool,
+            io_qspi: bool,
+            jtag: bool,
+            pads_bank0: bool,
+            pads_qspi: bool,
+            pio0: bool,
+            pio1: bool,
+            pll_sys: bool,
+            pll_usb: bool,
+            pwm: bool,
+            rtc: bool,
+            spi0: bool,
+            spi1: bool,
+            syscfg: bool,
+            sysinfo: bool,
+            tbman: bool,
+            timer: bool,
+            uart0: bool,
+            uart1: bool,
+            usbctrl: bool,
+        }
+        let proxy = Wdsel {
+            adc: self.adc(),
+            busctrl: self.busctrl(),
+            dma: self.dma(),
+            i2c0: self.i2c0(),
+            i2c1: self.i2c1(),
+            io_bank0: self.io_bank0(),
+            io_qspi: self.io_qspi(),
+            jtag: self.jtag(),
+            pads_bank0: self.pads_bank0(),
+            pads_qspi: self.pads_qspi(),
+            pio0: self.pio0(),
+            pio1: self.pio1(),
+            pll_sys: self.pll_sys(),
+            pll_usb: self.pll_usb(),
+            pwm: self.pwm(),
+            rtc: self.rtc(),
+            spi0: self.spi0(),
+            spi1: self.spi1(),
+            syscfg: self.syscfg(),
+            sysinfo: self.sysinfo(),
+            tbman: self.tbman(),
+            timer: self.timer(),
+            uart0: self.uart0(),
+            uart1: self.uart1(),
+            usbctrl: self.usbctrl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/rosc/regs.rs
+++ b/src/rp2040/rosc/regs.rs
@@ -19,6 +19,26 @@ impl Default for Count {
         Count(0)
     }
 }
+impl core::fmt::Debug for Count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Count")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Count {
+            count: u8,
+        }
+        let proxy = Count {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Ring Oscillator control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,6 +73,29 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("freq_range", &self.freq_range())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            freq_range: super::vals::FreqRange,
+            enable: super::vals::Enable,
+        }
+        let proxy = Ctrl {
+            freq_range: self.freq_range(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Controls the output divider"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -74,6 +117,22 @@ impl Default for Div {
     #[inline(always)]
     fn default() -> Div {
         Div(0)
+    }
+}
+impl core::fmt::Debug for Div {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Div").field("div", &self.div()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Div {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Div {
+            div: super::vals::Div,
+        }
+        let proxy = Div { div: self.div() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Ring Oscillator pause control"]
@@ -98,6 +157,26 @@ impl Default for Dormant {
     #[inline(always)]
     fn default() -> Dormant {
         Dormant(0)
+    }
+}
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dormant")
+            .field("dormant", &self.dormant())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dormant {
+            dormant: super::vals::Dormant,
+        }
+        let proxy = Dormant {
+            dormant: self.dormant(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "The FREQA & FREQB registers control the frequency by controlling the drive strength of each stage The drive strength has 4 levels determined by the number of bits set Increasing the number of bits set increases the drive strength and increases the oscillation frequency 0 bits set is the default drive strength 1 bit set doubles the drive strength 2 bits set triples drive strength 3 bits set quadruples drive strength"]
@@ -167,6 +246,38 @@ impl Default for Freqa {
         Freqa(0)
     }
 }
+impl core::fmt::Debug for Freqa {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Freqa")
+            .field("ds0", &self.ds0())
+            .field("ds1", &self.ds1())
+            .field("ds2", &self.ds2())
+            .field("ds3", &self.ds3())
+            .field("passwd", &self.passwd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Freqa {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Freqa {
+            ds0: u8,
+            ds1: u8,
+            ds2: u8,
+            ds3: u8,
+            passwd: super::vals::Passwd,
+        }
+        let proxy = Freqa {
+            ds0: self.ds0(),
+            ds1: self.ds1(),
+            ds2: self.ds2(),
+            ds3: self.ds3(),
+            passwd: self.passwd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "For a detailed description see freqa register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -234,6 +345,38 @@ impl Default for Freqb {
         Freqb(0)
     }
 }
+impl core::fmt::Debug for Freqb {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Freqb")
+            .field("ds4", &self.ds4())
+            .field("ds5", &self.ds5())
+            .field("ds6", &self.ds6())
+            .field("ds7", &self.ds7())
+            .field("passwd", &self.passwd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Freqb {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Freqb {
+            ds4: u8,
+            ds5: u8,
+            ds6: u8,
+            ds7: u8,
+            passwd: super::vals::Passwd,
+        }
+        let proxy = Freqb {
+            ds4: self.ds4(),
+            ds5: self.ds5(),
+            ds6: self.ds6(),
+            ds7: self.ds7(),
+            passwd: self.passwd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Controls the phase shifted output"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -290,6 +433,35 @@ impl Default for Phase {
         Phase(0)
     }
 }
+impl core::fmt::Debug for Phase {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Phase")
+            .field("shift", &self.shift())
+            .field("flip", &self.flip())
+            .field("enable", &self.enable())
+            .field("passwd", &self.passwd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Phase {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Phase {
+            shift: u8,
+            flip: bool,
+            enable: bool,
+            passwd: u8,
+        }
+        let proxy = Phase {
+            shift: self.shift(),
+            flip: self.flip(),
+            enable: self.enable(),
+            passwd: self.passwd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "This just reads the state of the oscillator output so randomness is compromised if the ring oscillator is stopped or run at a harmonic of the bus frequency"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -309,6 +481,26 @@ impl Default for Randombit {
     #[inline(always)]
     fn default() -> Randombit {
         Randombit(0)
+    }
+}
+impl core::fmt::Debug for Randombit {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Randombit")
+            .field("randombit", &self.randombit())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Randombit {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Randombit {
+            randombit: bool,
+        }
+        let proxy = Randombit {
+            randombit: self.randombit(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Ring Oscillator Status"]
@@ -365,5 +557,34 @@ impl Default for Status {
     #[inline(always)]
     fn default() -> Status {
         Status(0)
+    }
+}
+impl core::fmt::Debug for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Status")
+            .field("enabled", &self.enabled())
+            .field("div_running", &self.div_running())
+            .field("badwrite", &self.badwrite())
+            .field("stable", &self.stable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Status {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Status {
+            enabled: bool,
+            div_running: bool,
+            badwrite: bool,
+            stable: bool,
+        }
+        let proxy = Status {
+            enabled: self.enabled(),
+            div_running: self.div_running(),
+            badwrite: self.badwrite(),
+            stable: self.stable(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/rosc/vals.rs
+++ b/src/rp2040/rosc/vals.rs
@@ -12,6 +12,23 @@ impl Div {
         self.0
     }
 }
+impl core::fmt::Debug for Div {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0aa0 => f.write_str("PASS"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Div {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0aa0 => defmt::write!(f, "PASS"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Div {
     #[inline(always)]
     fn from(val: u16) -> Div {
@@ -39,6 +56,25 @@ impl Dormant {
         self.0
     }
 }
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x636f_6d61 => f.write_str("DORMANT"),
+            0x7761_6b65 => f.write_str("WAKE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x636f_6d61 => defmt::write!(f, "DORMANT"),
+            0x7761_6b65 => defmt::write!(f, "WAKE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u32> for Dormant {
     #[inline(always)]
     fn from(val: u32) -> Dormant {
@@ -64,6 +100,25 @@ impl Enable {
     }
     pub const fn to_bits(self) -> u16 {
         self.0
+    }
+}
+impl core::fmt::Debug for Enable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0d1e => f.write_str("DISABLE"),
+            0x0fab => f.write_str("ENABLE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enable {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0d1e => defmt::write!(f, "DISABLE"),
+            0x0fab => defmt::write!(f, "ENABLE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u16> for Enable {
@@ -95,6 +150,29 @@ impl FreqRange {
         self.0
     }
 }
+impl core::fmt::Debug for FreqRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0fa4 => f.write_str("LOW"),
+            0x0fa5 => f.write_str("MEDIUM"),
+            0x0fa6 => f.write_str("TOOHIGH"),
+            0x0fa7 => f.write_str("HIGH"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FreqRange {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0fa4 => defmt::write!(f, "LOW"),
+            0x0fa5 => defmt::write!(f, "MEDIUM"),
+            0x0fa6 => defmt::write!(f, "TOOHIGH"),
+            0x0fa7 => defmt::write!(f, "HIGH"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for FreqRange {
     #[inline(always)]
     fn from(val: u16) -> FreqRange {
@@ -119,6 +197,23 @@ impl Passwd {
     }
     pub const fn to_bits(self) -> u16 {
         self.0
+    }
+}
+impl core::fmt::Debug for Passwd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x9696 => f.write_str("PASS"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Passwd {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x9696 => defmt::write!(f, "PASS"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u16> for Passwd {

--- a/src/rp2040/rtc/regs.rs
+++ b/src/rp2040/rtc/regs.rs
@@ -19,6 +19,26 @@ impl Default for ClkdivM1 {
         ClkdivM1(0)
     }
 }
+impl core::fmt::Debug for ClkdivM1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkdivM1")
+            .field("clkdiv_m1", &self.clkdiv_m1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkdivM1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkdivM1 {
+            clkdiv_m1: u16,
+        }
+        let proxy = ClkdivM1 {
+            clkdiv_m1: self.clkdiv_m1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RTC Control and status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -75,6 +95,35 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("rtc_enable", &self.rtc_enable())
+            .field("rtc_active", &self.rtc_active())
+            .field("load", &self.load())
+            .field("force_notleapyear", &self.force_notleapyear())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            rtc_enable: bool,
+            rtc_active: bool,
+            load: bool,
+            force_notleapyear: bool,
+        }
+        let proxy = Ctrl {
+            rtc_enable: self.rtc_enable(),
+            rtc_active: self.rtc_active(),
+            load: self.load(),
+            force_notleapyear: self.force_notleapyear(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -94,6 +143,22 @@ impl Default for Int {
     #[inline(always)]
     fn default() -> Int {
         Int(0)
+    }
+}
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int").field("rtc", &self.rtc()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            rtc: bool,
+        }
+        let proxy = Int { rtc: self.rtc() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt setup register 0"]
@@ -192,6 +257,47 @@ impl Default for IrqSetup0 {
     #[inline(always)]
     fn default() -> IrqSetup0 {
         IrqSetup0(0)
+    }
+}
+impl core::fmt::Debug for IrqSetup0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IrqSetup0")
+            .field("day", &self.day())
+            .field("month", &self.month())
+            .field("year", &self.year())
+            .field("day_ena", &self.day_ena())
+            .field("month_ena", &self.month_ena())
+            .field("year_ena", &self.year_ena())
+            .field("match_ena", &self.match_ena())
+            .field("match_active", &self.match_active())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IrqSetup0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IrqSetup0 {
+            day: u8,
+            month: u8,
+            year: u16,
+            day_ena: bool,
+            month_ena: bool,
+            year_ena: bool,
+            match_ena: bool,
+            match_active: bool,
+        }
+        let proxy = IrqSetup0 {
+            day: self.day(),
+            month: self.month(),
+            year: self.year(),
+            day_ena: self.day_ena(),
+            month_ena: self.month_ena(),
+            year_ena: self.year_ena(),
+            match_ena: self.match_ena(),
+            match_active: self.match_active(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt setup register 1"]
@@ -294,6 +400,47 @@ impl Default for IrqSetup1 {
         IrqSetup1(0)
     }
 }
+impl core::fmt::Debug for IrqSetup1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IrqSetup1")
+            .field("sec", &self.sec())
+            .field("min", &self.min())
+            .field("hour", &self.hour())
+            .field("dotw", &self.dotw())
+            .field("sec_ena", &self.sec_ena())
+            .field("min_ena", &self.min_ena())
+            .field("hour_ena", &self.hour_ena())
+            .field("dotw_ena", &self.dotw_ena())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IrqSetup1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IrqSetup1 {
+            sec: u8,
+            min: u8,
+            hour: u8,
+            dotw: u8,
+            sec_ena: bool,
+            min_ena: bool,
+            hour_ena: bool,
+            dotw_ena: bool,
+        }
+        let proxy = IrqSetup1 {
+            sec: self.sec(),
+            min: self.min(),
+            hour: self.hour(),
+            dotw: self.dotw(),
+            sec_ena: self.sec_ena(),
+            min_ena: self.min_ena(),
+            hour_ena: self.hour_ena(),
+            dotw_ena: self.dotw_ena(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RTC register 0 Read this before RTC 1!"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -350,6 +497,35 @@ impl Default for Rtc0 {
         Rtc0(0)
     }
 }
+impl core::fmt::Debug for Rtc0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rtc0")
+            .field("sec", &self.sec())
+            .field("min", &self.min())
+            .field("hour", &self.hour())
+            .field("dotw", &self.dotw())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rtc0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rtc0 {
+            sec: u8,
+            min: u8,
+            hour: u8,
+            dotw: u8,
+        }
+        let proxy = Rtc0 {
+            sec: self.sec(),
+            min: self.min(),
+            hour: self.hour(),
+            dotw: self.dotw(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RTC register 1."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -395,6 +571,32 @@ impl Default for Rtc1 {
         Rtc1(0)
     }
 }
+impl core::fmt::Debug for Rtc1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rtc1")
+            .field("day", &self.day())
+            .field("month", &self.month())
+            .field("year", &self.year())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rtc1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rtc1 {
+            day: u8,
+            month: u8,
+            year: u16,
+        }
+        let proxy = Rtc1 {
+            day: self.day(),
+            month: self.month(),
+            year: self.year(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RTC setup register 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -438,6 +640,32 @@ impl Default for Setup0 {
     #[inline(always)]
     fn default() -> Setup0 {
         Setup0(0)
+    }
+}
+impl core::fmt::Debug for Setup0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Setup0")
+            .field("day", &self.day())
+            .field("month", &self.month())
+            .field("year", &self.year())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Setup0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Setup0 {
+            day: u8,
+            month: u8,
+            year: u16,
+        }
+        let proxy = Setup0 {
+            day: self.day(),
+            month: self.month(),
+            year: self.year(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "RTC setup register 1"]
@@ -494,5 +722,34 @@ impl Default for Setup1 {
     #[inline(always)]
     fn default() -> Setup1 {
         Setup1(0)
+    }
+}
+impl core::fmt::Debug for Setup1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Setup1")
+            .field("sec", &self.sec())
+            .field("min", &self.min())
+            .field("hour", &self.hour())
+            .field("dotw", &self.dotw())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Setup1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Setup1 {
+            sec: u8,
+            min: u8,
+            hour: u8,
+            dotw: u8,
+        }
+        let proxy = Setup1 {
+            sec: self.sec(),
+            min: self.min(),
+            hour: self.hour(),
+            dotw: self.dotw(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/sio.rs
+++ b/src/rp2040/sio.rs
@@ -95,22 +95,22 @@ impl Gpio {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "GPIO output enable"]
+    #[doc = "GPIO output value"]
     #[inline(always)]
     pub const fn value(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "GPIO output enable set"]
+    #[doc = "GPIO output value set"]
     #[inline(always)]
     pub const fn value_set(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
-    #[doc = "GPIO output enable clear"]
+    #[doc = "GPIO output value clear"]
     #[inline(always)]
     pub const fn value_clr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
-    #[doc = "GPIO output enable XOR"]
+    #[doc = "GPIO output value XOR"]
     #[inline(always)]
     pub const fn value_xor(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0cusize) as _) }

--- a/src/rp2040/sio/regs.rs
+++ b/src/rp2040/sio/regs.rs
@@ -32,6 +32,29 @@ impl Default for DivCsr {
         DivCsr(0)
     }
 }
+impl core::fmt::Debug for DivCsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DivCsr")
+            .field("ready", &self.ready())
+            .field("dirty", &self.dirty())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DivCsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DivCsr {
+            ready: bool,
+            dirty: bool,
+        }
+        let proxy = DivCsr {
+            ready: self.ready(),
+            dirty: self.dirty(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Status register for inter-core FIFOs (mailboxes). There is one FIFO in the core 0 -> core 1 direction, and one core 1 -> core 0. Both are 32 bits wide and 8 words deep. Core 0 can see the read side of the 1->0 FIFO (RX), and the write side of 0->1 FIFO (TX). Core 1 can see the read side of the 0->1 FIFO (RX), and the write side of 1->0 FIFO (TX). The SIO IRQ for each core is the logical OR of the VLD, WOF and ROE fields of its FIFO_ST register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +111,35 @@ impl Default for FifoSt {
         FifoSt(0)
     }
 }
+impl core::fmt::Debug for FifoSt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FifoSt")
+            .field("vld", &self.vld())
+            .field("rdy", &self.rdy())
+            .field("wof", &self.wof())
+            .field("roe", &self.roe())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FifoSt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FifoSt {
+            vld: bool,
+            rdy: bool,
+            wof: bool,
+            roe: bool,
+        }
+        let proxy = FifoSt {
+            vld: self.vld(),
+            rdy: self.rdy(),
+            wof: self.wof(),
+            roe: self.roe(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM0 Reading yields lane 0's raw shift and mask value (BASE0 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -109,6 +161,26 @@ impl Default for Interp0accum0add {
         Interp0accum0add(0)
     }
 }
+impl core::fmt::Debug for Interp0accum0add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0accum0add")
+            .field("interp0_accum0_add", &self.interp0_accum0_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0accum0add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0accum0add {
+            interp0_accum0_add: u32,
+        }
+        let proxy = Interp0accum0add {
+            interp0_accum0_add: self.interp0_accum0_add(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM1 Reading yields lane 1's raw shift and mask value (BASE1 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -128,6 +200,26 @@ impl Default for Interp0accum1add {
     #[inline(always)]
     fn default() -> Interp0accum1add {
         Interp0accum1add(0)
+    }
+}
+impl core::fmt::Debug for Interp0accum1add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0accum1add")
+            .field("interp0_accum1_add", &self.interp0_accum1_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0accum1add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0accum1add {
+            interp0_accum1_add: u32,
+        }
+        let proxy = Interp0accum1add {
+            interp0_accum1_add: self.interp0_accum1_add(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control register for lane 0"]
@@ -274,6 +366,59 @@ impl Default for Interp0ctrlLane0 {
         Interp0ctrlLane0(0)
     }
 }
+impl core::fmt::Debug for Interp0ctrlLane0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0ctrlLane0")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .field("blend", &self.blend())
+            .field("overf0", &self.overf0())
+            .field("overf1", &self.overf1())
+            .field("overf", &self.overf())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0ctrlLane0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0ctrlLane0 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+            blend: bool,
+            overf0: bool,
+            overf1: bool,
+            overf: bool,
+        }
+        let proxy = Interp0ctrlLane0 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+            blend: self.blend(),
+            overf0: self.overf0(),
+            overf1: self.overf1(),
+            overf: self.overf(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register for lane 1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -374,6 +519,47 @@ impl Default for Interp0ctrlLane1 {
         Interp0ctrlLane1(0)
     }
 }
+impl core::fmt::Debug for Interp0ctrlLane1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0ctrlLane1")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0ctrlLane1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0ctrlLane1 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+        }
+        let proxy = Interp0ctrlLane1 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM0 Reading yields lane 0's raw shift and mask value (BASE0 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -395,6 +581,26 @@ impl Default for Interp1accum0add {
         Interp1accum0add(0)
     }
 }
+impl core::fmt::Debug for Interp1accum0add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1accum0add")
+            .field("interp1_accum0_add", &self.interp1_accum0_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1accum0add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1accum0add {
+            interp1_accum0_add: u32,
+        }
+        let proxy = Interp1accum0add {
+            interp1_accum0_add: self.interp1_accum0_add(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM1 Reading yields lane 1's raw shift and mask value (BASE1 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -414,6 +620,26 @@ impl Default for Interp1accum1add {
     #[inline(always)]
     fn default() -> Interp1accum1add {
         Interp1accum1add(0)
+    }
+}
+impl core::fmt::Debug for Interp1accum1add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1accum1add")
+            .field("interp1_accum1_add", &self.interp1_accum1_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1accum1add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1accum1add {
+            interp1_accum1_add: u32,
+        }
+        let proxy = Interp1accum1add {
+            interp1_accum1_add: self.interp1_accum1_add(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control register for lane 0"]
@@ -560,6 +786,59 @@ impl Default for Interp1ctrlLane0 {
         Interp1ctrlLane0(0)
     }
 }
+impl core::fmt::Debug for Interp1ctrlLane0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1ctrlLane0")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .field("clamp", &self.clamp())
+            .field("overf0", &self.overf0())
+            .field("overf1", &self.overf1())
+            .field("overf", &self.overf())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1ctrlLane0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1ctrlLane0 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+            clamp: bool,
+            overf0: bool,
+            overf1: bool,
+            overf: bool,
+        }
+        let proxy = Interp1ctrlLane0 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+            clamp: self.clamp(),
+            overf0: self.overf0(),
+            overf1: self.overf1(),
+            overf: self.overf(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register for lane 1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -658,5 +937,46 @@ impl Default for Interp1ctrlLane1 {
     #[inline(always)]
     fn default() -> Interp1ctrlLane1 {
         Interp1ctrlLane1(0)
+    }
+}
+impl core::fmt::Debug for Interp1ctrlLane1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1ctrlLane1")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1ctrlLane1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1ctrlLane1 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+        }
+        let proxy = Interp1ctrlLane1 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/spi/regs.rs
+++ b/src/rp2040/spi/regs.rs
@@ -21,6 +21,26 @@ impl Default for Cpsr {
         Cpsr(0)
     }
 }
+impl core::fmt::Debug for Cpsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cpsr")
+            .field("cpsdvsr", &self.cpsdvsr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cpsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cpsr {
+            cpsdvsr: u8,
+        }
+        let proxy = Cpsr {
+            cpsdvsr: self.cpsdvsr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register 0, SSPCR0 on page 3-4"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +108,38 @@ impl Default for Cr0 {
         Cr0(0)
     }
 }
+impl core::fmt::Debug for Cr0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cr0")
+            .field("dss", &self.dss())
+            .field("frf", &self.frf())
+            .field("spo", &self.spo())
+            .field("sph", &self.sph())
+            .field("scr", &self.scr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cr0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cr0 {
+            dss: u8,
+            frf: u8,
+            spo: bool,
+            sph: bool,
+            scr: u8,
+        }
+        let proxy = Cr0 {
+            dss: self.dss(),
+            frf: self.frf(),
+            spo: self.spo(),
+            sph: self.sph(),
+            scr: self.scr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register 1, SSPCR1 on page 3-5"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -144,6 +196,35 @@ impl Default for Cr1 {
         Cr1(0)
     }
 }
+impl core::fmt::Debug for Cr1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cr1")
+            .field("lbm", &self.lbm())
+            .field("sse", &self.sse())
+            .field("ms", &self.ms())
+            .field("sod", &self.sod())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cr1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cr1 {
+            lbm: bool,
+            sse: bool,
+            ms: bool,
+            sod: bool,
+        }
+        let proxy = Cr1 {
+            lbm: self.lbm(),
+            sse: self.sse(),
+            ms: self.ms(),
+            sod: self.sod(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA control register, SSPDMACR on page 3-12"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -178,6 +259,29 @@ impl Default for Dmacr {
         Dmacr(0)
     }
 }
+impl core::fmt::Debug for Dmacr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dmacr")
+            .field("rxdmae", &self.rxdmae())
+            .field("txdmae", &self.txdmae())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dmacr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dmacr {
+            rxdmae: bool,
+            txdmae: bool,
+        }
+        let proxy = Dmacr {
+            rxdmae: self.rxdmae(),
+            txdmae: self.txdmae(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Data register, SSPDR on page 3-6"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -199,6 +303,22 @@ impl Default for Dr {
     #[inline(always)]
     fn default() -> Dr {
         Dr(0)
+    }
+}
+impl core::fmt::Debug for Dr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dr").field("data", &self.data()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dr {
+            data: u16,
+        }
+        let proxy = Dr { data: self.data() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt clear register, SSPICR on page 3-11"]
@@ -233,6 +353,29 @@ impl Default for Icr {
     #[inline(always)]
     fn default() -> Icr {
         Icr(0)
+    }
+}
+impl core::fmt::Debug for Icr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Icr")
+            .field("roric", &self.roric())
+            .field("rtic", &self.rtic())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Icr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Icr {
+            roric: bool,
+            rtic: bool,
+        }
+        let proxy = Icr {
+            roric: self.roric(),
+            rtic: self.rtic(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt mask set or clear register, SSPIMSC on page 3-9"]
@@ -291,6 +434,35 @@ impl Default for Imsc {
         Imsc(0)
     }
 }
+impl core::fmt::Debug for Imsc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Imsc")
+            .field("rorim", &self.rorim())
+            .field("rtim", &self.rtim())
+            .field("rxim", &self.rxim())
+            .field("txim", &self.txim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Imsc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Imsc {
+            rorim: bool,
+            rtim: bool,
+            rxim: bool,
+            txim: bool,
+        }
+        let proxy = Imsc {
+            rorim: self.rorim(),
+            rtim: self.rtim(),
+            rxim: self.rxim(),
+            txim: self.txim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Masked interrupt status register, SSPMIS on page 3-11"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -347,6 +519,35 @@ impl Default for Mis {
         Mis(0)
     }
 }
+impl core::fmt::Debug for Mis {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Mis")
+            .field("rormis", &self.rormis())
+            .field("rtmis", &self.rtmis())
+            .field("rxmis", &self.rxmis())
+            .field("txmis", &self.txmis())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Mis {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Mis {
+            rormis: bool,
+            rtmis: bool,
+            rxmis: bool,
+            txmis: bool,
+        }
+        let proxy = Mis {
+            rormis: self.rormis(),
+            rtmis: self.rtmis(),
+            rxmis: self.rxmis(),
+            txmis: self.txmis(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -368,6 +569,26 @@ impl Default for Pcellid0 {
     #[inline(always)]
     fn default() -> Pcellid0 {
         Pcellid0(0)
+    }
+}
+impl core::fmt::Debug for Pcellid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid0")
+            .field("ssppcellid0", &self.ssppcellid0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid0 {
+            ssppcellid0: u8,
+        }
+        let proxy = Pcellid0 {
+            ssppcellid0: self.ssppcellid0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
@@ -393,6 +614,26 @@ impl Default for Pcellid1 {
         Pcellid1(0)
     }
 }
+impl core::fmt::Debug for Pcellid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid1")
+            .field("ssppcellid1", &self.ssppcellid1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid1 {
+            ssppcellid1: u8,
+        }
+        let proxy = Pcellid1 {
+            ssppcellid1: self.ssppcellid1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -414,6 +655,26 @@ impl Default for Pcellid2 {
     #[inline(always)]
     fn default() -> Pcellid2 {
         Pcellid2(0)
+    }
+}
+impl core::fmt::Debug for Pcellid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid2")
+            .field("ssppcellid2", &self.ssppcellid2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid2 {
+            ssppcellid2: u8,
+        }
+        let proxy = Pcellid2 {
+            ssppcellid2: self.ssppcellid2(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
@@ -439,6 +700,26 @@ impl Default for Pcellid3 {
         Pcellid3(0)
     }
 }
+impl core::fmt::Debug for Pcellid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid3")
+            .field("ssppcellid3", &self.ssppcellid3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid3 {
+            ssppcellid3: u8,
+        }
+        let proxy = Pcellid3 {
+            ssppcellid3: self.ssppcellid3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -460,6 +741,26 @@ impl Default for Periphid0 {
     #[inline(always)]
     fn default() -> Periphid0 {
         Periphid0(0)
+    }
+}
+impl core::fmt::Debug for Periphid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid0")
+            .field("partnumber0", &self.partnumber0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid0 {
+            partnumber0: u8,
+        }
+        let proxy = Periphid0 {
+            partnumber0: self.partnumber0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
@@ -496,6 +797,29 @@ impl Default for Periphid1 {
         Periphid1(0)
     }
 }
+impl core::fmt::Debug for Periphid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid1")
+            .field("partnumber1", &self.partnumber1())
+            .field("designer0", &self.designer0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid1 {
+            partnumber1: u8,
+            designer0: u8,
+        }
+        let proxy = Periphid1 {
+            partnumber1: self.partnumber1(),
+            designer0: self.designer0(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -530,6 +854,29 @@ impl Default for Periphid2 {
         Periphid2(0)
     }
 }
+impl core::fmt::Debug for Periphid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid2")
+            .field("designer1", &self.designer1())
+            .field("revision", &self.revision())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid2 {
+            designer1: u8,
+            revision: u8,
+        }
+        let proxy = Periphid2 {
+            designer1: self.designer1(),
+            revision: self.revision(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -551,6 +898,26 @@ impl Default for Periphid3 {
     #[inline(always)]
     fn default() -> Periphid3 {
         Periphid3(0)
+    }
+}
+impl core::fmt::Debug for Periphid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid3")
+            .field("configuration", &self.configuration())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid3 {
+            configuration: u8,
+        }
+        let proxy = Periphid3 {
+            configuration: self.configuration(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Raw interrupt status register, SSPRIS on page 3-10"]
@@ -607,6 +974,35 @@ impl Default for Ris {
     #[inline(always)]
     fn default() -> Ris {
         Ris(0)
+    }
+}
+impl core::fmt::Debug for Ris {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ris")
+            .field("rorris", &self.rorris())
+            .field("rtris", &self.rtris())
+            .field("rxris", &self.rxris())
+            .field("txris", &self.txris())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ris {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ris {
+            rorris: bool,
+            rtris: bool,
+            rxris: bool,
+            txris: bool,
+        }
+        let proxy = Ris {
+            rorris: self.rorris(),
+            rtris: self.rtris(),
+            rxris: self.rxris(),
+            txris: self.txris(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Status register, SSPSR on page 3-7"]
@@ -674,5 +1070,37 @@ impl Default for Sr {
     #[inline(always)]
     fn default() -> Sr {
         Sr(0)
+    }
+}
+impl core::fmt::Debug for Sr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Sr")
+            .field("tfe", &self.tfe())
+            .field("tnf", &self.tnf())
+            .field("rne", &self.rne())
+            .field("rff", &self.rff())
+            .field("bsy", &self.bsy())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Sr {
+            tfe: bool,
+            tnf: bool,
+            rne: bool,
+            rff: bool,
+            bsy: bool,
+        }
+        let proxy = Sr {
+            tfe: self.tfe(),
+            tnf: self.tnf(),
+            rne: self.rne(),
+            rff: self.rff(),
+            bsy: self.bsy(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/ssi/regs.rs
+++ b/src/rp2040/ssi/regs.rs
@@ -21,6 +21,26 @@ impl Default for Baudr {
         Baudr(0)
     }
 }
+impl core::fmt::Debug for Baudr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Baudr")
+            .field("sckdv", &self.sckdv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Baudr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Baudr {
+            sckdv: u16,
+        }
+        let proxy = Baudr {
+            sckdv: self.sckdv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -154,6 +174,56 @@ impl Default for Ctrlr0 {
         Ctrlr0(0)
     }
 }
+impl core::fmt::Debug for Ctrlr0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrlr0")
+            .field("dfs", &self.dfs())
+            .field("frf", &self.frf())
+            .field("scph", &self.scph())
+            .field("scpol", &self.scpol())
+            .field("tmod", &self.tmod())
+            .field("slv_oe", &self.slv_oe())
+            .field("srl", &self.srl())
+            .field("cfs", &self.cfs())
+            .field("dfs_32", &self.dfs_32())
+            .field("spi_frf", &self.spi_frf())
+            .field("sste", &self.sste())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrlr0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrlr0 {
+            dfs: u8,
+            frf: u8,
+            scph: bool,
+            scpol: bool,
+            tmod: super::vals::Tmod,
+            slv_oe: bool,
+            srl: bool,
+            cfs: u8,
+            dfs_32: u8,
+            spi_frf: super::vals::SpiFrf,
+            sste: bool,
+        }
+        let proxy = Ctrlr0 {
+            dfs: self.dfs(),
+            frf: self.frf(),
+            scph: self.scph(),
+            scpol: self.scpol(),
+            tmod: self.tmod(),
+            slv_oe: self.slv_oe(),
+            srl: self.srl(),
+            cfs: self.cfs(),
+            dfs_32: self.dfs_32(),
+            spi_frf: self.spi_frf(),
+            sste: self.sste(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Master Control register 1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -175,6 +245,22 @@ impl Default for Ctrlr1 {
     #[inline(always)]
     fn default() -> Ctrlr1 {
         Ctrlr1(0)
+    }
+}
+impl core::fmt::Debug for Ctrlr1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrlr1").field("ndf", &self.ndf()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrlr1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrlr1 {
+            ndf: u16,
+        }
+        let proxy = Ctrlr1 { ndf: self.ndf() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "DMA control"]
@@ -211,6 +297,29 @@ impl Default for Dmacr {
         Dmacr(0)
     }
 }
+impl core::fmt::Debug for Dmacr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dmacr")
+            .field("rdmae", &self.rdmae())
+            .field("tdmae", &self.tdmae())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dmacr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dmacr {
+            rdmae: bool,
+            tdmae: bool,
+        }
+        let proxy = Dmacr {
+            rdmae: self.rdmae(),
+            tdmae: self.tdmae(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA RX data level"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -232,6 +341,26 @@ impl Default for Dmardlr {
     #[inline(always)]
     fn default() -> Dmardlr {
         Dmardlr(0)
+    }
+}
+impl core::fmt::Debug for Dmardlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dmardlr")
+            .field("dmardl", &self.dmardl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dmardlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dmardlr {
+            dmardl: u8,
+        }
+        let proxy = Dmardlr {
+            dmardl: self.dmardl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "DMA TX data level"]
@@ -257,6 +386,26 @@ impl Default for Dmatdlr {
         Dmatdlr(0)
     }
 }
+impl core::fmt::Debug for Dmatdlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dmatdlr")
+            .field("dmatdl", &self.dmatdl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dmatdlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dmatdlr {
+            dmatdl: u8,
+        }
+        let proxy = Dmatdlr {
+            dmatdl: self.dmatdl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt clear"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -278,6 +427,22 @@ impl Default for Icr {
     #[inline(always)]
     fn default() -> Icr {
         Icr(0)
+    }
+}
+impl core::fmt::Debug for Icr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Icr").field("icr", &self.icr()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Icr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Icr {
+            icr: bool,
+        }
+        let proxy = Icr { icr: self.icr() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt mask"]
@@ -358,6 +523,41 @@ impl Default for Imr {
         Imr(0)
     }
 }
+impl core::fmt::Debug for Imr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Imr")
+            .field("txeim", &self.txeim())
+            .field("txoim", &self.txoim())
+            .field("rxuim", &self.rxuim())
+            .field("rxoim", &self.rxoim())
+            .field("rxfim", &self.rxfim())
+            .field("mstim", &self.mstim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Imr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Imr {
+            txeim: bool,
+            txoim: bool,
+            rxuim: bool,
+            rxoim: bool,
+            rxfim: bool,
+            mstim: bool,
+        }
+        let proxy = Imr {
+            txeim: self.txeim(),
+            txoim: self.txoim(),
+            rxuim: self.rxuim(),
+            rxoim: self.rxoim(),
+            rxfim: self.rxfim(),
+            mstim: self.mstim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -436,6 +636,41 @@ impl Default for Isr {
         Isr(0)
     }
 }
+impl core::fmt::Debug for Isr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Isr")
+            .field("txeis", &self.txeis())
+            .field("txois", &self.txois())
+            .field("rxuis", &self.rxuis())
+            .field("rxois", &self.rxois())
+            .field("rxfis", &self.rxfis())
+            .field("mstis", &self.mstis())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Isr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Isr {
+            txeis: bool,
+            txois: bool,
+            rxuis: bool,
+            rxois: bool,
+            rxfis: bool,
+            mstis: bool,
+        }
+        let proxy = Isr {
+            txeis: self.txeis(),
+            txois: self.txois(),
+            rxuis: self.rxuis(),
+            rxois: self.rxois(),
+            rxfis: self.rxfis(),
+            mstis: self.mstis(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Multi-master interrupt clear"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -457,6 +692,26 @@ impl Default for Msticr {
     #[inline(always)]
     fn default() -> Msticr {
         Msticr(0)
+    }
+}
+impl core::fmt::Debug for Msticr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Msticr")
+            .field("msticr", &self.msticr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Msticr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Msticr {
+            msticr: bool,
+        }
+        let proxy = Msticr {
+            msticr: self.msticr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Microwire Control"]
@@ -502,6 +757,32 @@ impl Default for Mwcr {
     #[inline(always)]
     fn default() -> Mwcr {
         Mwcr(0)
+    }
+}
+impl core::fmt::Debug for Mwcr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Mwcr")
+            .field("mwmod", &self.mwmod())
+            .field("mdd", &self.mdd())
+            .field("mhs", &self.mhs())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Mwcr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Mwcr {
+            mwmod: bool,
+            mdd: bool,
+            mhs: bool,
+        }
+        let proxy = Mwcr {
+            mwmod: self.mwmod(),
+            mdd: self.mdd(),
+            mhs: self.mhs(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Raw interrupt status"]
@@ -582,6 +863,41 @@ impl Default for Risr {
         Risr(0)
     }
 }
+impl core::fmt::Debug for Risr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Risr")
+            .field("txeir", &self.txeir())
+            .field("txoir", &self.txoir())
+            .field("rxuir", &self.rxuir())
+            .field("rxoir", &self.rxoir())
+            .field("rxfir", &self.rxfir())
+            .field("mstir", &self.mstir())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Risr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Risr {
+            txeir: bool,
+            txoir: bool,
+            rxuir: bool,
+            rxoir: bool,
+            rxfir: bool,
+            mstir: bool,
+        }
+        let proxy = Risr {
+            txeir: self.txeir(),
+            txoir: self.txoir(),
+            rxuir: self.rxuir(),
+            rxoir: self.rxoir(),
+            rxfir: self.rxfir(),
+            mstir: self.mstir(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RX sample delay"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -603,6 +919,24 @@ impl Default for RxSampleDly {
     #[inline(always)]
     fn default() -> RxSampleDly {
         RxSampleDly(0)
+    }
+}
+impl core::fmt::Debug for RxSampleDly {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RxSampleDly")
+            .field("rsd", &self.rsd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RxSampleDly {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RxSampleDly {
+            rsd: u8,
+        }
+        let proxy = RxSampleDly { rsd: self.rsd() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "RX FIFO level"]
@@ -628,6 +962,26 @@ impl Default for Rxflr {
         Rxflr(0)
     }
 }
+impl core::fmt::Debug for Rxflr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rxflr")
+            .field("rxtfl", &self.rxtfl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rxflr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rxflr {
+            rxtfl: u8,
+        }
+        let proxy = Rxflr {
+            rxtfl: self.rxtfl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RX FIFO threshold level"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -649,6 +1003,22 @@ impl Default for Rxftlr {
     #[inline(always)]
     fn default() -> Rxftlr {
         Rxftlr(0)
+    }
+}
+impl core::fmt::Debug for Rxftlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rxftlr").field("rft", &self.rft()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rxftlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rxftlr {
+            rft: u8,
+        }
+        let proxy = Rxftlr { rft: self.rft() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "RX FIFO overflow interrupt clear"]
@@ -674,6 +1044,26 @@ impl Default for Rxoicr {
         Rxoicr(0)
     }
 }
+impl core::fmt::Debug for Rxoicr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rxoicr")
+            .field("rxoicr", &self.rxoicr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rxoicr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rxoicr {
+            rxoicr: bool,
+        }
+        let proxy = Rxoicr {
+            rxoicr: self.rxoicr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RX FIFO underflow interrupt clear"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -697,6 +1087,26 @@ impl Default for Rxuicr {
         Rxuicr(0)
     }
 }
+impl core::fmt::Debug for Rxuicr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rxuicr")
+            .field("rxuicr", &self.rxuicr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rxuicr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rxuicr {
+            rxuicr: bool,
+        }
+        let proxy = Rxuicr {
+            rxuicr: self.rxuicr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Slave enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -718,6 +1128,22 @@ impl Default for Ser {
     #[inline(always)]
     fn default() -> Ser {
         Ser(0)
+    }
+}
+impl core::fmt::Debug for Ser {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ser").field("ser", &self.ser()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ser {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ser {
+            ser: bool,
+        }
+        let proxy = Ser { ser: self.ser() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "SPI control"]
@@ -820,6 +1246,47 @@ impl Default for SpiCtrlr0 {
         SpiCtrlr0(0)
     }
 }
+impl core::fmt::Debug for SpiCtrlr0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SpiCtrlr0")
+            .field("trans_type", &self.trans_type())
+            .field("addr_l", &self.addr_l())
+            .field("inst_l", &self.inst_l())
+            .field("wait_cycles", &self.wait_cycles())
+            .field("spi_ddr_en", &self.spi_ddr_en())
+            .field("inst_ddr_en", &self.inst_ddr_en())
+            .field("spi_rxds_en", &self.spi_rxds_en())
+            .field("xip_cmd", &self.xip_cmd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SpiCtrlr0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SpiCtrlr0 {
+            trans_type: super::vals::TransType,
+            addr_l: u8,
+            inst_l: super::vals::InstL,
+            wait_cycles: u8,
+            spi_ddr_en: bool,
+            inst_ddr_en: bool,
+            spi_rxds_en: bool,
+            xip_cmd: u8,
+        }
+        let proxy = SpiCtrlr0 {
+            trans_type: self.trans_type(),
+            addr_l: self.addr_l(),
+            inst_l: self.inst_l(),
+            wait_cycles: self.wait_cycles(),
+            spi_ddr_en: self.spi_ddr_en(),
+            inst_ddr_en: self.inst_ddr_en(),
+            spi_rxds_en: self.spi_rxds_en(),
+            xip_cmd: self.xip_cmd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -909,6 +1376,44 @@ impl Default for Sr {
         Sr(0)
     }
 }
+impl core::fmt::Debug for Sr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Sr")
+            .field("busy", &self.busy())
+            .field("tfnf", &self.tfnf())
+            .field("tfe", &self.tfe())
+            .field("rfne", &self.rfne())
+            .field("rff", &self.rff())
+            .field("txe", &self.txe())
+            .field("dcol", &self.dcol())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Sr {
+            busy: bool,
+            tfnf: bool,
+            tfe: bool,
+            rfne: bool,
+            rff: bool,
+            txe: bool,
+            dcol: bool,
+        }
+        let proxy = Sr {
+            busy: self.busy(),
+            tfnf: self.tfnf(),
+            tfe: self.tfe(),
+            rfne: self.rfne(),
+            rff: self.rff(),
+            txe: self.txe(),
+            dcol: self.dcol(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "SSI Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -930,6 +1435,26 @@ impl Default for Ssienr {
     #[inline(always)]
     fn default() -> Ssienr {
         Ssienr(0)
+    }
+}
+impl core::fmt::Debug for Ssienr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ssienr")
+            .field("ssi_en", &self.ssi_en())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ssienr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ssienr {
+            ssi_en: bool,
+        }
+        let proxy = Ssienr {
+            ssi_en: self.ssi_en(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "TX drive edge"]
@@ -955,6 +1480,24 @@ impl Default for TxdDriveEdge {
         TxdDriveEdge(0)
     }
 }
+impl core::fmt::Debug for TxdDriveEdge {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TxdDriveEdge")
+            .field("tde", &self.tde())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TxdDriveEdge {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TxdDriveEdge {
+            tde: u8,
+        }
+        let proxy = TxdDriveEdge { tde: self.tde() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "TX FIFO level"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -976,6 +1519,26 @@ impl Default for Txflr {
     #[inline(always)]
     fn default() -> Txflr {
         Txflr(0)
+    }
+}
+impl core::fmt::Debug for Txflr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Txflr")
+            .field("tftfl", &self.tftfl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Txflr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Txflr {
+            tftfl: u8,
+        }
+        let proxy = Txflr {
+            tftfl: self.tftfl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "TX FIFO threshold level"]
@@ -1001,6 +1564,22 @@ impl Default for Txftlr {
         Txftlr(0)
     }
 }
+impl core::fmt::Debug for Txftlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Txftlr").field("tft", &self.tft()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Txftlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Txftlr {
+            tft: u8,
+        }
+        let proxy = Txftlr { tft: self.tft() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "TX FIFO overflow interrupt clear"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1022,5 +1601,25 @@ impl Default for Txoicr {
     #[inline(always)]
     fn default() -> Txoicr {
         Txoicr(0)
+    }
+}
+impl core::fmt::Debug for Txoicr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Txoicr")
+            .field("txoicr", &self.txoicr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Txoicr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Txoicr {
+            txoicr: bool,
+        }
+        let proxy = Txoicr {
+            txoicr: self.txoicr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/ssi/vals.rs
+++ b/src/rp2040/ssi/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum InstL {
     #[doc = "No instruction"]
     NONE = 0x0,
@@ -33,7 +34,8 @@ impl From<InstL> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SpiFrf {
     #[doc = "Standard 1-bit SPI frame format; 1 bit per SCK, full-duplex"]
     STD = 0x0,
@@ -66,7 +68,8 @@ impl From<SpiFrf> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Tmod {
     #[doc = "Both transmit and receive"]
     TX_AND_RX = 0x0,
@@ -100,7 +103,8 @@ impl From<Tmod> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TransType {
     #[doc = "Command and address both in standard SPI frame format"]
     _1C1A = 0x0,

--- a/src/rp2040/syscfg/regs.rs
+++ b/src/rp2040/syscfg/regs.rs
@@ -98,6 +98,47 @@ impl Default for Dbgforce {
         Dbgforce(0)
     }
 }
+impl core::fmt::Debug for Dbgforce {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dbgforce")
+            .field("proc0_swdo", &self.proc0_swdo())
+            .field("proc0_swdi", &self.proc0_swdi())
+            .field("proc0_swclk", &self.proc0_swclk())
+            .field("proc0_attach", &self.proc0_attach())
+            .field("proc1_swdo", &self.proc1_swdo())
+            .field("proc1_swdi", &self.proc1_swdi())
+            .field("proc1_swclk", &self.proc1_swclk())
+            .field("proc1_attach", &self.proc1_attach())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dbgforce {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dbgforce {
+            proc0_swdo: bool,
+            proc0_swdi: bool,
+            proc0_swclk: bool,
+            proc0_attach: bool,
+            proc1_swdo: bool,
+            proc1_swdi: bool,
+            proc1_swclk: bool,
+            proc1_attach: bool,
+        }
+        let proxy = Dbgforce {
+            proc0_swdo: self.proc0_swdo(),
+            proc0_swdi: self.proc0_swdi(),
+            proc0_swclk: self.proc0_swclk(),
+            proc0_attach: self.proc0_attach(),
+            proc1_swdo: self.proc1_swdo(),
+            proc1_swdi: self.proc1_swdi(),
+            proc1_swclk: self.proc1_swclk(),
+            proc1_attach: self.proc1_attach(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control power downs to memories. Set high to power down memories. Use with extreme caution"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -182,6 +223,47 @@ impl Default for Mempowerdown {
         Mempowerdown(0)
     }
 }
+impl core::fmt::Debug for Mempowerdown {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Mempowerdown")
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("usb", &self.usb())
+            .field("rom", &self.rom())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Mempowerdown {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Mempowerdown {
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            usb: bool,
+            rom: bool,
+        }
+        let proxy = Mempowerdown {
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            usb: self.usb(),
+            rom: self.rom(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Configuration for processors"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -238,6 +320,35 @@ impl Default for ProcConfig {
         ProcConfig(0)
     }
 }
+impl core::fmt::Debug for ProcConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ProcConfig")
+            .field("proc0_halted", &self.proc0_halted())
+            .field("proc1_halted", &self.proc1_halted())
+            .field("proc0_dap_instid", &self.proc0_dap_instid())
+            .field("proc1_dap_instid", &self.proc1_dap_instid())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProcConfig {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ProcConfig {
+            proc0_halted: bool,
+            proc1_halted: bool,
+            proc0_dap_instid: u8,
+            proc1_dap_instid: u8,
+        }
+        let proxy = ProcConfig {
+            proc0_halted: self.proc0_halted(),
+            proc1_halted: self.proc1_halted(),
+            proc0_dap_instid: self.proc0_dap_instid(),
+            proc1_dap_instid: self.proc1_dap_instid(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "For each bit, if 1, bypass the input synchronizer between that GPIO and the GPIO input register in the SIO. The input synchronizers should generally be unbypassed, to avoid injecting metastabilities into processors. If you're feeling brave, you can bypass to save two cycles of input latency. This register applies to GPIO 0...29."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -259,6 +370,26 @@ impl Default for ProcInSyncBypass {
         ProcInSyncBypass(0)
     }
 }
+impl core::fmt::Debug for ProcInSyncBypass {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ProcInSyncBypass")
+            .field("proc_in_sync_bypass", &self.proc_in_sync_bypass())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProcInSyncBypass {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ProcInSyncBypass {
+            proc_in_sync_bypass: u32,
+        }
+        let proxy = ProcInSyncBypass {
+            proc_in_sync_bypass: self.proc_in_sync_bypass(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "For each bit, if 1, bypass the input synchronizer between that GPIO and the GPIO input register in the SIO. The input synchronizers should generally be unbypassed, to avoid injecting metastabilities into processors. If you're feeling brave, you can bypass to save two cycles of input latency. This register applies to GPIO 30...35 (the QSPI IOs)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -278,5 +409,25 @@ impl Default for ProcInSyncBypassHi {
     #[inline(always)]
     fn default() -> ProcInSyncBypassHi {
         ProcInSyncBypassHi(0)
+    }
+}
+impl core::fmt::Debug for ProcInSyncBypassHi {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ProcInSyncBypassHi")
+            .field("proc_in_sync_bypass_hi", &self.proc_in_sync_bypass_hi())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProcInSyncBypassHi {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ProcInSyncBypassHi {
+            proc_in_sync_bypass_hi: u8,
+        }
+        let proxy = ProcInSyncBypassHi {
+            proc_in_sync_bypass_hi: self.proc_in_sync_bypass_hi(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/sysinfo/regs.rs
+++ b/src/rp2040/sysinfo/regs.rs
@@ -37,6 +37,32 @@ impl Default for ChipId {
         ChipId(0)
     }
 }
+impl core::fmt::Debug for ChipId {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChipId")
+            .field("manufacturer", &self.manufacturer())
+            .field("part", &self.part())
+            .field("revision", &self.revision())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChipId {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChipId {
+            manufacturer: u16,
+            part: u16,
+            revision: u8,
+        }
+        let proxy = ChipId {
+            manufacturer: self.manufacturer(),
+            part: self.part(),
+            revision: self.revision(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Platform register. Allows software to know what environment it is running in."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -65,5 +91,28 @@ impl Default for Platform {
     #[inline(always)]
     fn default() -> Platform {
         Platform(0)
+    }
+}
+impl core::fmt::Debug for Platform {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Platform")
+            .field("fpga", &self.fpga())
+            .field("asic", &self.asic())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Platform {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Platform {
+            fpga: bool,
+            asic: bool,
+        }
+        let proxy = Platform {
+            fpga: self.fpga(),
+            asic: self.asic(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/tbman/regs.rs
+++ b/src/rp2040/tbman/regs.rs
@@ -32,3 +32,26 @@ impl Default for Platform {
         Platform(0)
     }
 }
+impl core::fmt::Debug for Platform {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Platform")
+            .field("asic", &self.asic())
+            .field("fpga", &self.fpga())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Platform {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Platform {
+            asic: bool,
+            fpga: bool,
+        }
+        let proxy = Platform {
+            asic: self.asic(),
+            fpga: self.fpga(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}

--- a/src/rp2040/timer/regs.rs
+++ b/src/rp2040/timer/regs.rs
@@ -19,6 +19,26 @@ impl Default for Armed {
         Armed(0)
     }
 }
+impl core::fmt::Debug for Armed {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Armed")
+            .field("armed", &self.armed())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Armed {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Armed {
+            armed: u8,
+        }
+        let proxy = Armed {
+            armed: self.armed(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set bits high to enable pause when the corresponding debug ports are active"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,7 +73,30 @@ impl Default for Dbgpause {
         Dbgpause(0)
     }
 }
-#[doc = "Raw Interrupts"]
+impl core::fmt::Debug for Dbgpause {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dbgpause")
+            .field("dbg0", &self.dbg0())
+            .field("dbg1", &self.dbg1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dbgpause {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dbgpause {
+            dbg0: bool,
+            dbg1: bool,
+        }
+        let proxy = Dbgpause {
+            dbg0: self.dbg0(),
+            dbg1: self.dbg1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -78,6 +121,39 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field(
+                "alarm",
+                &[
+                    self.alarm(0usize),
+                    self.alarm(1usize),
+                    self.alarm(2usize),
+                    self.alarm(3usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            alarm: [bool; 4usize],
+        }
+        let proxy = Int {
+            alarm: [
+                self.alarm(0usize),
+                self.alarm(1usize),
+                self.alarm(2usize),
+                self.alarm(3usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set high to pause the timer"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -97,5 +173,25 @@ impl Default for Pause {
     #[inline(always)]
     fn default() -> Pause {
         Pause(0)
+    }
+}
+impl core::fmt::Debug for Pause {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pause")
+            .field("pause", &self.pause())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pause {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pause {
+            pause: bool,
+        }
+        let proxy = Pause {
+            pause: self.pause(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/uart/regs.rs
+++ b/src/rp2040/uart/regs.rs
@@ -142,6 +142,59 @@ impl Default for Uartcr {
         Uartcr(0)
     }
 }
+impl core::fmt::Debug for Uartcr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartcr")
+            .field("uarten", &self.uarten())
+            .field("siren", &self.siren())
+            .field("sirlp", &self.sirlp())
+            .field("lbe", &self.lbe())
+            .field("txe", &self.txe())
+            .field("rxe", &self.rxe())
+            .field("dtr", &self.dtr())
+            .field("rts", &self.rts())
+            .field("out1", &self.out1())
+            .field("out2", &self.out2())
+            .field("rtsen", &self.rtsen())
+            .field("ctsen", &self.ctsen())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartcr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartcr {
+            uarten: bool,
+            siren: bool,
+            sirlp: bool,
+            lbe: bool,
+            txe: bool,
+            rxe: bool,
+            dtr: bool,
+            rts: bool,
+            out1: bool,
+            out2: bool,
+            rtsen: bool,
+            ctsen: bool,
+        }
+        let proxy = Uartcr {
+            uarten: self.uarten(),
+            siren: self.siren(),
+            sirlp: self.sirlp(),
+            lbe: self.lbe(),
+            txe: self.txe(),
+            rxe: self.rxe(),
+            dtr: self.dtr(),
+            rts: self.rts(),
+            out1: self.out1(),
+            out2: self.out2(),
+            rtsen: self.rtsen(),
+            ctsen: self.ctsen(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA Control Register, UARTDMACR"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -185,6 +238,32 @@ impl Default for Uartdmacr {
     #[inline(always)]
     fn default() -> Uartdmacr {
         Uartdmacr(0)
+    }
+}
+impl core::fmt::Debug for Uartdmacr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartdmacr")
+            .field("rxdmae", &self.rxdmae())
+            .field("txdmae", &self.txdmae())
+            .field("dmaonerr", &self.dmaonerr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartdmacr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartdmacr {
+            rxdmae: bool,
+            txdmae: bool,
+            dmaonerr: bool,
+        }
+        let proxy = Uartdmacr {
+            rxdmae: self.rxdmae(),
+            txdmae: self.txdmae(),
+            dmaonerr: self.dmaonerr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Data Register, UARTDR"]
@@ -254,6 +333,38 @@ impl Default for Uartdr {
         Uartdr(0)
     }
 }
+impl core::fmt::Debug for Uartdr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartdr")
+            .field("data", &self.data())
+            .field("fe", &self.fe())
+            .field("pe", &self.pe())
+            .field("be", &self.be())
+            .field("oe", &self.oe())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartdr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartdr {
+            data: u8,
+            fe: bool,
+            pe: bool,
+            be: bool,
+            oe: bool,
+        }
+        let proxy = Uartdr {
+            data: self.data(),
+            fe: self.fe(),
+            pe: self.pe(),
+            be: self.be(),
+            oe: self.oe(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Fractional Baud Rate Register, UARTFBRD"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -275,6 +386,26 @@ impl Default for Uartfbrd {
     #[inline(always)]
     fn default() -> Uartfbrd {
         Uartfbrd(0)
+    }
+}
+impl core::fmt::Debug for Uartfbrd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartfbrd")
+            .field("baud_divfrac", &self.baud_divfrac())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartfbrd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartfbrd {
+            baud_divfrac: u8,
+        }
+        let proxy = Uartfbrd {
+            baud_divfrac: self.baud_divfrac(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Flag Register, UARTFR"]
@@ -388,6 +519,50 @@ impl Default for Uartfr {
         Uartfr(0)
     }
 }
+impl core::fmt::Debug for Uartfr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartfr")
+            .field("cts", &self.cts())
+            .field("dsr", &self.dsr())
+            .field("dcd", &self.dcd())
+            .field("busy", &self.busy())
+            .field("rxfe", &self.rxfe())
+            .field("txff", &self.txff())
+            .field("rxff", &self.rxff())
+            .field("txfe", &self.txfe())
+            .field("ri", &self.ri())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartfr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartfr {
+            cts: bool,
+            dsr: bool,
+            dcd: bool,
+            busy: bool,
+            rxfe: bool,
+            txff: bool,
+            rxff: bool,
+            txfe: bool,
+            ri: bool,
+        }
+        let proxy = Uartfr {
+            cts: self.cts(),
+            dsr: self.dsr(),
+            dcd: self.dcd(),
+            busy: self.busy(),
+            rxfe: self.rxfe(),
+            txff: self.txff(),
+            rxff: self.rxff(),
+            txfe: self.txfe(),
+            ri: self.ri(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Integer Baud Rate Register, UARTIBRD"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -409,6 +584,26 @@ impl Default for Uartibrd {
     #[inline(always)]
     fn default() -> Uartibrd {
         Uartibrd(0)
+    }
+}
+impl core::fmt::Debug for Uartibrd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartibrd")
+            .field("baud_divint", &self.baud_divint())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartibrd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartibrd {
+            baud_divint: u16,
+        }
+        let proxy = Uartibrd {
+            baud_divint: self.baud_divint(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Clear Register, UARTICR"]
@@ -544,6 +739,56 @@ impl Default for Uarticr {
         Uarticr(0)
     }
 }
+impl core::fmt::Debug for Uarticr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uarticr")
+            .field("rimic", &self.rimic())
+            .field("ctsmic", &self.ctsmic())
+            .field("dcdmic", &self.dcdmic())
+            .field("dsrmic", &self.dsrmic())
+            .field("rxic", &self.rxic())
+            .field("txic", &self.txic())
+            .field("rtic", &self.rtic())
+            .field("feic", &self.feic())
+            .field("peic", &self.peic())
+            .field("beic", &self.beic())
+            .field("oeic", &self.oeic())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uarticr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uarticr {
+            rimic: bool,
+            ctsmic: bool,
+            dcdmic: bool,
+            dsrmic: bool,
+            rxic: bool,
+            txic: bool,
+            rtic: bool,
+            feic: bool,
+            peic: bool,
+            beic: bool,
+            oeic: bool,
+        }
+        let proxy = Uarticr {
+            rimic: self.rimic(),
+            ctsmic: self.ctsmic(),
+            dcdmic: self.dcdmic(),
+            dsrmic: self.dsrmic(),
+            rxic: self.rxic(),
+            txic: self.txic(),
+            rtic: self.rtic(),
+            feic: self.feic(),
+            peic: self.peic(),
+            beic: self.beic(),
+            oeic: self.oeic(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt FIFO Level Select Register, UARTIFLS"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -578,6 +823,29 @@ impl Default for Uartifls {
         Uartifls(0)
     }
 }
+impl core::fmt::Debug for Uartifls {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartifls")
+            .field("txiflsel", &self.txiflsel())
+            .field("rxiflsel", &self.rxiflsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartifls {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartifls {
+            txiflsel: u8,
+            rxiflsel: u8,
+        }
+        let proxy = Uartifls {
+            txiflsel: self.txiflsel(),
+            rxiflsel: self.rxiflsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "IrDA Low-Power Counter Register, UARTILPR"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -599,6 +867,26 @@ impl Default for Uartilpr {
     #[inline(always)]
     fn default() -> Uartilpr {
         Uartilpr(0)
+    }
+}
+impl core::fmt::Debug for Uartilpr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartilpr")
+            .field("ilpdvsr", &self.ilpdvsr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartilpr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartilpr {
+            ilpdvsr: u8,
+        }
+        let proxy = Uartilpr {
+            ilpdvsr: self.ilpdvsr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Mask Set/Clear Register, UARTIMSC"]
@@ -734,6 +1022,56 @@ impl Default for Uartimsc {
         Uartimsc(0)
     }
 }
+impl core::fmt::Debug for Uartimsc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartimsc")
+            .field("rimim", &self.rimim())
+            .field("ctsmim", &self.ctsmim())
+            .field("dcdmim", &self.dcdmim())
+            .field("dsrmim", &self.dsrmim())
+            .field("rxim", &self.rxim())
+            .field("txim", &self.txim())
+            .field("rtim", &self.rtim())
+            .field("feim", &self.feim())
+            .field("peim", &self.peim())
+            .field("beim", &self.beim())
+            .field("oeim", &self.oeim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartimsc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartimsc {
+            rimim: bool,
+            ctsmim: bool,
+            dcdmim: bool,
+            dsrmim: bool,
+            rxim: bool,
+            txim: bool,
+            rtim: bool,
+            feim: bool,
+            peim: bool,
+            beim: bool,
+            oeim: bool,
+        }
+        let proxy = Uartimsc {
+            rimim: self.rimim(),
+            ctsmim: self.ctsmim(),
+            dcdmim: self.dcdmim(),
+            dsrmim: self.dsrmim(),
+            rxim: self.rxim(),
+            txim: self.txim(),
+            rtim: self.rtim(),
+            feim: self.feim(),
+            peim: self.peim(),
+            beim: self.beim(),
+            oeim: self.oeim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Line Control Register, UARTLCR_H"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -821,6 +1159,44 @@ impl Default for UartlcrH {
     #[inline(always)]
     fn default() -> UartlcrH {
         UartlcrH(0)
+    }
+}
+impl core::fmt::Debug for UartlcrH {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UartlcrH")
+            .field("brk", &self.brk())
+            .field("pen", &self.pen())
+            .field("eps", &self.eps())
+            .field("stp2", &self.stp2())
+            .field("fen", &self.fen())
+            .field("wlen", &self.wlen())
+            .field("sps", &self.sps())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UartlcrH {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UartlcrH {
+            brk: bool,
+            pen: bool,
+            eps: bool,
+            stp2: bool,
+            fen: bool,
+            wlen: u8,
+            sps: bool,
+        }
+        let proxy = UartlcrH {
+            brk: self.brk(),
+            pen: self.pen(),
+            eps: self.eps(),
+            stp2: self.stp2(),
+            fen: self.fen(),
+            wlen: self.wlen(),
+            sps: self.sps(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Masked Interrupt Status Register, UARTMIS"]
@@ -956,6 +1332,56 @@ impl Default for Uartmis {
         Uartmis(0)
     }
 }
+impl core::fmt::Debug for Uartmis {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartmis")
+            .field("rimmis", &self.rimmis())
+            .field("ctsmmis", &self.ctsmmis())
+            .field("dcdmmis", &self.dcdmmis())
+            .field("dsrmmis", &self.dsrmmis())
+            .field("rxmis", &self.rxmis())
+            .field("txmis", &self.txmis())
+            .field("rtmis", &self.rtmis())
+            .field("femis", &self.femis())
+            .field("pemis", &self.pemis())
+            .field("bemis", &self.bemis())
+            .field("oemis", &self.oemis())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartmis {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartmis {
+            rimmis: bool,
+            ctsmmis: bool,
+            dcdmmis: bool,
+            dsrmmis: bool,
+            rxmis: bool,
+            txmis: bool,
+            rtmis: bool,
+            femis: bool,
+            pemis: bool,
+            bemis: bool,
+            oemis: bool,
+        }
+        let proxy = Uartmis {
+            rimmis: self.rimmis(),
+            ctsmmis: self.ctsmmis(),
+            dcdmmis: self.dcdmmis(),
+            dsrmmis: self.dsrmmis(),
+            rxmis: self.rxmis(),
+            txmis: self.txmis(),
+            rtmis: self.rtmis(),
+            femis: self.femis(),
+            pemis: self.pemis(),
+            bemis: self.bemis(),
+            oemis: self.oemis(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPCellID0 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -977,6 +1403,26 @@ impl Default for Uartpcellid0 {
     #[inline(always)]
     fn default() -> Uartpcellid0 {
         Uartpcellid0(0)
+    }
+}
+impl core::fmt::Debug for Uartpcellid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid0")
+            .field("uartpcellid0", &self.uartpcellid0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid0 {
+            uartpcellid0: u8,
+        }
+        let proxy = Uartpcellid0 {
+            uartpcellid0: self.uartpcellid0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "UARTPCellID1 Register"]
@@ -1002,6 +1448,26 @@ impl Default for Uartpcellid1 {
         Uartpcellid1(0)
     }
 }
+impl core::fmt::Debug for Uartpcellid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid1")
+            .field("uartpcellid1", &self.uartpcellid1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid1 {
+            uartpcellid1: u8,
+        }
+        let proxy = Uartpcellid1 {
+            uartpcellid1: self.uartpcellid1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPCellID2 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1023,6 +1489,26 @@ impl Default for Uartpcellid2 {
     #[inline(always)]
     fn default() -> Uartpcellid2 {
         Uartpcellid2(0)
+    }
+}
+impl core::fmt::Debug for Uartpcellid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid2")
+            .field("uartpcellid2", &self.uartpcellid2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid2 {
+            uartpcellid2: u8,
+        }
+        let proxy = Uartpcellid2 {
+            uartpcellid2: self.uartpcellid2(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "UARTPCellID3 Register"]
@@ -1048,6 +1534,26 @@ impl Default for Uartpcellid3 {
         Uartpcellid3(0)
     }
 }
+impl core::fmt::Debug for Uartpcellid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid3")
+            .field("uartpcellid3", &self.uartpcellid3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid3 {
+            uartpcellid3: u8,
+        }
+        let proxy = Uartpcellid3 {
+            uartpcellid3: self.uartpcellid3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPeriphID0 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1069,6 +1575,26 @@ impl Default for Uartperiphid0 {
     #[inline(always)]
     fn default() -> Uartperiphid0 {
         Uartperiphid0(0)
+    }
+}
+impl core::fmt::Debug for Uartperiphid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid0")
+            .field("partnumber0", &self.partnumber0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid0 {
+            partnumber0: u8,
+        }
+        let proxy = Uartperiphid0 {
+            partnumber0: self.partnumber0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "UARTPeriphID1 Register"]
@@ -1105,6 +1631,29 @@ impl Default for Uartperiphid1 {
         Uartperiphid1(0)
     }
 }
+impl core::fmt::Debug for Uartperiphid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid1")
+            .field("partnumber1", &self.partnumber1())
+            .field("designer0", &self.designer0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid1 {
+            partnumber1: u8,
+            designer0: u8,
+        }
+        let proxy = Uartperiphid1 {
+            partnumber1: self.partnumber1(),
+            designer0: self.designer0(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPeriphID2 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1139,6 +1688,29 @@ impl Default for Uartperiphid2 {
         Uartperiphid2(0)
     }
 }
+impl core::fmt::Debug for Uartperiphid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid2")
+            .field("designer1", &self.designer1())
+            .field("revision", &self.revision())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid2 {
+            designer1: u8,
+            revision: u8,
+        }
+        let proxy = Uartperiphid2 {
+            designer1: self.designer1(),
+            revision: self.revision(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPeriphID3 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1160,6 +1732,26 @@ impl Default for Uartperiphid3 {
     #[inline(always)]
     fn default() -> Uartperiphid3 {
         Uartperiphid3(0)
+    }
+}
+impl core::fmt::Debug for Uartperiphid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid3")
+            .field("configuration", &self.configuration())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid3 {
+            configuration: u8,
+        }
+        let proxy = Uartperiphid3 {
+            configuration: self.configuration(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Raw Interrupt Status Register, UARTRIS"]
@@ -1295,6 +1887,56 @@ impl Default for Uartris {
         Uartris(0)
     }
 }
+impl core::fmt::Debug for Uartris {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartris")
+            .field("rirmis", &self.rirmis())
+            .field("ctsrmis", &self.ctsrmis())
+            .field("dcdrmis", &self.dcdrmis())
+            .field("dsrrmis", &self.dsrrmis())
+            .field("rxris", &self.rxris())
+            .field("txris", &self.txris())
+            .field("rtris", &self.rtris())
+            .field("feris", &self.feris())
+            .field("peris", &self.peris())
+            .field("beris", &self.beris())
+            .field("oeris", &self.oeris())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartris {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartris {
+            rirmis: bool,
+            ctsrmis: bool,
+            dcdrmis: bool,
+            dsrrmis: bool,
+            rxris: bool,
+            txris: bool,
+            rtris: bool,
+            feris: bool,
+            peris: bool,
+            beris: bool,
+            oeris: bool,
+        }
+        let proxy = Uartris {
+            rirmis: self.rirmis(),
+            ctsrmis: self.ctsrmis(),
+            dcdrmis: self.dcdrmis(),
+            dsrrmis: self.dsrrmis(),
+            rxris: self.rxris(),
+            txris: self.txris(),
+            rtris: self.rtris(),
+            feris: self.feris(),
+            peris: self.peris(),
+            beris: self.beris(),
+            oeris: self.oeris(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Receive Status Register/Error Clear Register, UARTRSR/UARTECR"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1349,5 +1991,34 @@ impl Default for Uartrsr {
     #[inline(always)]
     fn default() -> Uartrsr {
         Uartrsr(0)
+    }
+}
+impl core::fmt::Debug for Uartrsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartrsr")
+            .field("fe", &self.fe())
+            .field("pe", &self.pe())
+            .field("be", &self.be())
+            .field("oe", &self.oe())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartrsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartrsr {
+            fe: bool,
+            pe: bool,
+            be: bool,
+            oe: bool,
+        }
+        let proxy = Uartrsr {
+            fe: self.fe(),
+            pe: self.pe(),
+            be: self.be(),
+            oe: self.oe(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/usb/regs.rs
+++ b/src/rp2040/usb/regs.rs
@@ -32,7 +32,30 @@ impl Default for AddrEndp {
         AddrEndp(0)
     }
 }
-#[doc = "Interrupt endpoint 13. Only valid for HOST mode."]
+impl core::fmt::Debug for AddrEndp {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AddrEndp")
+            .field("address", &self.address())
+            .field("endpoint", &self.endpoint())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AddrEndp {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AddrEndp {
+            address: u8,
+            endpoint: u8,
+        }
+        let proxy = AddrEndp {
+            address: self.address(),
+            endpoint: self.endpoint(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt endpoint 1. Only valid for HOST mode."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct AddrEndpX(pub u32);
@@ -88,6 +111,35 @@ impl Default for AddrEndpX {
         AddrEndpX(0)
     }
 }
+impl core::fmt::Debug for AddrEndpX {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AddrEndpX")
+            .field("address", &self.address())
+            .field("endpoint", &self.endpoint())
+            .field("intep_dir", &self.intep_dir())
+            .field("intep_preamble", &self.intep_preamble())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AddrEndpX {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AddrEndpX {
+            address: u8,
+            endpoint: u8,
+            intep_dir: bool,
+            intep_preamble: bool,
+        }
+        let proxy = AddrEndpX {
+            address: self.address(),
+            endpoint: self.endpoint(),
+            intep_dir: self.intep_dir(),
+            intep_preamble: self.intep_preamble(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Which of the double buffers should be handled. Only valid if using an interrupt per buffer (i.e. not per 2 buffers). Not valid for host interrupt endpoint polling because they are only single buffered."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -124,6 +176,103 @@ impl Default for BuffCpuShouldHandle {
     #[inline(always)]
     fn default() -> BuffCpuShouldHandle {
         BuffCpuShouldHandle(0)
+    }
+}
+impl core::fmt::Debug for BuffCpuShouldHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BuffCpuShouldHandle")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BuffCpuShouldHandle {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BuffCpuShouldHandle {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = BuffCpuShouldHandle {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Buffer status register. A bit set here indicates that a buffer has completed on the endpoint (if the buffer interrupt is enabled). It is possible for 2 buffers to be completed, so clearing the buffer status bit may instantly re set it on the next clock cycle."]
@@ -164,6 +313,103 @@ impl Default for BuffStatus {
         BuffStatus(0)
     }
 }
+impl core::fmt::Debug for BuffStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BuffStatus")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BuffStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BuffStatus {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = BuffStatus {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Device only: Can be set to ignore the buffer control register for this endpoint in case you would like to revoke a buffer. A NAK will be sent for every access to the endpoint until this bit is cleared. A corresponding bit in `EP_ABORT_DONE` is set when it is safe to modify the buffer control register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -200,6 +446,103 @@ impl Default for EpAbort {
     #[inline(always)]
     fn default() -> EpAbort {
         EpAbort(0)
+    }
+}
+impl core::fmt::Debug for EpAbort {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpAbort")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpAbort {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpAbort {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = EpAbort {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Device only: Used in conjunction with `EP_ABORT`. Set once an endpoint is idle so the programmer knows it is safe to modify the buffer control register."]
@@ -240,6 +583,103 @@ impl Default for EpAbortDone {
         EpAbortDone(0)
     }
 }
+impl core::fmt::Debug for EpAbortDone {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpAbortDone")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpAbortDone {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpAbortDone {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = EpAbortDone {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Device: this bit must be set in conjunction with the `STALL` bit in the buffer control register to send a STALL on EP0. The device controller clears these bits when a SETUP packet is received because the USB spec requires that a STALL condition is cleared when a SETUP packet is received."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -268,6 +708,29 @@ impl Default for EpStallArm {
     #[inline(always)]
     fn default() -> EpStallArm {
         EpStallArm(0)
+    }
+}
+impl core::fmt::Debug for EpStallArm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpStallArm")
+            .field("ep0_in", &self.ep0_in())
+            .field("ep0_out", &self.ep0_out())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpStallArm {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpStallArm {
+            ep0_in: bool,
+            ep0_out: bool,
+        }
+        let proxy = EpStallArm {
+            ep0_in: self.ep0_in(),
+            ep0_out: self.ep0_out(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Device: bits are set when the `IRQ_ON_NAK` or `IRQ_ON_STALL` bits are set. For EP0 this comes from `SIE_CTRL`. For all other endpoints it comes from the endpoint control register."]
@@ -308,7 +771,104 @@ impl Default for EpStatusStallNak {
         EpStatusStallNak(0)
     }
 }
-#[doc = "Interrupt Force"]
+impl core::fmt::Debug for EpStatusStallNak {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpStatusStallNak")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpStatusStallNak {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpStatusStallNak {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = EpStatusStallNak {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -540,6 +1100,83 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field("host_conn_dis", &self.host_conn_dis())
+            .field("host_resume", &self.host_resume())
+            .field("host_sof", &self.host_sof())
+            .field("trans_complete", &self.trans_complete())
+            .field("buff_status", &self.buff_status())
+            .field("error_data_seq", &self.error_data_seq())
+            .field("error_rx_timeout", &self.error_rx_timeout())
+            .field("error_rx_overflow", &self.error_rx_overflow())
+            .field("error_bit_stuff", &self.error_bit_stuff())
+            .field("error_crc", &self.error_crc())
+            .field("stall", &self.stall())
+            .field("vbus_detect", &self.vbus_detect())
+            .field("bus_reset", &self.bus_reset())
+            .field("dev_conn_dis", &self.dev_conn_dis())
+            .field("dev_suspend", &self.dev_suspend())
+            .field("dev_resume_from_host", &self.dev_resume_from_host())
+            .field("setup_req", &self.setup_req())
+            .field("dev_sof", &self.dev_sof())
+            .field("abort_done", &self.abort_done())
+            .field("ep_stall_nak", &self.ep_stall_nak())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            host_conn_dis: bool,
+            host_resume: bool,
+            host_sof: bool,
+            trans_complete: bool,
+            buff_status: bool,
+            error_data_seq: bool,
+            error_rx_timeout: bool,
+            error_rx_overflow: bool,
+            error_bit_stuff: bool,
+            error_crc: bool,
+            stall: bool,
+            vbus_detect: bool,
+            bus_reset: bool,
+            dev_conn_dis: bool,
+            dev_suspend: bool,
+            dev_resume_from_host: bool,
+            setup_req: bool,
+            dev_sof: bool,
+            abort_done: bool,
+            ep_stall_nak: bool,
+        }
+        let proxy = Int {
+            host_conn_dis: self.host_conn_dis(),
+            host_resume: self.host_resume(),
+            host_sof: self.host_sof(),
+            trans_complete: self.trans_complete(),
+            buff_status: self.buff_status(),
+            error_data_seq: self.error_data_seq(),
+            error_rx_timeout: self.error_rx_timeout(),
+            error_rx_overflow: self.error_rx_overflow(),
+            error_bit_stuff: self.error_bit_stuff(),
+            error_crc: self.error_crc(),
+            stall: self.stall(),
+            vbus_detect: self.vbus_detect(),
+            bus_reset: self.bus_reset(),
+            dev_conn_dis: self.dev_conn_dis(),
+            dev_suspend: self.dev_suspend(),
+            dev_resume_from_host: self.dev_resume_from_host(),
+            setup_req: self.setup_req(),
+            dev_sof: self.dev_sof(),
+            abort_done: self.abort_done(),
+            ep_stall_nak: self.ep_stall_nak(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "interrupt endpoint control register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -561,6 +1198,26 @@ impl Default for IntEpCtrl {
     #[inline(always)]
     fn default() -> IntEpCtrl {
         IntEpCtrl(0)
+    }
+}
+impl core::fmt::Debug for IntEpCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IntEpCtrl")
+            .field("int_ep_active", &self.int_ep_active())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IntEpCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IntEpCtrl {
+            int_ep_active: u16,
+        }
+        let proxy = IntEpCtrl {
+            int_ep_active: self.int_ep_active(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Main control register"]
@@ -608,6 +1265,32 @@ impl Default for MainCtrl {
         MainCtrl(0)
     }
 }
+impl core::fmt::Debug for MainCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MainCtrl")
+            .field("controller_en", &self.controller_en())
+            .field("host_ndevice", &self.host_ndevice())
+            .field("sim_timing", &self.sim_timing())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for MainCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct MainCtrl {
+            controller_en: bool,
+            host_ndevice: bool,
+            sim_timing: bool,
+        }
+        let proxy = MainCtrl {
+            controller_en: self.controller_en(),
+            host_ndevice: self.host_ndevice(),
+            sim_timing: self.sim_timing(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Used by the host controller. Sets the wait time in microseconds before trying again if the device replies with a NAK."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -640,6 +1323,29 @@ impl Default for NakPoll {
     #[inline(always)]
     fn default() -> NakPoll {
         NakPoll(0)
+    }
+}
+impl core::fmt::Debug for NakPoll {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("NakPoll")
+            .field("delay_ls", &self.delay_ls())
+            .field("delay_fs", &self.delay_fs())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for NakPoll {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct NakPoll {
+            delay_ls: u16,
+            delay_fs: u16,
+        }
+        let proxy = NakPoll {
+            delay_ls: self.delay_ls(),
+            delay_fs: self.delay_fs(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "SIE control register"]
@@ -918,6 +1624,95 @@ impl Default for SieCtrl {
         SieCtrl(0)
     }
 }
+impl core::fmt::Debug for SieCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SieCtrl")
+            .field("start_trans", &self.start_trans())
+            .field("send_setup", &self.send_setup())
+            .field("send_data", &self.send_data())
+            .field("receive_data", &self.receive_data())
+            .field("stop_trans", &self.stop_trans())
+            .field("preamble_en", &self.preamble_en())
+            .field("sof_sync", &self.sof_sync())
+            .field("sof_en", &self.sof_en())
+            .field("keep_alive_en", &self.keep_alive_en())
+            .field("vbus_en", &self.vbus_en())
+            .field("resume", &self.resume())
+            .field("reset_bus", &self.reset_bus())
+            .field("pulldown_en", &self.pulldown_en())
+            .field("pullup_en", &self.pullup_en())
+            .field("rpu_opt", &self.rpu_opt())
+            .field("transceiver_pd", &self.transceiver_pd())
+            .field("direct_dm", &self.direct_dm())
+            .field("direct_dp", &self.direct_dp())
+            .field("direct_en", &self.direct_en())
+            .field("ep0_int_nak", &self.ep0_int_nak())
+            .field("ep0_int_2buf", &self.ep0_int_2buf())
+            .field("ep0_int_1buf", &self.ep0_int_1buf())
+            .field("ep0_double_buf", &self.ep0_double_buf())
+            .field("ep0_int_stall", &self.ep0_int_stall())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SieCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SieCtrl {
+            start_trans: bool,
+            send_setup: bool,
+            send_data: bool,
+            receive_data: bool,
+            stop_trans: bool,
+            preamble_en: bool,
+            sof_sync: bool,
+            sof_en: bool,
+            keep_alive_en: bool,
+            vbus_en: bool,
+            resume: bool,
+            reset_bus: bool,
+            pulldown_en: bool,
+            pullup_en: bool,
+            rpu_opt: bool,
+            transceiver_pd: bool,
+            direct_dm: bool,
+            direct_dp: bool,
+            direct_en: bool,
+            ep0_int_nak: bool,
+            ep0_int_2buf: bool,
+            ep0_int_1buf: bool,
+            ep0_double_buf: bool,
+            ep0_int_stall: bool,
+        }
+        let proxy = SieCtrl {
+            start_trans: self.start_trans(),
+            send_setup: self.send_setup(),
+            send_data: self.send_data(),
+            receive_data: self.receive_data(),
+            stop_trans: self.stop_trans(),
+            preamble_en: self.preamble_en(),
+            sof_sync: self.sof_sync(),
+            sof_en: self.sof_en(),
+            keep_alive_en: self.keep_alive_en(),
+            vbus_en: self.vbus_en(),
+            resume: self.resume(),
+            reset_bus: self.reset_bus(),
+            pulldown_en: self.pulldown_en(),
+            pullup_en: self.pullup_en(),
+            rpu_opt: self.rpu_opt(),
+            transceiver_pd: self.transceiver_pd(),
+            direct_dm: self.direct_dm(),
+            direct_dp: self.direct_dp(),
+            direct_en: self.direct_en(),
+            ep0_int_nak: self.ep0_int_nak(),
+            ep0_int_2buf: self.ep0_int_2buf(),
+            ep0_int_1buf: self.ep0_int_1buf(),
+            ep0_double_buf: self.ep0_double_buf(),
+            ep0_int_stall: self.ep0_int_stall(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "SIE status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1128,6 +1923,77 @@ impl Default for SieStatus {
         SieStatus(0)
     }
 }
+impl core::fmt::Debug for SieStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SieStatus")
+            .field("vbus_detected", &self.vbus_detected())
+            .field("line_state", &self.line_state())
+            .field("suspended", &self.suspended())
+            .field("speed", &self.speed())
+            .field("vbus_over_curr", &self.vbus_over_curr())
+            .field("resume", &self.resume())
+            .field("connected", &self.connected())
+            .field("setup_rec", &self.setup_rec())
+            .field("trans_complete", &self.trans_complete())
+            .field("bus_reset", &self.bus_reset())
+            .field("crc_error", &self.crc_error())
+            .field("bit_stuff_error", &self.bit_stuff_error())
+            .field("rx_overflow", &self.rx_overflow())
+            .field("rx_timeout", &self.rx_timeout())
+            .field("nak_rec", &self.nak_rec())
+            .field("stall_rec", &self.stall_rec())
+            .field("ack_rec", &self.ack_rec())
+            .field("data_seq_error", &self.data_seq_error())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SieStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SieStatus {
+            vbus_detected: bool,
+            line_state: u8,
+            suspended: bool,
+            speed: u8,
+            vbus_over_curr: bool,
+            resume: bool,
+            connected: bool,
+            setup_rec: bool,
+            trans_complete: bool,
+            bus_reset: bool,
+            crc_error: bool,
+            bit_stuff_error: bool,
+            rx_overflow: bool,
+            rx_timeout: bool,
+            nak_rec: bool,
+            stall_rec: bool,
+            ack_rec: bool,
+            data_seq_error: bool,
+        }
+        let proxy = SieStatus {
+            vbus_detected: self.vbus_detected(),
+            line_state: self.line_state(),
+            suspended: self.suspended(),
+            speed: self.speed(),
+            vbus_over_curr: self.vbus_over_curr(),
+            resume: self.resume(),
+            connected: self.connected(),
+            setup_rec: self.setup_rec(),
+            trans_complete: self.trans_complete(),
+            bus_reset: self.bus_reset(),
+            crc_error: self.crc_error(),
+            bit_stuff_error: self.bit_stuff_error(),
+            rx_overflow: self.rx_overflow(),
+            rx_timeout: self.rx_timeout(),
+            nak_rec: self.nak_rec(),
+            stall_rec: self.stall_rec(),
+            ack_rec: self.ack_rec(),
+            data_seq_error: self.data_seq_error(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Read the last SOF (Start of Frame) frame number seen. In device mode the last SOF received from the host. In host mode the last SOF sent by the host."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1149,6 +2015,26 @@ impl Default for SofRd {
         SofRd(0)
     }
 }
+impl core::fmt::Debug for SofRd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SofRd")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SofRd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SofRd {
+            count: u16,
+        }
+        let proxy = SofRd {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set the SOF (Start of Frame) frame number in the host controller. The SOF packet is sent every 1ms and the host will increment the frame number by 1 each time."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1168,6 +2054,26 @@ impl Default for SofWr {
     #[inline(always)]
     fn default() -> SofWr {
         SofWr(0)
+    }
+}
+impl core::fmt::Debug for SofWr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SofWr")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SofWr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SofWr {
+            count: u16,
+        }
+        let proxy = SofWr {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Where to connect the USB controller. Should be to_phy by default."]
@@ -1216,6 +2122,35 @@ impl Default for UsbMuxing {
     #[inline(always)]
     fn default() -> UsbMuxing {
         UsbMuxing(0)
+    }
+}
+impl core::fmt::Debug for UsbMuxing {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbMuxing")
+            .field("to_phy", &self.to_phy())
+            .field("to_extphy", &self.to_extphy())
+            .field("to_digital_pad", &self.to_digital_pad())
+            .field("softcon", &self.softcon())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbMuxing {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbMuxing {
+            to_phy: bool,
+            to_extphy: bool,
+            to_digital_pad: bool,
+            softcon: bool,
+        }
+        let proxy = UsbMuxing {
+            to_phy: self.to_phy(),
+            to_extphy: self.to_extphy(),
+            to_digital_pad: self.to_digital_pad(),
+            softcon: self.softcon(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Overrides for the power signals in the event that the VBUS signals are not hooked up to GPIO. Set the value of the override and then the override enable so switch over to the override value."]
@@ -1282,6 +2217,41 @@ impl Default for UsbPwr {
     #[inline(always)]
     fn default() -> UsbPwr {
         UsbPwr(0)
+    }
+}
+impl core::fmt::Debug for UsbPwr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbPwr")
+            .field("vbus_en", &self.vbus_en())
+            .field("vbus_en_override_en", &self.vbus_en_override_en())
+            .field("vbus_detect", &self.vbus_detect())
+            .field("vbus_detect_override_en", &self.vbus_detect_override_en())
+            .field("overcurr_detect", &self.overcurr_detect())
+            .field("overcurr_detect_en", &self.overcurr_detect_en())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbPwr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbPwr {
+            vbus_en: bool,
+            vbus_en_override_en: bool,
+            vbus_detect: bool,
+            vbus_detect_override_en: bool,
+            overcurr_detect: bool,
+            overcurr_detect_en: bool,
+        }
+        let proxy = UsbPwr {
+            vbus_en: self.vbus_en(),
+            vbus_en_override_en: self.vbus_en_override_en(),
+            vbus_detect: self.vbus_detect(),
+            vbus_detect_override_en: self.vbus_detect_override_en(),
+            overcurr_detect: self.overcurr_detect(),
+            overcurr_detect_en: self.overcurr_detect_en(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Note that most functions are driven directly from usb_fsls controller. This register allows more detailed control/status from the USB PHY. Useful for debug but not expected to be used in normal operation Use in conjunction with usbphy_direct_override register"]
@@ -1519,6 +2489,86 @@ impl Default for UsbphyDirect {
         UsbphyDirect(0)
     }
 }
+impl core::fmt::Debug for UsbphyDirect {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbphyDirect")
+            .field("dp_pullup_hisel", &self.dp_pullup_hisel())
+            .field("dp_pullup_en", &self.dp_pullup_en())
+            .field("dp_pulldn_en", &self.dp_pulldn_en())
+            .field("dm_pullup_hisel", &self.dm_pullup_hisel())
+            .field("dm_pullup_en", &self.dm_pullup_en())
+            .field("dm_pulldn_en", &self.dm_pulldn_en())
+            .field("tx_dp_oe", &self.tx_dp_oe())
+            .field("tx_dm_oe", &self.tx_dm_oe())
+            .field("tx_dp", &self.tx_dp())
+            .field("tx_dm", &self.tx_dm())
+            .field("rx_pd", &self.rx_pd())
+            .field("tx_pd", &self.tx_pd())
+            .field("tx_fsslew", &self.tx_fsslew())
+            .field("tx_diffmode", &self.tx_diffmode())
+            .field("rx_dd", &self.rx_dd())
+            .field("rx_dp", &self.rx_dp())
+            .field("rx_dm", &self.rx_dm())
+            .field("dp_ovcn", &self.dp_ovcn())
+            .field("dm_ovcn", &self.dm_ovcn())
+            .field("dp_ovv", &self.dp_ovv())
+            .field("dm_ovv", &self.dm_ovv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbphyDirect {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbphyDirect {
+            dp_pullup_hisel: bool,
+            dp_pullup_en: bool,
+            dp_pulldn_en: bool,
+            dm_pullup_hisel: bool,
+            dm_pullup_en: bool,
+            dm_pulldn_en: bool,
+            tx_dp_oe: bool,
+            tx_dm_oe: bool,
+            tx_dp: bool,
+            tx_dm: bool,
+            rx_pd: bool,
+            tx_pd: bool,
+            tx_fsslew: bool,
+            tx_diffmode: bool,
+            rx_dd: bool,
+            rx_dp: bool,
+            rx_dm: bool,
+            dp_ovcn: bool,
+            dm_ovcn: bool,
+            dp_ovv: bool,
+            dm_ovv: bool,
+        }
+        let proxy = UsbphyDirect {
+            dp_pullup_hisel: self.dp_pullup_hisel(),
+            dp_pullup_en: self.dp_pullup_en(),
+            dp_pulldn_en: self.dp_pulldn_en(),
+            dm_pullup_hisel: self.dm_pullup_hisel(),
+            dm_pullup_en: self.dm_pullup_en(),
+            dm_pulldn_en: self.dm_pulldn_en(),
+            tx_dp_oe: self.tx_dp_oe(),
+            tx_dm_oe: self.tx_dm_oe(),
+            tx_dp: self.tx_dp(),
+            tx_dm: self.tx_dm(),
+            rx_pd: self.rx_pd(),
+            tx_pd: self.tx_pd(),
+            tx_fsslew: self.tx_fsslew(),
+            tx_diffmode: self.tx_diffmode(),
+            rx_dd: self.rx_dd(),
+            rx_dp: self.rx_dp(),
+            rx_dm: self.rx_dm(),
+            dp_ovcn: self.dp_ovcn(),
+            dm_ovcn: self.dm_ovcn(),
+            dp_ovv: self.dp_ovv(),
+            dm_ovv: self.dm_ovv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct UsbphyDirectOverride(pub u32);
@@ -1670,6 +2720,71 @@ impl Default for UsbphyDirectOverride {
         UsbphyDirectOverride(0)
     }
 }
+impl core::fmt::Debug for UsbphyDirectOverride {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbphyDirectOverride")
+            .field(
+                "dp_pullup_hisel_override_en",
+                &self.dp_pullup_hisel_override_en(),
+            )
+            .field(
+                "dm_pullup_hisel_override_en",
+                &self.dm_pullup_hisel_override_en(),
+            )
+            .field("dp_pullup_en_override_en", &self.dp_pullup_en_override_en())
+            .field("dp_pulldn_en_override_en", &self.dp_pulldn_en_override_en())
+            .field("dm_pulldn_en_override_en", &self.dm_pulldn_en_override_en())
+            .field("tx_dp_oe_override_en", &self.tx_dp_oe_override_en())
+            .field("tx_dm_oe_override_en", &self.tx_dm_oe_override_en())
+            .field("tx_dp_override_en", &self.tx_dp_override_en())
+            .field("tx_dm_override_en", &self.tx_dm_override_en())
+            .field("rx_pd_override_en", &self.rx_pd_override_en())
+            .field("tx_pd_override_en", &self.tx_pd_override_en())
+            .field("tx_fsslew_override_en", &self.tx_fsslew_override_en())
+            .field("dm_pullup_override_en", &self.dm_pullup_override_en())
+            .field("tx_diffmode_override_en", &self.tx_diffmode_override_en())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbphyDirectOverride {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbphyDirectOverride {
+            dp_pullup_hisel_override_en: bool,
+            dm_pullup_hisel_override_en: bool,
+            dp_pullup_en_override_en: bool,
+            dp_pulldn_en_override_en: bool,
+            dm_pulldn_en_override_en: bool,
+            tx_dp_oe_override_en: bool,
+            tx_dm_oe_override_en: bool,
+            tx_dp_override_en: bool,
+            tx_dm_override_en: bool,
+            rx_pd_override_en: bool,
+            tx_pd_override_en: bool,
+            tx_fsslew_override_en: bool,
+            dm_pullup_override_en: bool,
+            tx_diffmode_override_en: bool,
+        }
+        let proxy = UsbphyDirectOverride {
+            dp_pullup_hisel_override_en: self.dp_pullup_hisel_override_en(),
+            dm_pullup_hisel_override_en: self.dm_pullup_hisel_override_en(),
+            dp_pullup_en_override_en: self.dp_pullup_en_override_en(),
+            dp_pulldn_en_override_en: self.dp_pulldn_en_override_en(),
+            dm_pulldn_en_override_en: self.dm_pulldn_en_override_en(),
+            tx_dp_oe_override_en: self.tx_dp_oe_override_en(),
+            tx_dm_oe_override_en: self.tx_dm_oe_override_en(),
+            tx_dp_override_en: self.tx_dp_override_en(),
+            tx_dm_override_en: self.tx_dm_override_en(),
+            rx_pd_override_en: self.rx_pd_override_en(),
+            tx_pd_override_en: self.tx_pd_override_en(),
+            tx_fsslew_override_en: self.tx_fsslew_override_en(),
+            dm_pullup_override_en: self.dm_pullup_override_en(),
+            tx_diffmode_override_en: self.tx_diffmode_override_en(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Note that most functions are driven directly from usb_fsls controller. This register allows more detailed control/status from the USB PHY. Useful for debug but not expected to be used in normal operation"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1702,5 +2817,28 @@ impl Default for UsbphyTrim {
     #[inline(always)]
     fn default() -> UsbphyTrim {
         UsbphyTrim(0)
+    }
+}
+impl core::fmt::Debug for UsbphyTrim {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbphyTrim")
+            .field("dp_pulldn_trim", &self.dp_pulldn_trim())
+            .field("dm_pulldn_trim", &self.dm_pulldn_trim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbphyTrim {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbphyTrim {
+            dp_pulldn_trim: u8,
+            dm_pulldn_trim: u8,
+        }
+        let proxy = UsbphyTrim {
+            dp_pulldn_trim: self.dp_pulldn_trim(),
+            dm_pulldn_trim: self.dm_pulldn_trim(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/usb_dpram/regs.rs
+++ b/src/rp2040/usb_dpram/regs.rs
@@ -123,6 +123,50 @@ impl Default for EpBufferControl {
         EpBufferControl(0)
     }
 }
+impl core::fmt::Debug for EpBufferControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpBufferControl")
+            .field("length", &[self.length(0usize), self.length(1usize)])
+            .field(
+                "available",
+                &[self.available(0usize), self.available(1usize)],
+            )
+            .field("stall", &self.stall())
+            .field("reset", &self.reset())
+            .field("pid", &[self.pid(0usize), self.pid(1usize)])
+            .field("last", &[self.last(0usize), self.last(1usize)])
+            .field("full", &[self.full(0usize), self.full(1usize)])
+            .field("double_buffer_iso_offset", &self.double_buffer_iso_offset())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpBufferControl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpBufferControl {
+            length: [u16; 2usize],
+            available: [bool; 2usize],
+            stall: bool,
+            reset: bool,
+            pid: [bool; 2usize],
+            last: [bool; 2usize],
+            full: [bool; 2usize],
+            double_buffer_iso_offset: super::vals::EpBufferControlDoubleBufferIsoOffset,
+        }
+        let proxy = EpBufferControl {
+            length: [self.length(0usize), self.length(1usize)],
+            available: [self.available(0usize), self.available(1usize)],
+            stall: self.stall(),
+            reset: self.reset(),
+            pid: [self.pid(0usize), self.pid(1usize)],
+            last: [self.last(0usize), self.last(1usize)],
+            full: [self.full(0usize), self.full(1usize)],
+            double_buffer_iso_offset: self.double_buffer_iso_offset(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct EpControl(pub u32);
@@ -220,6 +264,50 @@ impl Default for EpControl {
         EpControl(0)
     }
 }
+impl core::fmt::Debug for EpControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpControl")
+            .field("buffer_address", &self.buffer_address())
+            .field("interrupt_on_nak", &self.interrupt_on_nak())
+            .field("interrupt_on_stall", &self.interrupt_on_stall())
+            .field("endpoint_type", &self.endpoint_type())
+            .field(
+                "interrupt_per_double_buff",
+                &self.interrupt_per_double_buff(),
+            )
+            .field("interrupt_per_buff", &self.interrupt_per_buff())
+            .field("double_buffered", &self.double_buffered())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpControl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpControl {
+            buffer_address: u16,
+            interrupt_on_nak: bool,
+            interrupt_on_stall: bool,
+            endpoint_type: super::vals::EpControlEndpointType,
+            interrupt_per_double_buff: bool,
+            interrupt_per_buff: bool,
+            double_buffered: bool,
+            enable: bool,
+        }
+        let proxy = EpControl {
+            buffer_address: self.buffer_address(),
+            interrupt_on_nak: self.interrupt_on_nak(),
+            interrupt_on_stall: self.interrupt_on_stall(),
+            endpoint_type: self.endpoint_type(),
+            interrupt_per_double_buff: self.interrupt_per_double_buff(),
+            interrupt_per_buff: self.interrupt_per_buff(),
+            double_buffered: self.double_buffered(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Bytes 4-7 of the setup packet from the host."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -248,6 +336,29 @@ impl Default for SetupPacketHigh {
     #[inline(always)]
     fn default() -> SetupPacketHigh {
         SetupPacketHigh(0)
+    }
+}
+impl core::fmt::Debug for SetupPacketHigh {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetupPacketHigh")
+            .field("windex", &self.windex())
+            .field("wlength", &self.wlength())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetupPacketHigh {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetupPacketHigh {
+            windex: u16,
+            wlength: u16,
+        }
+        let proxy = SetupPacketHigh {
+            windex: self.windex(),
+            wlength: self.wlength(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Bytes 0-3 of the SETUP packet from the host."]
@@ -287,5 +398,31 @@ impl Default for SetupPacketLow {
     #[inline(always)]
     fn default() -> SetupPacketLow {
         SetupPacketLow(0)
+    }
+}
+impl core::fmt::Debug for SetupPacketLow {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetupPacketLow")
+            .field("bmrequesttype", &self.bmrequesttype())
+            .field("brequest", &self.brequest())
+            .field("wvalue", &self.wvalue())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetupPacketLow {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetupPacketLow {
+            bmrequesttype: u8,
+            brequest: u8,
+            wvalue: u16,
+        }
+        let proxy = SetupPacketLow {
+            bmrequesttype: self.bmrequesttype(),
+            brequest: self.brequest(),
+            wvalue: self.wvalue(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/usb_dpram/vals.rs
+++ b/src/rp2040/usb_dpram/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum EpBufferControlDoubleBufferIsoOffset {
     _128 = 0x0,
     _256 = 0x01,
@@ -29,7 +30,8 @@ impl From<EpBufferControlDoubleBufferIsoOffset> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum EpControlEndpointType {
     CONTROL = 0x0,
     ISOCHRONOUS = 0x01,

--- a/src/rp2040/vreg_and_chip_reset/regs.rs
+++ b/src/rp2040/vreg_and_chip_reset/regs.rs
@@ -32,6 +32,29 @@ impl Default for Bod {
         Bod(0)
     }
 }
+impl core::fmt::Debug for Bod {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Bod")
+            .field("en", &self.en())
+            .field("vsel", &self.vsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bod {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Bod {
+            en: bool,
+            vsel: u8,
+        }
+        let proxy = Bod {
+            en: self.en(),
+            vsel: self.vsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Chip reset control and status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +111,35 @@ impl Default for ChipReset {
         ChipReset(0)
     }
 }
+impl core::fmt::Debug for ChipReset {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChipReset")
+            .field("had_por", &self.had_por())
+            .field("had_run", &self.had_run())
+            .field("had_psm_restart", &self.had_psm_restart())
+            .field("psm_restart_flag", &self.psm_restart_flag())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChipReset {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChipReset {
+            had_por: bool,
+            had_run: bool,
+            had_psm_restart: bool,
+            psm_restart_flag: bool,
+        }
+        let proxy = ChipReset {
+            had_por: self.had_por(),
+            had_run: self.had_run(),
+            had_psm_restart: self.had_psm_restart(),
+            psm_restart_flag: self.psm_restart_flag(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Voltage regulator control and status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -142,5 +194,34 @@ impl Default for Vreg {
     #[inline(always)]
     fn default() -> Vreg {
         Vreg(0)
+    }
+}
+impl core::fmt::Debug for Vreg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Vreg")
+            .field("en", &self.en())
+            .field("hiz", &self.hiz())
+            .field("vsel", &self.vsel())
+            .field("rok", &self.rok())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Vreg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Vreg {
+            en: bool,
+            hiz: bool,
+            vsel: u8,
+            rok: bool,
+        }
+        let proxy = Vreg {
+            en: self.en(),
+            hiz: self.hiz(),
+            vsel: self.vsel(),
+            rok: self.rok(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/watchdog/regs.rs
+++ b/src/rp2040/watchdog/regs.rs
@@ -76,6 +76,41 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("time", &self.time())
+            .field("pause_jtag", &self.pause_jtag())
+            .field("pause_dbg0", &self.pause_dbg0())
+            .field("pause_dbg1", &self.pause_dbg1())
+            .field("enable", &self.enable())
+            .field("trigger", &self.trigger())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            time: u32,
+            pause_jtag: bool,
+            pause_dbg0: bool,
+            pause_dbg1: bool,
+            enable: bool,
+            trigger: bool,
+        }
+        let proxy = Ctrl {
+            time: self.time(),
+            pause_jtag: self.pause_jtag(),
+            pause_dbg0: self.pause_dbg0(),
+            pause_dbg1: self.pause_dbg1(),
+            enable: self.enable(),
+            trigger: self.trigger(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Load the watchdog timer. The maximum setting is 0xffffff which corresponds to 0xffffff / 2 ticks before triggering a watchdog reset (see errata RP2040-E1)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -95,6 +130,22 @@ impl Default for Load {
     #[inline(always)]
     fn default() -> Load {
         Load(0)
+    }
+}
+impl core::fmt::Debug for Load {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Load").field("load", &self.load()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Load {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Load {
+            load: u32,
+        }
+        let proxy = Load { load: self.load() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Logs the reason for the last reset. Both bits are zero for the case of a hardware reset."]
@@ -125,6 +176,29 @@ impl Default for Reason {
     #[inline(always)]
     fn default() -> Reason {
         Reason(0)
+    }
+}
+impl core::fmt::Debug for Reason {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Reason")
+            .field("timer", &self.timer())
+            .field("force", &self.force())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Reason {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Reason {
+            timer: bool,
+            force: bool,
+        }
+        let proxy = Reason {
+            timer: self.timer(),
+            force: self.force(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the tick generator"]
@@ -181,5 +255,34 @@ impl Default for Tick {
     #[inline(always)]
     fn default() -> Tick {
         Tick(0)
+    }
+}
+impl core::fmt::Debug for Tick {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Tick")
+            .field("cycles", &self.cycles())
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Tick {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Tick {
+            cycles: u16,
+            enable: bool,
+            running: bool,
+            count: u16,
+        }
+        let proxy = Tick {
+            cycles: self.cycles(),
+            enable: self.enable(),
+            running: self.running(),
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/xip_ctrl/regs.rs
+++ b/src/rp2040/xip_ctrl/regs.rs
@@ -43,6 +43,32 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("en", &self.en())
+            .field("err_badwrite", &self.err_badwrite())
+            .field("power_down", &self.power_down())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            en: bool,
+            err_badwrite: bool,
+            power_down: bool,
+        }
+        let proxy = Ctrl {
+            en: self.en(),
+            err_badwrite: self.err_badwrite(),
+            power_down: self.power_down(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Cache Flush control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -64,6 +90,26 @@ impl Default for Flush {
     #[inline(always)]
     fn default() -> Flush {
         Flush(0)
+    }
+}
+impl core::fmt::Debug for Flush {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Flush")
+            .field("flush", &self.flush())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Flush {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Flush {
+            flush: bool,
+        }
+        let proxy = Flush {
+            flush: self.flush(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Cache Status"]
@@ -111,6 +157,32 @@ impl Default for Stat {
         Stat(0)
     }
 }
+impl core::fmt::Debug for Stat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Stat")
+            .field("flush_ready", &self.flush_ready())
+            .field("fifo_empty", &self.fifo_empty())
+            .field("fifo_full", &self.fifo_full())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Stat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Stat {
+            flush_ready: bool,
+            fifo_empty: bool,
+            fifo_full: bool,
+        }
+        let proxy = Stat {
+            flush_ready: self.flush_ready(),
+            fifo_empty: self.fifo_empty(),
+            fifo_full: self.fifo_full(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO stream address"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -134,6 +206,26 @@ impl Default for StreamAddr {
         StreamAddr(0)
     }
 }
+impl core::fmt::Debug for StreamAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("StreamAddr")
+            .field("stream_addr", &self.stream_addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for StreamAddr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct StreamAddr {
+            stream_addr: u32,
+        }
+        let proxy = StreamAddr {
+            stream_addr: self.stream_addr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO stream control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -155,5 +247,25 @@ impl Default for StreamCtr {
     #[inline(always)]
     fn default() -> StreamCtr {
         StreamCtr(0)
+    }
+}
+impl core::fmt::Debug for StreamCtr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("StreamCtr")
+            .field("stream_ctr", &self.stream_ctr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for StreamCtr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct StreamCtr {
+            stream_ctr: u32,
+        }
+        let proxy = StreamCtr {
+            stream_ctr: self.stream_ctr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/xosc/regs.rs
+++ b/src/rp2040/xosc/regs.rs
@@ -19,6 +19,26 @@ impl Default for Count {
         Count(0)
     }
 }
+impl core::fmt::Debug for Count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Count")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Count {
+            count: u8,
+        }
+        let proxy = Count {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Crystal Oscillator Control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,6 +73,29 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("freq_range", &self.freq_range())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            freq_range: super::vals::CtrlFreqRange,
+            enable: super::vals::Enable,
+        }
+        let proxy = Ctrl {
+            freq_range: self.freq_range(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Crystal Oscillator pause control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -75,6 +118,26 @@ impl Default for Dormant {
     #[inline(always)]
     fn default() -> Dormant {
         Dormant(0)
+    }
+}
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dormant")
+            .field("dormant", &self.dormant())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dormant {
+            dormant: super::vals::Dormant,
+        }
+        let proxy = Dormant {
+            dormant: self.dormant(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the startup delay"]
@@ -109,6 +172,29 @@ impl Default for Startup {
     #[inline(always)]
     fn default() -> Startup {
         Startup(0)
+    }
+}
+impl core::fmt::Debug for Startup {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Startup")
+            .field("delay", &self.delay())
+            .field("x4", &self.x4())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Startup {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Startup {
+            delay: u16,
+            x4: bool,
+        }
+        let proxy = Startup {
+            delay: self.delay(),
+            x4: self.x4(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Crystal Oscillator Status"]
@@ -165,5 +251,34 @@ impl Default for Status {
     #[inline(always)]
     fn default() -> Status {
         Status(0)
+    }
+}
+impl core::fmt::Debug for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Status")
+            .field("freq_range", &self.freq_range())
+            .field("enabled", &self.enabled())
+            .field("badwrite", &self.badwrite())
+            .field("stable", &self.stable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Status {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Status {
+            freq_range: super::vals::StatusFreqRange,
+            enabled: bool,
+            badwrite: bool,
+            stable: bool,
+        }
+        let proxy = Status {
+            freq_range: self.freq_range(),
+            enabled: self.enabled(),
+            badwrite: self.badwrite(),
+            stable: self.stable(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp2040/xosc/vals.rs
+++ b/src/rp2040/xosc/vals.rs
@@ -15,6 +15,29 @@ impl CtrlFreqRange {
         self.0
     }
 }
+impl core::fmt::Debug for CtrlFreqRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0aa0 => f.write_str("_1_15MHZ"),
+            0x0aa1 => f.write_str("RESERVED_1"),
+            0x0aa2 => f.write_str("RESERVED_2"),
+            0x0aa3 => f.write_str("RESERVED_3"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CtrlFreqRange {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0aa0 => defmt::write!(f, "_1_15MHZ"),
+            0x0aa1 => defmt::write!(f, "RESERVED_1"),
+            0x0aa2 => defmt::write!(f, "RESERVED_2"),
+            0x0aa3 => defmt::write!(f, "RESERVED_3"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for CtrlFreqRange {
     #[inline(always)]
     fn from(val: u16) -> CtrlFreqRange {
@@ -40,6 +63,25 @@ impl Dormant {
     }
     pub const fn to_bits(self) -> u32 {
         self.0
+    }
+}
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x636f_6d61 => f.write_str("DORMANT"),
+            0x7761_6b65 => f.write_str("WAKE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x636f_6d61 => defmt::write!(f, "DORMANT"),
+            0x7761_6b65 => defmt::write!(f, "WAKE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u32> for Dormant {
@@ -69,6 +111,25 @@ impl Enable {
         self.0
     }
 }
+impl core::fmt::Debug for Enable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0d1e => f.write_str("DISABLE"),
+            0x0fab => f.write_str("ENABLE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enable {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0d1e => defmt::write!(f, "DISABLE"),
+            0x0fab => defmt::write!(f, "ENABLE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Enable {
     #[inline(always)]
     fn from(val: u16) -> Enable {
@@ -82,7 +143,8 @@ impl From<Enable> for u16 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StatusFreqRange {
     _1_15MHZ = 0x0,
     RESERVED_1 = 0x01,

--- a/src/rp235x/accessctrl/regs.rs
+++ b/src/rp235x/accessctrl/regs.rs
@@ -1,92 +1,92 @@
-#[doc = "Control whether debugger, DMA, core 0 and core 1 can access TIMER0, and at what security/privilege levels they can do so. Defaults to Secure access from any master. This register is writable only from a Secure, Privileged processor or debugger, with the exception of the NSU bit, which becomes Non-secure-Privileged-writable when the NSP bit is set."]
+#[doc = "Control whether debugger, DMA, core 0 and core 1 can access ADC0, and at what security/privilege levels they can do so. Defaults to Secure access from any master. This register is writable only from a Secure, Privileged processor or debugger, with the exception of the NSU bit, which becomes Non-secure-Privileged-writable when the NSP bit is set."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Access(pub u32);
 impl Access {
-    #[doc = "If 1, and NSP is also set, TIMER0 can be accessed from a Non-secure, Unprivileged context. This bit is writable from a Non-secure, Privileged context, if and only if the NSP bit is set."]
+    #[doc = "If 1, and NSP is also set, ADC0 can be accessed from a Non-secure, Unprivileged context. This bit is writable from a Non-secure, Privileged context, if and only if the NSP bit is set."]
     #[inline(always)]
     pub const fn nsu(&self) -> bool {
         let val = (self.0 >> 0usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, and NSP is also set, TIMER0 can be accessed from a Non-secure, Unprivileged context. This bit is writable from a Non-secure, Privileged context, if and only if the NSP bit is set."]
+    #[doc = "If 1, and NSP is also set, ADC0 can be accessed from a Non-secure, Unprivileged context. This bit is writable from a Non-secure, Privileged context, if and only if the NSP bit is set."]
     #[inline(always)]
     pub fn set_nsu(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 0usize)) | (((val as u32) & 0x01) << 0usize);
     }
-    #[doc = "If 1, TIMER0 can be accessed from a Non-secure, Privileged context."]
+    #[doc = "If 1, ADC0 can be accessed from a Non-secure, Privileged context."]
     #[inline(always)]
     pub const fn nsp(&self) -> bool {
         let val = (self.0 >> 1usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, TIMER0 can be accessed from a Non-secure, Privileged context."]
+    #[doc = "If 1, ADC0 can be accessed from a Non-secure, Privileged context."]
     #[inline(always)]
     pub fn set_nsp(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 1usize)) | (((val as u32) & 0x01) << 1usize);
     }
-    #[doc = "If 1, and SP is also set, TIMER0 can be accessed from a Secure, Unprivileged context."]
+    #[doc = "If 1, and SP is also set, ADC0 can be accessed from a Secure, Unprivileged context."]
     #[inline(always)]
     pub const fn su(&self) -> bool {
         let val = (self.0 >> 2usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, and SP is also set, TIMER0 can be accessed from a Secure, Unprivileged context."]
+    #[doc = "If 1, and SP is also set, ADC0 can be accessed from a Secure, Unprivileged context."]
     #[inline(always)]
     pub fn set_su(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
     }
-    #[doc = "If 1, TIMER0 can be accessed from a Secure, Privileged context."]
+    #[doc = "If 1, ADC0 can be accessed from a Secure, Privileged context."]
     #[inline(always)]
     pub const fn sp(&self) -> bool {
         let val = (self.0 >> 3usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, TIMER0 can be accessed from a Secure, Privileged context."]
+    #[doc = "If 1, ADC0 can be accessed from a Secure, Privileged context."]
     #[inline(always)]
     pub fn set_sp(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 3usize)) | (((val as u32) & 0x01) << 3usize);
     }
-    #[doc = "If 1, TIMER0 can be accessed by core 0, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by core 0, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub const fn core0(&self) -> bool {
         let val = (self.0 >> 4usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, TIMER0 can be accessed by core 0, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by core 0, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub fn set_core0(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
     }
-    #[doc = "If 1, TIMER0 can be accessed by core 1, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by core 1, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub const fn core1(&self) -> bool {
         let val = (self.0 >> 5usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, TIMER0 can be accessed by core 1, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by core 1, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub fn set_core1(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
     }
-    #[doc = "If 1, TIMER0 can be accessed by the DMA, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by the DMA, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub const fn dma(&self) -> bool {
         let val = (self.0 >> 6usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, TIMER0 can be accessed by the DMA, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by the DMA, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub fn set_dma(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 6usize)) | (((val as u32) & 0x01) << 6usize);
     }
-    #[doc = "If 1, TIMER0 can be accessed by the debugger, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by the debugger, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub const fn dbg(&self) -> bool {
         let val = (self.0 >> 7usize) & 0x01;
         val != 0
     }
-    #[doc = "If 1, TIMER0 can be accessed by the debugger, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
+    #[doc = "If 1, ADC0 can be accessed by the debugger, at security/privilege levels permitted by SP/NSP/SU/NSU in this register."]
     #[inline(always)]
     pub fn set_dbg(&mut self, val: bool) {
         self.0 = (self.0 & !(0x01 << 7usize)) | (((val as u32) & 0x01) << 7usize);
@@ -96,6 +96,47 @@ impl Default for Access {
     #[inline(always)]
     fn default() -> Access {
         Access(0)
+    }
+}
+impl core::fmt::Debug for Access {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Access")
+            .field("nsu", &self.nsu())
+            .field("nsp", &self.nsp())
+            .field("su", &self.su())
+            .field("sp", &self.sp())
+            .field("core0", &self.core0())
+            .field("core1", &self.core1())
+            .field("dma", &self.dma())
+            .field("dbg", &self.dbg())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Access {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Access {
+            nsu: bool,
+            nsp: bool,
+            su: bool,
+            sp: bool,
+            core0: bool,
+            core1: bool,
+            dma: bool,
+            dbg: bool,
+        }
+        let proxy = Access {
+            nsu: self.nsu(),
+            nsp: self.nsp(),
+            su: self.su(),
+            sp: self.sp(),
+            core0: self.core0(),
+            core1: self.core1(),
+            dma: self.dma(),
+            dbg: self.dbg(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Write 1 to reset all ACCESSCTRL configuration, except for the LOCK and FORCE_CORE_NS registers. This bit is used in the RP2350 bootrom to quickly restore ACCESSCTRL to a known state during the boot path. Note that, like all registers in ACCESSCTRL, this register is not writable when the writer's corresponding LOCK bit is set, therefore a master which has been locked out of ACCESSCTRL can not use the CFGRESET register to disturb its contents."]
@@ -119,6 +160,26 @@ impl Default for Cfgreset {
         Cfgreset(0)
     }
 }
+impl core::fmt::Debug for Cfgreset {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cfgreset")
+            .field("cfgreset", &self.cfgreset())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cfgreset {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cfgreset {
+            cfgreset: bool,
+        }
+        let proxy = Cfgreset {
+            cfgreset: self.cfgreset(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Force core 1's bus accesses to always be Non-secure, no matter the core's internal state. Useful for schemes where one core is designated as the Non-secure core, since some peripherals may filter individual registers internally based on security state but not on master ID."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -138,6 +199,26 @@ impl Default for ForceCoreNs {
     #[inline(always)]
     fn default() -> ForceCoreNs {
         ForceCoreNs(0)
+    }
+}
+impl core::fmt::Debug for ForceCoreNs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ForceCoreNs")
+            .field("core1", &self.core1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ForceCoreNs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ForceCoreNs {
+            core1: bool,
+        }
+        let proxy = ForceCoreNs {
+            core1: self.core1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control whether GPIO32..47 are accessible to Non-secure code, and whether QSPI and USB bitbang are accessible through the Non-secure SIO. Writable only by a Secure, Privileged processor or debugger."]
@@ -206,6 +287,41 @@ impl Default for GpioNsmask1 {
         GpioNsmask1(0)
     }
 }
+impl core::fmt::Debug for GpioNsmask1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioNsmask1")
+            .field("gpio", &self.gpio())
+            .field("usb_dp", &self.usb_dp())
+            .field("usb_dm", &self.usb_dm())
+            .field("qspi_sck", &self.qspi_sck())
+            .field("qspi_csn", &self.qspi_csn())
+            .field("qspi_sd", &self.qspi_sd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioNsmask1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioNsmask1 {
+            gpio: u16,
+            usb_dp: bool,
+            usb_dm: bool,
+            qspi_sck: bool,
+            qspi_csn: bool,
+            qspi_sd: u8,
+        }
+        let proxy = GpioNsmask1 {
+            gpio: self.gpio(),
+            usb_dp: self.usb_dp(),
+            usb_dm: self.usb_dm(),
+            qspi_sck: self.qspi_sck(),
+            qspi_csn: self.qspi_csn(),
+            qspi_sd: self.qspi_sd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Once a LOCK bit is written to 1, ACCESSCTRL silently ignores writes from that master. LOCK is writable only by a Secure, Privileged processor or debugger. LOCK bits are only writable when their value is zero. Once set, they can never be cleared, except by a full reset of ACCESSCTRL Setting the LOCK bit does not affect whether an access raises a bus error. Unprivileged writes, or writes from the DMA, will continue to raise bus errors. All other accesses will continue not to."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -252,5 +368,34 @@ impl Default for Lock {
     #[inline(always)]
     fn default() -> Lock {
         Lock(0)
+    }
+}
+impl core::fmt::Debug for Lock {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Lock")
+            .field("core0", &self.core0())
+            .field("core1", &self.core1())
+            .field("dma", &self.dma())
+            .field("debug", &self.debug())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Lock {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Lock {
+            core0: bool,
+            core1: bool,
+            dma: bool,
+            debug: bool,
+        }
+        let proxy = Lock {
+            core0: self.core0(),
+            core1: self.core1(),
+            dma: self.dma(),
+            debug: self.debug(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/adc/regs.rs
+++ b/src/rp235x/adc/regs.rs
@@ -109,6 +109,50 @@ impl Default for Cs {
         Cs(0)
     }
 }
+impl core::fmt::Debug for Cs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cs")
+            .field("en", &self.en())
+            .field("ts_en", &self.ts_en())
+            .field("start_once", &self.start_once())
+            .field("start_many", &self.start_many())
+            .field("ready", &self.ready())
+            .field("err", &self.err())
+            .field("err_sticky", &self.err_sticky())
+            .field("ainsel", &self.ainsel())
+            .field("rrobin", &self.rrobin())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cs {
+            en: bool,
+            ts_en: bool,
+            start_once: bool,
+            start_many: bool,
+            ready: bool,
+            err: bool,
+            err_sticky: bool,
+            ainsel: u8,
+            rrobin: u16,
+        }
+        let proxy = Cs {
+            en: self.en(),
+            ts_en: self.ts_en(),
+            start_once: self.start_once(),
+            start_many: self.start_many(),
+            ready: self.ready(),
+            err: self.err(),
+            err_sticky: self.err_sticky(),
+            ainsel: self.ainsel(),
+            rrobin: self.rrobin(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock divider. If non-zero, CS_START_MANY will start conversions at regular intervals rather than back-to-back. The divider is reset when either of these fields are written. Total period is 1 + INT + FRAC / 256"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -141,6 +185,29 @@ impl Default for Div {
     #[inline(always)]
     fn default() -> Div {
         Div(0)
+    }
+}
+impl core::fmt::Debug for Div {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Div")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Div {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Div {
+            frac: u8,
+            int: u16,
+        }
+        let proxy = Div {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "FIFO control and status"]
@@ -261,6 +328,53 @@ impl Default for Fcs {
         Fcs(0)
     }
 }
+impl core::fmt::Debug for Fcs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fcs")
+            .field("en", &self.en())
+            .field("shift", &self.shift())
+            .field("err", &self.err())
+            .field("dreq_en", &self.dreq_en())
+            .field("empty", &self.empty())
+            .field("full", &self.full())
+            .field("under", &self.under())
+            .field("over", &self.over())
+            .field("level", &self.level())
+            .field("thresh", &self.thresh())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fcs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fcs {
+            en: bool,
+            shift: bool,
+            err: bool,
+            dreq_en: bool,
+            empty: bool,
+            full: bool,
+            under: bool,
+            over: bool,
+            level: u8,
+            thresh: u8,
+        }
+        let proxy = Fcs {
+            en: self.en(),
+            shift: self.shift(),
+            err: self.err(),
+            dreq_en: self.dreq_en(),
+            empty: self.empty(),
+            full: self.full(),
+            under: self.under(),
+            over: self.over(),
+            level: self.level(),
+            thresh: self.thresh(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Conversion result FIFO"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -293,7 +407,30 @@ impl Default for Fifo {
         Fifo(0)
     }
 }
-#[doc = "Interrupt Force"]
+impl core::fmt::Debug for Fifo {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fifo")
+            .field("val", &self.val())
+            .field("err", &self.err())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fifo {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fifo {
+            val: u16,
+            err: bool,
+        }
+        let proxy = Fifo {
+            val: self.val(),
+            err: self.err(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -316,6 +453,22 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int").field("fifo", &self.fifo()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            fifo: bool,
+        }
+        let proxy = Int { fifo: self.fifo() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Result of most recent ADC conversion"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -335,5 +488,25 @@ impl Default for Result {
     #[inline(always)]
     fn default() -> Result {
         Result(0)
+    }
+}
+impl core::fmt::Debug for Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Result")
+            .field("result", &self.result())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Result {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Result {
+            result: u16,
+        }
+        let proxy = Result {
+            result: self.result(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/bootram/regs.rs
+++ b/src/rp235x/bootram/regs.rs
@@ -19,3 +19,23 @@ impl Default for BootlockStat {
         BootlockStat(0)
     }
 }
+impl core::fmt::Debug for BootlockStat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootlockStat")
+            .field("bootlock_stat", &self.bootlock_stat())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootlockStat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootlockStat {
+            bootlock_stat: u8,
+        }
+        let proxy = BootlockStat {
+            bootlock_stat: self.bootlock_stat(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}

--- a/src/rp235x/busctrl/regs.rs
+++ b/src/rp235x/busctrl/regs.rs
@@ -54,6 +54,35 @@ impl Default for BusPriority {
         BusPriority(0)
     }
 }
+impl core::fmt::Debug for BusPriority {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BusPriority")
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .field("dma_r", &self.dma_r())
+            .field("dma_w", &self.dma_w())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BusPriority {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BusPriority {
+            proc0: bool,
+            proc1: bool,
+            dma_r: bool,
+            dma_w: bool,
+        }
+        let proxy = BusPriority {
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+            dma_r: self.dma_r(),
+            dma_w: self.dma_w(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Bus priority acknowledge"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -77,18 +106,38 @@ impl Default for BusPriorityAck {
         BusPriorityAck(0)
     }
 }
-#[doc = "Bus fabric performance counter 3"]
+impl core::fmt::Debug for BusPriorityAck {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BusPriorityAck")
+            .field("bus_priority_ack", &self.bus_priority_ack())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BusPriorityAck {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BusPriorityAck {
+            bus_priority_ack: bool,
+        }
+        let proxy = BusPriorityAck {
+            bus_priority_ack: self.bus_priority_ack(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Bus fabric performance counter 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Perfctr(pub u32);
 impl Perfctr {
-    #[doc = "Busfabric saturating performance counter 3 Count some event signal from the busfabric arbiters, if PERFCTR_EN is set. Write any value to clear. Select an event to count using PERFSEL3"]
+    #[doc = "Busfabric saturating performance counter 0 Count some event signal from the busfabric arbiters, if PERFCTR_EN is set. Write any value to clear. Select an event to count using PERFSEL0"]
     #[inline(always)]
     pub const fn perfctr(&self) -> u32 {
         let val = (self.0 >> 0usize) & 0x00ff_ffff;
         val as u32
     }
-    #[doc = "Busfabric saturating performance counter 3 Count some event signal from the busfabric arbiters, if PERFCTR_EN is set. Write any value to clear. Select an event to count using PERFSEL3"]
+    #[doc = "Busfabric saturating performance counter 0 Count some event signal from the busfabric arbiters, if PERFCTR_EN is set. Write any value to clear. Select an event to count using PERFSEL0"]
     #[inline(always)]
     pub fn set_perfctr(&mut self, val: u32) {
         self.0 = (self.0 & !(0x00ff_ffff << 0usize)) | (((val as u32) & 0x00ff_ffff) << 0usize);
@@ -98,6 +147,26 @@ impl Default for Perfctr {
     #[inline(always)]
     fn default() -> Perfctr {
         Perfctr(0)
+    }
+}
+impl core::fmt::Debug for Perfctr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Perfctr")
+            .field("perfctr", &self.perfctr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Perfctr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Perfctr {
+            perfctr: u32,
+        }
+        let proxy = Perfctr {
+            perfctr: self.perfctr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Enable the performance counters. If 0, the performance counters do not increment. This can be used to precisely start/stop event sampling around the profiled section of code. The performance counters are initially disabled, to save energy."]
@@ -121,18 +190,38 @@ impl Default for PerfctrEn {
         PerfctrEn(0)
     }
 }
-#[doc = "Bus fabric performance event select for PERFCTR1"]
+impl core::fmt::Debug for PerfctrEn {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PerfctrEn")
+            .field("perfctr_en", &self.perfctr_en())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PerfctrEn {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PerfctrEn {
+            perfctr_en: bool,
+        }
+        let proxy = PerfctrEn {
+            perfctr_en: self.perfctr_en(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Bus fabric performance event select for PERFCTR0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Perfsel(pub u32);
 impl Perfsel {
-    #[doc = "Select an event for PERFCTR1. For each downstream port of the main crossbar, four events are available: ACCESS, an access took place; ACCESS_CONTESTED, an access took place that previously stalled due to contention from other masters; STALL_DOWNSTREAM, count cycles where any master stalled due to a stall on the downstream bus; STALL_UPSTREAM, count cycles where any master stalled for any reason, including contention from other masters."]
+    #[doc = "Select an event for PERFCTR0. For each downstream port of the main crossbar, four events are available: ACCESS, an access took place; ACCESS_CONTESTED, an access took place that previously stalled due to contention from other masters; STALL_DOWNSTREAM, count cycles where any master stalled due to a stall on the downstream bus; STALL_UPSTREAM, count cycles where any master stalled for any reason, including contention from other masters."]
     #[inline(always)]
     pub const fn perfsel(&self) -> super::vals::Perfsel {
         let val = (self.0 >> 0usize) & 0x7f;
         super::vals::Perfsel::from_bits(val as u8)
     }
-    #[doc = "Select an event for PERFCTR1. For each downstream port of the main crossbar, four events are available: ACCESS, an access took place; ACCESS_CONTESTED, an access took place that previously stalled due to contention from other masters; STALL_DOWNSTREAM, count cycles where any master stalled due to a stall on the downstream bus; STALL_UPSTREAM, count cycles where any master stalled for any reason, including contention from other masters."]
+    #[doc = "Select an event for PERFCTR0. For each downstream port of the main crossbar, four events are available: ACCESS, an access took place; ACCESS_CONTESTED, an access took place that previously stalled due to contention from other masters; STALL_DOWNSTREAM, count cycles where any master stalled due to a stall on the downstream bus; STALL_UPSTREAM, count cycles where any master stalled for any reason, including contention from other masters."]
     #[inline(always)]
     pub fn set_perfsel(&mut self, val: super::vals::Perfsel) {
         self.0 = (self.0 & !(0x7f << 0usize)) | (((val.to_bits() as u32) & 0x7f) << 0usize);
@@ -142,5 +231,25 @@ impl Default for Perfsel {
     #[inline(always)]
     fn default() -> Perfsel {
         Perfsel(0)
+    }
+}
+impl core::fmt::Debug for Perfsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Perfsel")
+            .field("perfsel", &self.perfsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Perfsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Perfsel {
+            perfsel: super::vals::Perfsel,
+        }
+        let proxy = Perfsel {
+            perfsel: self.perfsel(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/busctrl/vals.rs
+++ b/src/rp235x/busctrl/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Perfsel {
     SIOB_PROC1_STALL_UPSTREAM = 0x0,
     SIOB_PROC1_STALL_DOWNSTREAM = 0x01,

--- a/src/rp235x/clocks/regs.rs
+++ b/src/rp235x/clocks/regs.rs
@@ -76,6 +76,41 @@ impl Default for ClkAdcCtrl {
         ClkAdcCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkAdcCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkAdcCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkAdcCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkAdcCtrl {
+            auxsrc: super::vals::ClkAdcCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            phase: u8,
+            nudge: bool,
+            enabled: bool,
+        }
+        let proxy = ClkAdcCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+            enabled: self.enabled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkAdcDiv(pub u32);
@@ -96,6 +131,24 @@ impl Default for ClkAdcDiv {
     #[inline(always)]
     fn default() -> ClkAdcDiv {
         ClkAdcDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkAdcDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkAdcDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkAdcDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkAdcDiv {
+            int: u8,
+        }
+        let proxy = ClkAdcDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -121,6 +174,26 @@ impl Default for ClkAdcSelected {
         ClkAdcSelected(0)
     }
 }
+impl core::fmt::Debug for ClkAdcSelected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkAdcSelected")
+            .field("clk_adc_selected", &self.clk_adc_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkAdcSelected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkAdcSelected {
+            clk_adc_selected: bool,
+        }
+        let proxy = ClkAdcSelected {
+            clk_adc_selected: self.clk_adc_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Indicates which src is currently selected (one-hot)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -142,6 +215,26 @@ impl Default for ClkGpout0selected {
     #[inline(always)]
     fn default() -> ClkGpout0selected {
         ClkGpout0selected(0)
+    }
+}
+impl core::fmt::Debug for ClkGpout0selected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpout0selected")
+            .field("clk_gpout0_selected", &self.clk_gpout0_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpout0selected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpout0selected {
+            clk_gpout0_selected: bool,
+        }
+        let proxy = ClkGpout0selected {
+            clk_gpout0_selected: self.clk_gpout0_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -167,6 +260,26 @@ impl Default for ClkGpout1selected {
         ClkGpout1selected(0)
     }
 }
+impl core::fmt::Debug for ClkGpout1selected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpout1selected")
+            .field("clk_gpout1_selected", &self.clk_gpout1_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpout1selected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpout1selected {
+            clk_gpout1_selected: bool,
+        }
+        let proxy = ClkGpout1selected {
+            clk_gpout1_selected: self.clk_gpout1_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Indicates which src is currently selected (one-hot)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -190,6 +303,26 @@ impl Default for ClkGpout2selected {
         ClkGpout2selected(0)
     }
 }
+impl core::fmt::Debug for ClkGpout2selected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpout2selected")
+            .field("clk_gpout2_selected", &self.clk_gpout2_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpout2selected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpout2selected {
+            clk_gpout2_selected: bool,
+        }
+        let proxy = ClkGpout2selected {
+            clk_gpout2_selected: self.clk_gpout2_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Indicates which src is currently selected (one-hot)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -211,6 +344,26 @@ impl Default for ClkGpout3selected {
     #[inline(always)]
     fn default() -> ClkGpout3selected {
         ClkGpout3selected(0)
+    }
+}
+impl core::fmt::Debug for ClkGpout3selected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpout3selected")
+            .field("clk_gpout3_selected", &self.clk_gpout3_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpout3selected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpout3selected {
+            clk_gpout3_selected: bool,
+        }
+        let proxy = ClkGpout3selected {
+            clk_gpout3_selected: self.clk_gpout3_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -302,6 +455,44 @@ impl Default for ClkGpoutCtrl {
         ClkGpoutCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkGpoutCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpoutCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("dc50", &self.dc50())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpoutCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpoutCtrl {
+            auxsrc: super::vals::ClkGpoutCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            dc50: bool,
+            phase: u8,
+            nudge: bool,
+            enabled: bool,
+        }
+        let proxy = ClkGpoutCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            dc50: self.dc50(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+            enabled: self.enabled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkGpoutDiv(pub u32);
@@ -333,6 +524,29 @@ impl Default for ClkGpoutDiv {
     #[inline(always)]
     fn default() -> ClkGpoutDiv {
         ClkGpoutDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkGpoutDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkGpoutDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkGpoutDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkGpoutDiv {
+            frac: u16,
+            int: u16,
+        }
+        let proxy = ClkGpoutDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -413,6 +627,41 @@ impl Default for ClkHstxCtrl {
         ClkHstxCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkHstxCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkHstxCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkHstxCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkHstxCtrl {
+            auxsrc: super::vals::ClkHstxCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            phase: u8,
+            nudge: bool,
+            enabled: bool,
+        }
+        let proxy = ClkHstxCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+            enabled: self.enabled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkHstxDiv(pub u32);
@@ -433,6 +682,24 @@ impl Default for ClkHstxDiv {
     #[inline(always)]
     fn default() -> ClkHstxDiv {
         ClkHstxDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkHstxDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkHstxDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkHstxDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkHstxDiv {
+            int: u8,
+        }
+        let proxy = ClkHstxDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -456,6 +723,26 @@ impl Default for ClkHstxSelected {
     #[inline(always)]
     fn default() -> ClkHstxSelected {
         ClkHstxSelected(0)
+    }
+}
+impl core::fmt::Debug for ClkHstxSelected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkHstxSelected")
+            .field("clk_hstx_selected", &self.clk_hstx_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkHstxSelected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkHstxSelected {
+            clk_hstx_selected: bool,
+        }
+        let proxy = ClkHstxSelected {
+            clk_hstx_selected: self.clk_hstx_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -514,6 +801,35 @@ impl Default for ClkPeriCtrl {
         ClkPeriCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkPeriCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkPeriCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkPeriCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkPeriCtrl {
+            auxsrc: super::vals::ClkPeriCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            enabled: bool,
+        }
+        let proxy = ClkPeriCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            enabled: self.enabled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkPeriDiv(pub u32);
@@ -534,6 +850,24 @@ impl Default for ClkPeriDiv {
     #[inline(always)]
     fn default() -> ClkPeriDiv {
         ClkPeriDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkPeriDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkPeriDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkPeriDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkPeriDiv {
+            int: u8,
+        }
+        let proxy = ClkPeriDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -557,6 +891,26 @@ impl Default for ClkPeriSelected {
     #[inline(always)]
     fn default() -> ClkPeriSelected {
         ClkPeriSelected(0)
+    }
+}
+impl core::fmt::Debug for ClkPeriSelected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkPeriSelected")
+            .field("clk_peri_selected", &self.clk_peri_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkPeriSelected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkPeriSelected {
+            clk_peri_selected: bool,
+        }
+        let proxy = ClkPeriSelected {
+            clk_peri_selected: self.clk_peri_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -593,6 +947,29 @@ impl Default for ClkRefCtrl {
         ClkRefCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkRefCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRefCtrl")
+            .field("src", &self.src())
+            .field("auxsrc", &self.auxsrc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRefCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRefCtrl {
+            src: super::vals::ClkRefCtrlSrc,
+            auxsrc: super::vals::ClkRefCtrlAuxsrc,
+        }
+        let proxy = ClkRefCtrl {
+            src: self.src(),
+            auxsrc: self.auxsrc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkRefDiv(pub u32);
@@ -613,6 +990,24 @@ impl Default for ClkRefDiv {
     #[inline(always)]
     fn default() -> ClkRefDiv {
         ClkRefDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkRefDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRefDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRefDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRefDiv {
+            int: u8,
+        }
+        let proxy = ClkRefDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -636,6 +1031,26 @@ impl Default for ClkRefSelected {
     #[inline(always)]
     fn default() -> ClkRefSelected {
         ClkRefSelected(0)
+    }
+}
+impl core::fmt::Debug for ClkRefSelected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkRefSelected")
+            .field("clk_ref_selected", &self.clk_ref_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkRefSelected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkRefSelected {
+            clk_ref_selected: u8,
+        }
+        let proxy = ClkRefSelected {
+            clk_ref_selected: self.clk_ref_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -672,6 +1087,29 @@ impl Default for ClkSysCtrl {
         ClkSysCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkSysCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysCtrl")
+            .field("src", &self.src())
+            .field("auxsrc", &self.auxsrc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysCtrl {
+            src: super::vals::ClkSysCtrlSrc,
+            auxsrc: super::vals::ClkSysCtrlAuxsrc,
+        }
+        let proxy = ClkSysCtrl {
+            src: self.src(),
+            auxsrc: self.auxsrc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkSysDiv(pub u32);
@@ -703,6 +1141,29 @@ impl Default for ClkSysDiv {
     #[inline(always)]
     fn default() -> ClkSysDiv {
         ClkSysDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkSysDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysDiv {
+            frac: u16,
+            int: u16,
+        }
+        let proxy = ClkSysDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -760,6 +1221,35 @@ impl Default for ClkSysResusCtrl {
         ClkSysResusCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkSysResusCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysResusCtrl")
+            .field("timeout", &self.timeout())
+            .field("enable", &self.enable())
+            .field("frce", &self.frce())
+            .field("clear", &self.clear())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysResusCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysResusCtrl {
+            timeout: u8,
+            enable: bool,
+            frce: bool,
+            clear: bool,
+        }
+        let proxy = ClkSysResusCtrl {
+            timeout: self.timeout(),
+            enable: self.enable(),
+            frce: self.frce(),
+            clear: self.clear(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkSysResusStatus(pub u32);
@@ -780,6 +1270,26 @@ impl Default for ClkSysResusStatus {
     #[inline(always)]
     fn default() -> ClkSysResusStatus {
         ClkSysResusStatus(0)
+    }
+}
+impl core::fmt::Debug for ClkSysResusStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysResusStatus")
+            .field("resussed", &self.resussed())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysResusStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysResusStatus {
+            resussed: bool,
+        }
+        let proxy = ClkSysResusStatus {
+            resussed: self.resussed(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -803,6 +1313,26 @@ impl Default for ClkSysSelected {
     #[inline(always)]
     fn default() -> ClkSysSelected {
         ClkSysSelected(0)
+    }
+}
+impl core::fmt::Debug for ClkSysSelected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkSysSelected")
+            .field("clk_sys_selected", &self.clk_sys_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkSysSelected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkSysSelected {
+            clk_sys_selected: u8,
+        }
+        let proxy = ClkSysSelected {
+            clk_sys_selected: self.clk_sys_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clock control, can be changed on-the-fly (except for auxsrc)"]
@@ -883,6 +1413,41 @@ impl Default for ClkUsbCtrl {
         ClkUsbCtrl(0)
     }
 }
+impl core::fmt::Debug for ClkUsbCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkUsbCtrl")
+            .field("auxsrc", &self.auxsrc())
+            .field("kill", &self.kill())
+            .field("enable", &self.enable())
+            .field("phase", &self.phase())
+            .field("nudge", &self.nudge())
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkUsbCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkUsbCtrl {
+            auxsrc: super::vals::ClkUsbCtrlAuxsrc,
+            kill: bool,
+            enable: bool,
+            phase: u8,
+            nudge: bool,
+            enabled: bool,
+        }
+        let proxy = ClkUsbCtrl {
+            auxsrc: self.auxsrc(),
+            kill: self.kill(),
+            enable: self.enable(),
+            phase: self.phase(),
+            nudge: self.nudge(),
+            enabled: self.enabled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ClkUsbDiv(pub u32);
@@ -903,6 +1468,24 @@ impl Default for ClkUsbDiv {
     #[inline(always)]
     fn default() -> ClkUsbDiv {
         ClkUsbDiv(0)
+    }
+}
+impl core::fmt::Debug for ClkUsbDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkUsbDiv")
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkUsbDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkUsbDiv {
+            int: u8,
+        }
+        let proxy = ClkUsbDiv { int: self.int() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Indicates which src is currently selected (one-hot)"]
@@ -928,6 +1511,26 @@ impl Default for ClkUsbSelected {
         ClkUsbSelected(0)
     }
 }
+impl core::fmt::Debug for ClkUsbSelected {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ClkUsbSelected")
+            .field("clk_usb_selected", &self.clk_usb_selected())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ClkUsbSelected {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ClkUsbSelected {
+            clk_usb_selected: bool,
+        }
+        let proxy = ClkUsbSelected {
+            clk_usb_selected: self.clk_usb_selected(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct DftclkLposcCtrl(pub u32);
@@ -946,6 +1549,24 @@ impl Default for DftclkLposcCtrl {
     #[inline(always)]
     fn default() -> DftclkLposcCtrl {
         DftclkLposcCtrl(0)
+    }
+}
+impl core::fmt::Debug for DftclkLposcCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DftclkLposcCtrl")
+            .field("src", &self.src())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DftclkLposcCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DftclkLposcCtrl {
+            src: super::vals::DftclkLposcCtrlSrc,
+        }
+        let proxy = DftclkLposcCtrl { src: self.src() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -968,6 +1589,24 @@ impl Default for DftclkRoscCtrl {
         DftclkRoscCtrl(0)
     }
 }
+impl core::fmt::Debug for DftclkRoscCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DftclkRoscCtrl")
+            .field("src", &self.src())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DftclkRoscCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DftclkRoscCtrl {
+            src: super::vals::DftclkRoscCtrlSrc,
+        }
+        let proxy = DftclkRoscCtrl { src: self.src() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct DftclkXoscCtrl(pub u32);
@@ -986,6 +1625,24 @@ impl Default for DftclkXoscCtrl {
     #[inline(always)]
     fn default() -> DftclkXoscCtrl {
         DftclkXoscCtrl(0)
+    }
+}
+impl core::fmt::Debug for DftclkXoscCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DftclkXoscCtrl")
+            .field("src", &self.src())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DftclkXoscCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DftclkXoscCtrl {
+            src: super::vals::DftclkXoscCtrlSrc,
+        }
+        let proxy = DftclkXoscCtrl { src: self.src() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "indicates the state of the clock enable"]
@@ -1288,6 +1945,119 @@ impl Default for Enabled0 {
         Enabled0(0)
     }
 }
+impl core::fmt::Debug for Enabled0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Enabled0")
+            .field("clk_sys_clocks", &self.clk_sys_clocks())
+            .field("clk_sys_accessctrl", &self.clk_sys_accessctrl())
+            .field("clk_adc", &self.clk_adc())
+            .field("clk_sys_adc", &self.clk_sys_adc())
+            .field("clk_sys_bootram", &self.clk_sys_bootram())
+            .field("clk_sys_busctrl", &self.clk_sys_busctrl())
+            .field("clk_sys_busfabric", &self.clk_sys_busfabric())
+            .field("clk_sys_dma", &self.clk_sys_dma())
+            .field("clk_sys_glitch_detector", &self.clk_sys_glitch_detector())
+            .field("clk_hstx", &self.clk_hstx())
+            .field("clk_sys_hstx", &self.clk_sys_hstx())
+            .field("clk_sys_i2c0", &self.clk_sys_i2c0())
+            .field("clk_sys_i2c1", &self.clk_sys_i2c1())
+            .field("clk_sys_io", &self.clk_sys_io())
+            .field("clk_sys_jtag", &self.clk_sys_jtag())
+            .field("clk_ref_otp", &self.clk_ref_otp())
+            .field("clk_sys_otp", &self.clk_sys_otp())
+            .field("clk_sys_pads", &self.clk_sys_pads())
+            .field("clk_sys_pio0", &self.clk_sys_pio0())
+            .field("clk_sys_pio1", &self.clk_sys_pio1())
+            .field("clk_sys_pio2", &self.clk_sys_pio2())
+            .field("clk_sys_pll_sys", &self.clk_sys_pll_sys())
+            .field("clk_sys_pll_usb", &self.clk_sys_pll_usb())
+            .field("clk_ref_powman", &self.clk_ref_powman())
+            .field("clk_sys_powman", &self.clk_sys_powman())
+            .field("clk_sys_pwm", &self.clk_sys_pwm())
+            .field("clk_sys_resets", &self.clk_sys_resets())
+            .field("clk_sys_rom", &self.clk_sys_rom())
+            .field("clk_sys_rosc", &self.clk_sys_rosc())
+            .field("clk_sys_psm", &self.clk_sys_psm())
+            .field("clk_sys_sha256", &self.clk_sys_sha256())
+            .field("clk_sys_sio", &self.clk_sys_sio())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enabled0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Enabled0 {
+            clk_sys_clocks: bool,
+            clk_sys_accessctrl: bool,
+            clk_adc: bool,
+            clk_sys_adc: bool,
+            clk_sys_bootram: bool,
+            clk_sys_busctrl: bool,
+            clk_sys_busfabric: bool,
+            clk_sys_dma: bool,
+            clk_sys_glitch_detector: bool,
+            clk_hstx: bool,
+            clk_sys_hstx: bool,
+            clk_sys_i2c0: bool,
+            clk_sys_i2c1: bool,
+            clk_sys_io: bool,
+            clk_sys_jtag: bool,
+            clk_ref_otp: bool,
+            clk_sys_otp: bool,
+            clk_sys_pads: bool,
+            clk_sys_pio0: bool,
+            clk_sys_pio1: bool,
+            clk_sys_pio2: bool,
+            clk_sys_pll_sys: bool,
+            clk_sys_pll_usb: bool,
+            clk_ref_powman: bool,
+            clk_sys_powman: bool,
+            clk_sys_pwm: bool,
+            clk_sys_resets: bool,
+            clk_sys_rom: bool,
+            clk_sys_rosc: bool,
+            clk_sys_psm: bool,
+            clk_sys_sha256: bool,
+            clk_sys_sio: bool,
+        }
+        let proxy = Enabled0 {
+            clk_sys_clocks: self.clk_sys_clocks(),
+            clk_sys_accessctrl: self.clk_sys_accessctrl(),
+            clk_adc: self.clk_adc(),
+            clk_sys_adc: self.clk_sys_adc(),
+            clk_sys_bootram: self.clk_sys_bootram(),
+            clk_sys_busctrl: self.clk_sys_busctrl(),
+            clk_sys_busfabric: self.clk_sys_busfabric(),
+            clk_sys_dma: self.clk_sys_dma(),
+            clk_sys_glitch_detector: self.clk_sys_glitch_detector(),
+            clk_hstx: self.clk_hstx(),
+            clk_sys_hstx: self.clk_sys_hstx(),
+            clk_sys_i2c0: self.clk_sys_i2c0(),
+            clk_sys_i2c1: self.clk_sys_i2c1(),
+            clk_sys_io: self.clk_sys_io(),
+            clk_sys_jtag: self.clk_sys_jtag(),
+            clk_ref_otp: self.clk_ref_otp(),
+            clk_sys_otp: self.clk_sys_otp(),
+            clk_sys_pads: self.clk_sys_pads(),
+            clk_sys_pio0: self.clk_sys_pio0(),
+            clk_sys_pio1: self.clk_sys_pio1(),
+            clk_sys_pio2: self.clk_sys_pio2(),
+            clk_sys_pll_sys: self.clk_sys_pll_sys(),
+            clk_sys_pll_usb: self.clk_sys_pll_usb(),
+            clk_ref_powman: self.clk_ref_powman(),
+            clk_sys_powman: self.clk_sys_powman(),
+            clk_sys_pwm: self.clk_sys_pwm(),
+            clk_sys_resets: self.clk_sys_resets(),
+            clk_sys_rom: self.clk_sys_rom(),
+            clk_sys_rosc: self.clk_sys_rosc(),
+            clk_sys_psm: self.clk_sys_psm(),
+            clk_sys_sha256: self.clk_sys_sha256(),
+            clk_sys_sio: self.clk_sys_sio(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "indicates the state of the clock enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1579,6 +2349,116 @@ impl Default for Enabled1 {
         Enabled1(0)
     }
 }
+impl core::fmt::Debug for Enabled1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Enabled1")
+            .field("clk_peri_spi0", &self.clk_peri_spi0())
+            .field("clk_sys_spi0", &self.clk_sys_spi0())
+            .field("clk_peri_spi1", &self.clk_peri_spi1())
+            .field("clk_sys_spi1", &self.clk_sys_spi1())
+            .field("clk_sys_sram0", &self.clk_sys_sram0())
+            .field("clk_sys_sram1", &self.clk_sys_sram1())
+            .field("clk_sys_sram2", &self.clk_sys_sram2())
+            .field("clk_sys_sram3", &self.clk_sys_sram3())
+            .field("clk_sys_sram4", &self.clk_sys_sram4())
+            .field("clk_sys_sram5", &self.clk_sys_sram5())
+            .field("clk_sys_sram6", &self.clk_sys_sram6())
+            .field("clk_sys_sram7", &self.clk_sys_sram7())
+            .field("clk_sys_sram8", &self.clk_sys_sram8())
+            .field("clk_sys_sram9", &self.clk_sys_sram9())
+            .field("clk_sys_syscfg", &self.clk_sys_syscfg())
+            .field("clk_sys_sysinfo", &self.clk_sys_sysinfo())
+            .field("clk_sys_tbman", &self.clk_sys_tbman())
+            .field("clk_ref_ticks", &self.clk_ref_ticks())
+            .field("clk_sys_ticks", &self.clk_sys_ticks())
+            .field("clk_sys_timer0", &self.clk_sys_timer0())
+            .field("clk_sys_timer1", &self.clk_sys_timer1())
+            .field("clk_sys_trng", &self.clk_sys_trng())
+            .field("clk_peri_uart0", &self.clk_peri_uart0())
+            .field("clk_sys_uart0", &self.clk_sys_uart0())
+            .field("clk_peri_uart1", &self.clk_peri_uart1())
+            .field("clk_sys_uart1", &self.clk_sys_uart1())
+            .field("clk_sys_usbctrl", &self.clk_sys_usbctrl())
+            .field("clk_usb", &self.clk_usb())
+            .field("clk_sys_watchdog", &self.clk_sys_watchdog())
+            .field("clk_sys_xip", &self.clk_sys_xip())
+            .field("clk_sys_xosc", &self.clk_sys_xosc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enabled1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Enabled1 {
+            clk_peri_spi0: bool,
+            clk_sys_spi0: bool,
+            clk_peri_spi1: bool,
+            clk_sys_spi1: bool,
+            clk_sys_sram0: bool,
+            clk_sys_sram1: bool,
+            clk_sys_sram2: bool,
+            clk_sys_sram3: bool,
+            clk_sys_sram4: bool,
+            clk_sys_sram5: bool,
+            clk_sys_sram6: bool,
+            clk_sys_sram7: bool,
+            clk_sys_sram8: bool,
+            clk_sys_sram9: bool,
+            clk_sys_syscfg: bool,
+            clk_sys_sysinfo: bool,
+            clk_sys_tbman: bool,
+            clk_ref_ticks: bool,
+            clk_sys_ticks: bool,
+            clk_sys_timer0: bool,
+            clk_sys_timer1: bool,
+            clk_sys_trng: bool,
+            clk_peri_uart0: bool,
+            clk_sys_uart0: bool,
+            clk_peri_uart1: bool,
+            clk_sys_uart1: bool,
+            clk_sys_usbctrl: bool,
+            clk_usb: bool,
+            clk_sys_watchdog: bool,
+            clk_sys_xip: bool,
+            clk_sys_xosc: bool,
+        }
+        let proxy = Enabled1 {
+            clk_peri_spi0: self.clk_peri_spi0(),
+            clk_sys_spi0: self.clk_sys_spi0(),
+            clk_peri_spi1: self.clk_peri_spi1(),
+            clk_sys_spi1: self.clk_sys_spi1(),
+            clk_sys_sram0: self.clk_sys_sram0(),
+            clk_sys_sram1: self.clk_sys_sram1(),
+            clk_sys_sram2: self.clk_sys_sram2(),
+            clk_sys_sram3: self.clk_sys_sram3(),
+            clk_sys_sram4: self.clk_sys_sram4(),
+            clk_sys_sram5: self.clk_sys_sram5(),
+            clk_sys_sram6: self.clk_sys_sram6(),
+            clk_sys_sram7: self.clk_sys_sram7(),
+            clk_sys_sram8: self.clk_sys_sram8(),
+            clk_sys_sram9: self.clk_sys_sram9(),
+            clk_sys_syscfg: self.clk_sys_syscfg(),
+            clk_sys_sysinfo: self.clk_sys_sysinfo(),
+            clk_sys_tbman: self.clk_sys_tbman(),
+            clk_ref_ticks: self.clk_ref_ticks(),
+            clk_sys_ticks: self.clk_sys_ticks(),
+            clk_sys_timer0: self.clk_sys_timer0(),
+            clk_sys_timer1: self.clk_sys_timer1(),
+            clk_sys_trng: self.clk_sys_trng(),
+            clk_peri_uart0: self.clk_peri_uart0(),
+            clk_sys_uart0: self.clk_sys_uart0(),
+            clk_peri_uart1: self.clk_peri_uart1(),
+            clk_sys_uart1: self.clk_sys_uart1(),
+            clk_sys_usbctrl: self.clk_sys_usbctrl(),
+            clk_usb: self.clk_usb(),
+            clk_sys_watchdog: self.clk_sys_watchdog(),
+            clk_sys_xip: self.clk_sys_xip(),
+            clk_sys_xosc: self.clk_sys_xosc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Delays the start of frequency counting to allow the mux to settle Delay is measured in multiples of the reference clock period"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1598,6 +2478,26 @@ impl Default for Fc0delay {
     #[inline(always)]
     fn default() -> Fc0delay {
         Fc0delay(0)
+    }
+}
+impl core::fmt::Debug for Fc0delay {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0delay")
+            .field("fc0_delay", &self.fc0_delay())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0delay {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0delay {
+            fc0_delay: u8,
+        }
+        let proxy = Fc0delay {
+            fc0_delay: self.fc0_delay(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "The test interval is 0.98us * 2**interval, but let's call it 1us * 2**interval The default gives a test interval of 250us"]
@@ -1621,6 +2521,26 @@ impl Default for Fc0interval {
         Fc0interval(0)
     }
 }
+impl core::fmt::Debug for Fc0interval {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0interval")
+            .field("fc0_interval", &self.fc0_interval())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0interval {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0interval {
+            fc0_interval: u8,
+        }
+        let proxy = Fc0interval {
+            fc0_interval: self.fc0_interval(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Maximum pass frequency in kHz. This is optional. Set to 0x1ffffff if you are not using the pass/fail flags"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1640,6 +2560,26 @@ impl Default for Fc0maxKhz {
     #[inline(always)]
     fn default() -> Fc0maxKhz {
         Fc0maxKhz(0)
+    }
+}
+impl core::fmt::Debug for Fc0maxKhz {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0maxKhz")
+            .field("fc0_max_khz", &self.fc0_max_khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0maxKhz {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0maxKhz {
+            fc0_max_khz: u32,
+        }
+        let proxy = Fc0maxKhz {
+            fc0_max_khz: self.fc0_max_khz(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Minimum pass frequency in kHz. This is optional. Set to 0 if you are not using the pass/fail flags"]
@@ -1663,6 +2603,26 @@ impl Default for Fc0minKhz {
         Fc0minKhz(0)
     }
 }
+impl core::fmt::Debug for Fc0minKhz {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0minKhz")
+            .field("fc0_min_khz", &self.fc0_min_khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0minKhz {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0minKhz {
+            fc0_min_khz: u32,
+        }
+        let proxy = Fc0minKhz {
+            fc0_min_khz: self.fc0_min_khz(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Reference clock frequency in kHz"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1682,6 +2642,26 @@ impl Default for Fc0refKhz {
     #[inline(always)]
     fn default() -> Fc0refKhz {
         Fc0refKhz(0)
+    }
+}
+impl core::fmt::Debug for Fc0refKhz {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0refKhz")
+            .field("fc0_ref_khz", &self.fc0_ref_khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0refKhz {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0refKhz {
+            fc0_ref_khz: u32,
+        }
+        let proxy = Fc0refKhz {
+            fc0_ref_khz: self.fc0_ref_khz(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Result of frequency measurement, only valid when status_done=1"]
@@ -1714,6 +2694,29 @@ impl Default for Fc0result {
         Fc0result(0)
     }
 }
+impl core::fmt::Debug for Fc0result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0result")
+            .field("frac", &self.frac())
+            .field("khz", &self.khz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0result {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0result {
+            frac: u8,
+            khz: u32,
+        }
+        let proxy = Fc0result {
+            frac: self.frac(),
+            khz: self.khz(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clock sent to frequency counter, set to 0 when not required Writing to this register initiates the frequency count"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1733,6 +2736,26 @@ impl Default for Fc0src {
     #[inline(always)]
     fn default() -> Fc0src {
         Fc0src(0)
+    }
+}
+impl core::fmt::Debug for Fc0src {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0src")
+            .field("fc0_src", &self.fc0_src())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0src {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0src {
+            fc0_src: super::vals::Fc0src,
+        }
+        let proxy = Fc0src {
+            fc0_src: self.fc0_src(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Frequency counter status"]
@@ -1835,7 +2858,48 @@ impl Default for Fc0status {
         Fc0status(0)
     }
 }
-#[doc = "Interrupt status after masking & forcing"]
+impl core::fmt::Debug for Fc0status {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fc0status")
+            .field("pass", &self.pass())
+            .field("done", &self.done())
+            .field("running", &self.running())
+            .field("waiting", &self.waiting())
+            .field("fail", &self.fail())
+            .field("slow", &self.slow())
+            .field("fast", &self.fast())
+            .field("died", &self.died())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fc0status {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fc0status {
+            pass: bool,
+            done: bool,
+            running: bool,
+            waiting: bool,
+            fail: bool,
+            slow: bool,
+            fast: bool,
+            died: bool,
+        }
+        let proxy = Fc0status {
+            pass: self.pass(),
+            done: self.done(),
+            running: self.running(),
+            waiting: self.waiting(),
+            fail: self.fail(),
+            slow: self.slow(),
+            fast: self.fast(),
+            died: self.died(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -1854,6 +2918,26 @@ impl Default for Int {
     #[inline(always)]
     fn default() -> Int {
         Int(0)
+    }
+}
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field("clk_sys_resus", &self.clk_sys_resus())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            clk_sys_resus: bool,
+        }
+        let proxy = Int {
+            clk_sys_resus: self.clk_sys_resus(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "enable clock in sleep mode"]
@@ -2156,6 +3240,119 @@ impl Default for SleepEn0 {
         SleepEn0(0)
     }
 }
+impl core::fmt::Debug for SleepEn0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SleepEn0")
+            .field("clk_sys_clocks", &self.clk_sys_clocks())
+            .field("clk_sys_accessctrl", &self.clk_sys_accessctrl())
+            .field("clk_adc", &self.clk_adc())
+            .field("clk_sys_adc", &self.clk_sys_adc())
+            .field("clk_sys_bootram", &self.clk_sys_bootram())
+            .field("clk_sys_busctrl", &self.clk_sys_busctrl())
+            .field("clk_sys_busfabric", &self.clk_sys_busfabric())
+            .field("clk_sys_dma", &self.clk_sys_dma())
+            .field("clk_sys_glitch_detector", &self.clk_sys_glitch_detector())
+            .field("clk_hstx", &self.clk_hstx())
+            .field("clk_sys_hstx", &self.clk_sys_hstx())
+            .field("clk_sys_i2c0", &self.clk_sys_i2c0())
+            .field("clk_sys_i2c1", &self.clk_sys_i2c1())
+            .field("clk_sys_io", &self.clk_sys_io())
+            .field("clk_sys_jtag", &self.clk_sys_jtag())
+            .field("clk_ref_otp", &self.clk_ref_otp())
+            .field("clk_sys_otp", &self.clk_sys_otp())
+            .field("clk_sys_pads", &self.clk_sys_pads())
+            .field("clk_sys_pio0", &self.clk_sys_pio0())
+            .field("clk_sys_pio1", &self.clk_sys_pio1())
+            .field("clk_sys_pio2", &self.clk_sys_pio2())
+            .field("clk_sys_pll_sys", &self.clk_sys_pll_sys())
+            .field("clk_sys_pll_usb", &self.clk_sys_pll_usb())
+            .field("clk_ref_powman", &self.clk_ref_powman())
+            .field("clk_sys_powman", &self.clk_sys_powman())
+            .field("clk_sys_pwm", &self.clk_sys_pwm())
+            .field("clk_sys_resets", &self.clk_sys_resets())
+            .field("clk_sys_rom", &self.clk_sys_rom())
+            .field("clk_sys_rosc", &self.clk_sys_rosc())
+            .field("clk_sys_psm", &self.clk_sys_psm())
+            .field("clk_sys_sha256", &self.clk_sys_sha256())
+            .field("clk_sys_sio", &self.clk_sys_sio())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SleepEn0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SleepEn0 {
+            clk_sys_clocks: bool,
+            clk_sys_accessctrl: bool,
+            clk_adc: bool,
+            clk_sys_adc: bool,
+            clk_sys_bootram: bool,
+            clk_sys_busctrl: bool,
+            clk_sys_busfabric: bool,
+            clk_sys_dma: bool,
+            clk_sys_glitch_detector: bool,
+            clk_hstx: bool,
+            clk_sys_hstx: bool,
+            clk_sys_i2c0: bool,
+            clk_sys_i2c1: bool,
+            clk_sys_io: bool,
+            clk_sys_jtag: bool,
+            clk_ref_otp: bool,
+            clk_sys_otp: bool,
+            clk_sys_pads: bool,
+            clk_sys_pio0: bool,
+            clk_sys_pio1: bool,
+            clk_sys_pio2: bool,
+            clk_sys_pll_sys: bool,
+            clk_sys_pll_usb: bool,
+            clk_ref_powman: bool,
+            clk_sys_powman: bool,
+            clk_sys_pwm: bool,
+            clk_sys_resets: bool,
+            clk_sys_rom: bool,
+            clk_sys_rosc: bool,
+            clk_sys_psm: bool,
+            clk_sys_sha256: bool,
+            clk_sys_sio: bool,
+        }
+        let proxy = SleepEn0 {
+            clk_sys_clocks: self.clk_sys_clocks(),
+            clk_sys_accessctrl: self.clk_sys_accessctrl(),
+            clk_adc: self.clk_adc(),
+            clk_sys_adc: self.clk_sys_adc(),
+            clk_sys_bootram: self.clk_sys_bootram(),
+            clk_sys_busctrl: self.clk_sys_busctrl(),
+            clk_sys_busfabric: self.clk_sys_busfabric(),
+            clk_sys_dma: self.clk_sys_dma(),
+            clk_sys_glitch_detector: self.clk_sys_glitch_detector(),
+            clk_hstx: self.clk_hstx(),
+            clk_sys_hstx: self.clk_sys_hstx(),
+            clk_sys_i2c0: self.clk_sys_i2c0(),
+            clk_sys_i2c1: self.clk_sys_i2c1(),
+            clk_sys_io: self.clk_sys_io(),
+            clk_sys_jtag: self.clk_sys_jtag(),
+            clk_ref_otp: self.clk_ref_otp(),
+            clk_sys_otp: self.clk_sys_otp(),
+            clk_sys_pads: self.clk_sys_pads(),
+            clk_sys_pio0: self.clk_sys_pio0(),
+            clk_sys_pio1: self.clk_sys_pio1(),
+            clk_sys_pio2: self.clk_sys_pio2(),
+            clk_sys_pll_sys: self.clk_sys_pll_sys(),
+            clk_sys_pll_usb: self.clk_sys_pll_usb(),
+            clk_ref_powman: self.clk_ref_powman(),
+            clk_sys_powman: self.clk_sys_powman(),
+            clk_sys_pwm: self.clk_sys_pwm(),
+            clk_sys_resets: self.clk_sys_resets(),
+            clk_sys_rom: self.clk_sys_rom(),
+            clk_sys_rosc: self.clk_sys_rosc(),
+            clk_sys_psm: self.clk_sys_psm(),
+            clk_sys_sha256: self.clk_sys_sha256(),
+            clk_sys_sio: self.clk_sys_sio(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "enable clock in sleep mode"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2445,6 +3642,116 @@ impl Default for SleepEn1 {
     #[inline(always)]
     fn default() -> SleepEn1 {
         SleepEn1(0)
+    }
+}
+impl core::fmt::Debug for SleepEn1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SleepEn1")
+            .field("clk_peri_spi0", &self.clk_peri_spi0())
+            .field("clk_sys_spi0", &self.clk_sys_spi0())
+            .field("clk_peri_spi1", &self.clk_peri_spi1())
+            .field("clk_sys_spi1", &self.clk_sys_spi1())
+            .field("clk_sys_sram0", &self.clk_sys_sram0())
+            .field("clk_sys_sram1", &self.clk_sys_sram1())
+            .field("clk_sys_sram2", &self.clk_sys_sram2())
+            .field("clk_sys_sram3", &self.clk_sys_sram3())
+            .field("clk_sys_sram4", &self.clk_sys_sram4())
+            .field("clk_sys_sram5", &self.clk_sys_sram5())
+            .field("clk_sys_sram6", &self.clk_sys_sram6())
+            .field("clk_sys_sram7", &self.clk_sys_sram7())
+            .field("clk_sys_sram8", &self.clk_sys_sram8())
+            .field("clk_sys_sram9", &self.clk_sys_sram9())
+            .field("clk_sys_syscfg", &self.clk_sys_syscfg())
+            .field("clk_sys_sysinfo", &self.clk_sys_sysinfo())
+            .field("clk_sys_tbman", &self.clk_sys_tbman())
+            .field("clk_ref_ticks", &self.clk_ref_ticks())
+            .field("clk_sys_ticks", &self.clk_sys_ticks())
+            .field("clk_sys_timer0", &self.clk_sys_timer0())
+            .field("clk_sys_timer1", &self.clk_sys_timer1())
+            .field("clk_sys_trng", &self.clk_sys_trng())
+            .field("clk_peri_uart0", &self.clk_peri_uart0())
+            .field("clk_sys_uart0", &self.clk_sys_uart0())
+            .field("clk_peri_uart1", &self.clk_peri_uart1())
+            .field("clk_sys_uart1", &self.clk_sys_uart1())
+            .field("clk_sys_usbctrl", &self.clk_sys_usbctrl())
+            .field("clk_usb", &self.clk_usb())
+            .field("clk_sys_watchdog", &self.clk_sys_watchdog())
+            .field("clk_sys_xip", &self.clk_sys_xip())
+            .field("clk_sys_xosc", &self.clk_sys_xosc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SleepEn1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SleepEn1 {
+            clk_peri_spi0: bool,
+            clk_sys_spi0: bool,
+            clk_peri_spi1: bool,
+            clk_sys_spi1: bool,
+            clk_sys_sram0: bool,
+            clk_sys_sram1: bool,
+            clk_sys_sram2: bool,
+            clk_sys_sram3: bool,
+            clk_sys_sram4: bool,
+            clk_sys_sram5: bool,
+            clk_sys_sram6: bool,
+            clk_sys_sram7: bool,
+            clk_sys_sram8: bool,
+            clk_sys_sram9: bool,
+            clk_sys_syscfg: bool,
+            clk_sys_sysinfo: bool,
+            clk_sys_tbman: bool,
+            clk_ref_ticks: bool,
+            clk_sys_ticks: bool,
+            clk_sys_timer0: bool,
+            clk_sys_timer1: bool,
+            clk_sys_trng: bool,
+            clk_peri_uart0: bool,
+            clk_sys_uart0: bool,
+            clk_peri_uart1: bool,
+            clk_sys_uart1: bool,
+            clk_sys_usbctrl: bool,
+            clk_usb: bool,
+            clk_sys_watchdog: bool,
+            clk_sys_xip: bool,
+            clk_sys_xosc: bool,
+        }
+        let proxy = SleepEn1 {
+            clk_peri_spi0: self.clk_peri_spi0(),
+            clk_sys_spi0: self.clk_sys_spi0(),
+            clk_peri_spi1: self.clk_peri_spi1(),
+            clk_sys_spi1: self.clk_sys_spi1(),
+            clk_sys_sram0: self.clk_sys_sram0(),
+            clk_sys_sram1: self.clk_sys_sram1(),
+            clk_sys_sram2: self.clk_sys_sram2(),
+            clk_sys_sram3: self.clk_sys_sram3(),
+            clk_sys_sram4: self.clk_sys_sram4(),
+            clk_sys_sram5: self.clk_sys_sram5(),
+            clk_sys_sram6: self.clk_sys_sram6(),
+            clk_sys_sram7: self.clk_sys_sram7(),
+            clk_sys_sram8: self.clk_sys_sram8(),
+            clk_sys_sram9: self.clk_sys_sram9(),
+            clk_sys_syscfg: self.clk_sys_syscfg(),
+            clk_sys_sysinfo: self.clk_sys_sysinfo(),
+            clk_sys_tbman: self.clk_sys_tbman(),
+            clk_ref_ticks: self.clk_ref_ticks(),
+            clk_sys_ticks: self.clk_sys_ticks(),
+            clk_sys_timer0: self.clk_sys_timer0(),
+            clk_sys_timer1: self.clk_sys_timer1(),
+            clk_sys_trng: self.clk_sys_trng(),
+            clk_peri_uart0: self.clk_peri_uart0(),
+            clk_sys_uart0: self.clk_sys_uart0(),
+            clk_peri_uart1: self.clk_peri_uart1(),
+            clk_sys_uart1: self.clk_sys_uart1(),
+            clk_sys_usbctrl: self.clk_sys_usbctrl(),
+            clk_usb: self.clk_usb(),
+            clk_sys_watchdog: self.clk_sys_watchdog(),
+            clk_sys_xip: self.clk_sys_xip(),
+            clk_sys_xosc: self.clk_sys_xosc(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "enable clock in wake mode"]
@@ -2747,6 +4054,119 @@ impl Default for WakeEn0 {
         WakeEn0(0)
     }
 }
+impl core::fmt::Debug for WakeEn0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WakeEn0")
+            .field("clk_sys_clocks", &self.clk_sys_clocks())
+            .field("clk_sys_accessctrl", &self.clk_sys_accessctrl())
+            .field("clk_adc", &self.clk_adc())
+            .field("clk_sys_adc", &self.clk_sys_adc())
+            .field("clk_sys_bootram", &self.clk_sys_bootram())
+            .field("clk_sys_busctrl", &self.clk_sys_busctrl())
+            .field("clk_sys_busfabric", &self.clk_sys_busfabric())
+            .field("clk_sys_dma", &self.clk_sys_dma())
+            .field("clk_sys_glitch_detector", &self.clk_sys_glitch_detector())
+            .field("clk_hstx", &self.clk_hstx())
+            .field("clk_sys_hstx", &self.clk_sys_hstx())
+            .field("clk_sys_i2c0", &self.clk_sys_i2c0())
+            .field("clk_sys_i2c1", &self.clk_sys_i2c1())
+            .field("clk_sys_io", &self.clk_sys_io())
+            .field("clk_sys_jtag", &self.clk_sys_jtag())
+            .field("clk_ref_otp", &self.clk_ref_otp())
+            .field("clk_sys_otp", &self.clk_sys_otp())
+            .field("clk_sys_pads", &self.clk_sys_pads())
+            .field("clk_sys_pio0", &self.clk_sys_pio0())
+            .field("clk_sys_pio1", &self.clk_sys_pio1())
+            .field("clk_sys_pio2", &self.clk_sys_pio2())
+            .field("clk_sys_pll_sys", &self.clk_sys_pll_sys())
+            .field("clk_sys_pll_usb", &self.clk_sys_pll_usb())
+            .field("clk_ref_powman", &self.clk_ref_powman())
+            .field("clk_sys_powman", &self.clk_sys_powman())
+            .field("clk_sys_pwm", &self.clk_sys_pwm())
+            .field("clk_sys_resets", &self.clk_sys_resets())
+            .field("clk_sys_rom", &self.clk_sys_rom())
+            .field("clk_sys_rosc", &self.clk_sys_rosc())
+            .field("clk_sys_psm", &self.clk_sys_psm())
+            .field("clk_sys_sha256", &self.clk_sys_sha256())
+            .field("clk_sys_sio", &self.clk_sys_sio())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WakeEn0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WakeEn0 {
+            clk_sys_clocks: bool,
+            clk_sys_accessctrl: bool,
+            clk_adc: bool,
+            clk_sys_adc: bool,
+            clk_sys_bootram: bool,
+            clk_sys_busctrl: bool,
+            clk_sys_busfabric: bool,
+            clk_sys_dma: bool,
+            clk_sys_glitch_detector: bool,
+            clk_hstx: bool,
+            clk_sys_hstx: bool,
+            clk_sys_i2c0: bool,
+            clk_sys_i2c1: bool,
+            clk_sys_io: bool,
+            clk_sys_jtag: bool,
+            clk_ref_otp: bool,
+            clk_sys_otp: bool,
+            clk_sys_pads: bool,
+            clk_sys_pio0: bool,
+            clk_sys_pio1: bool,
+            clk_sys_pio2: bool,
+            clk_sys_pll_sys: bool,
+            clk_sys_pll_usb: bool,
+            clk_ref_powman: bool,
+            clk_sys_powman: bool,
+            clk_sys_pwm: bool,
+            clk_sys_resets: bool,
+            clk_sys_rom: bool,
+            clk_sys_rosc: bool,
+            clk_sys_psm: bool,
+            clk_sys_sha256: bool,
+            clk_sys_sio: bool,
+        }
+        let proxy = WakeEn0 {
+            clk_sys_clocks: self.clk_sys_clocks(),
+            clk_sys_accessctrl: self.clk_sys_accessctrl(),
+            clk_adc: self.clk_adc(),
+            clk_sys_adc: self.clk_sys_adc(),
+            clk_sys_bootram: self.clk_sys_bootram(),
+            clk_sys_busctrl: self.clk_sys_busctrl(),
+            clk_sys_busfabric: self.clk_sys_busfabric(),
+            clk_sys_dma: self.clk_sys_dma(),
+            clk_sys_glitch_detector: self.clk_sys_glitch_detector(),
+            clk_hstx: self.clk_hstx(),
+            clk_sys_hstx: self.clk_sys_hstx(),
+            clk_sys_i2c0: self.clk_sys_i2c0(),
+            clk_sys_i2c1: self.clk_sys_i2c1(),
+            clk_sys_io: self.clk_sys_io(),
+            clk_sys_jtag: self.clk_sys_jtag(),
+            clk_ref_otp: self.clk_ref_otp(),
+            clk_sys_otp: self.clk_sys_otp(),
+            clk_sys_pads: self.clk_sys_pads(),
+            clk_sys_pio0: self.clk_sys_pio0(),
+            clk_sys_pio1: self.clk_sys_pio1(),
+            clk_sys_pio2: self.clk_sys_pio2(),
+            clk_sys_pll_sys: self.clk_sys_pll_sys(),
+            clk_sys_pll_usb: self.clk_sys_pll_usb(),
+            clk_ref_powman: self.clk_ref_powman(),
+            clk_sys_powman: self.clk_sys_powman(),
+            clk_sys_pwm: self.clk_sys_pwm(),
+            clk_sys_resets: self.clk_sys_resets(),
+            clk_sys_rom: self.clk_sys_rom(),
+            clk_sys_rosc: self.clk_sys_rosc(),
+            clk_sys_psm: self.clk_sys_psm(),
+            clk_sys_sha256: self.clk_sys_sha256(),
+            clk_sys_sio: self.clk_sys_sio(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "enable clock in wake mode"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3036,5 +4456,115 @@ impl Default for WakeEn1 {
     #[inline(always)]
     fn default() -> WakeEn1 {
         WakeEn1(0)
+    }
+}
+impl core::fmt::Debug for WakeEn1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WakeEn1")
+            .field("clk_peri_spi0", &self.clk_peri_spi0())
+            .field("clk_sys_spi0", &self.clk_sys_spi0())
+            .field("clk_peri_spi1", &self.clk_peri_spi1())
+            .field("clk_sys_spi1", &self.clk_sys_spi1())
+            .field("clk_sys_sram0", &self.clk_sys_sram0())
+            .field("clk_sys_sram1", &self.clk_sys_sram1())
+            .field("clk_sys_sram2", &self.clk_sys_sram2())
+            .field("clk_sys_sram3", &self.clk_sys_sram3())
+            .field("clk_sys_sram4", &self.clk_sys_sram4())
+            .field("clk_sys_sram5", &self.clk_sys_sram5())
+            .field("clk_sys_sram6", &self.clk_sys_sram6())
+            .field("clk_sys_sram7", &self.clk_sys_sram7())
+            .field("clk_sys_sram8", &self.clk_sys_sram8())
+            .field("clk_sys_sram9", &self.clk_sys_sram9())
+            .field("clk_sys_syscfg", &self.clk_sys_syscfg())
+            .field("clk_sys_sysinfo", &self.clk_sys_sysinfo())
+            .field("clk_sys_tbman", &self.clk_sys_tbman())
+            .field("clk_ref_ticks", &self.clk_ref_ticks())
+            .field("clk_sys_ticks", &self.clk_sys_ticks())
+            .field("clk_sys_timer0", &self.clk_sys_timer0())
+            .field("clk_sys_timer1", &self.clk_sys_timer1())
+            .field("clk_sys_trng", &self.clk_sys_trng())
+            .field("clk_peri_uart0", &self.clk_peri_uart0())
+            .field("clk_sys_uart0", &self.clk_sys_uart0())
+            .field("clk_peri_uart1", &self.clk_peri_uart1())
+            .field("clk_sys_uart1", &self.clk_sys_uart1())
+            .field("clk_sys_usbctrl", &self.clk_sys_usbctrl())
+            .field("clk_usb", &self.clk_usb())
+            .field("clk_sys_watchdog", &self.clk_sys_watchdog())
+            .field("clk_sys_xip", &self.clk_sys_xip())
+            .field("clk_sys_xosc", &self.clk_sys_xosc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WakeEn1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WakeEn1 {
+            clk_peri_spi0: bool,
+            clk_sys_spi0: bool,
+            clk_peri_spi1: bool,
+            clk_sys_spi1: bool,
+            clk_sys_sram0: bool,
+            clk_sys_sram1: bool,
+            clk_sys_sram2: bool,
+            clk_sys_sram3: bool,
+            clk_sys_sram4: bool,
+            clk_sys_sram5: bool,
+            clk_sys_sram6: bool,
+            clk_sys_sram7: bool,
+            clk_sys_sram8: bool,
+            clk_sys_sram9: bool,
+            clk_sys_syscfg: bool,
+            clk_sys_sysinfo: bool,
+            clk_sys_tbman: bool,
+            clk_ref_ticks: bool,
+            clk_sys_ticks: bool,
+            clk_sys_timer0: bool,
+            clk_sys_timer1: bool,
+            clk_sys_trng: bool,
+            clk_peri_uart0: bool,
+            clk_sys_uart0: bool,
+            clk_peri_uart1: bool,
+            clk_sys_uart1: bool,
+            clk_sys_usbctrl: bool,
+            clk_usb: bool,
+            clk_sys_watchdog: bool,
+            clk_sys_xip: bool,
+            clk_sys_xosc: bool,
+        }
+        let proxy = WakeEn1 {
+            clk_peri_spi0: self.clk_peri_spi0(),
+            clk_sys_spi0: self.clk_sys_spi0(),
+            clk_peri_spi1: self.clk_peri_spi1(),
+            clk_sys_spi1: self.clk_sys_spi1(),
+            clk_sys_sram0: self.clk_sys_sram0(),
+            clk_sys_sram1: self.clk_sys_sram1(),
+            clk_sys_sram2: self.clk_sys_sram2(),
+            clk_sys_sram3: self.clk_sys_sram3(),
+            clk_sys_sram4: self.clk_sys_sram4(),
+            clk_sys_sram5: self.clk_sys_sram5(),
+            clk_sys_sram6: self.clk_sys_sram6(),
+            clk_sys_sram7: self.clk_sys_sram7(),
+            clk_sys_sram8: self.clk_sys_sram8(),
+            clk_sys_sram9: self.clk_sys_sram9(),
+            clk_sys_syscfg: self.clk_sys_syscfg(),
+            clk_sys_sysinfo: self.clk_sys_sysinfo(),
+            clk_sys_tbman: self.clk_sys_tbman(),
+            clk_ref_ticks: self.clk_ref_ticks(),
+            clk_sys_ticks: self.clk_sys_ticks(),
+            clk_sys_timer0: self.clk_sys_timer0(),
+            clk_sys_timer1: self.clk_sys_timer1(),
+            clk_sys_trng: self.clk_sys_trng(),
+            clk_peri_uart0: self.clk_peri_uart0(),
+            clk_sys_uart0: self.clk_sys_uart0(),
+            clk_peri_uart1: self.clk_peri_uart1(),
+            clk_sys_uart1: self.clk_sys_uart1(),
+            clk_sys_usbctrl: self.clk_sys_usbctrl(),
+            clk_usb: self.clk_usb(),
+            clk_sys_watchdog: self.clk_sys_watchdog(),
+            clk_sys_xip: self.clk_sys_xip(),
+            clk_sys_xosc: self.clk_sys_xosc(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/clocks/vals.rs
+++ b/src/rp235x/clocks/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkAdcCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -33,7 +34,8 @@ impl From<ClkAdcCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkGpoutCtrlAuxsrc {
     CLKSRC_PLL_SYS = 0x0,
     CLKSRC_GPIN0 = 0x01,
@@ -75,7 +77,8 @@ impl From<ClkGpoutCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkHstxCtrlAuxsrc {
     CLK_SYS = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -109,7 +112,8 @@ impl From<ClkHstxCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkPeriCtrlAuxsrc {
     CLK_SYS = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -143,7 +147,8 @@ impl From<ClkPeriCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkRefCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_GPIN0 = 0x01,
@@ -173,7 +178,8 @@ impl From<ClkRefCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkRefCtrlSrc {
     ROSC_CLKSRC_PH = 0x0,
     CLKSRC_CLK_REF_AUX = 0x01,
@@ -203,7 +209,8 @@ impl From<ClkRefCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkSysCtrlAuxsrc {
     CLKSRC_PLL_SYS = 0x0,
     CLKSRC_PLL_USB = 0x01,
@@ -237,7 +244,8 @@ impl From<ClkSysCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkSysCtrlSrc {
     CLK_REF = 0x0,
     CLKSRC_CLK_SYS_AUX = 0x01,
@@ -265,7 +273,8 @@ impl From<ClkSysCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkUsbCtrlAuxsrc {
     CLKSRC_PLL_USB = 0x0,
     CLKSRC_PLL_SYS = 0x01,
@@ -299,7 +308,8 @@ impl From<ClkUsbCtrlAuxsrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DftclkLposcCtrlSrc {
     NULL = 0x0,
     CLKSRC_PLL_USB_PRIMARY_LPOSC = 0x01,
@@ -329,7 +339,8 @@ impl From<DftclkLposcCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DftclkRoscCtrlSrc {
     NULL = 0x0,
     CLKSRC_PLL_SYS_PRIMARY_ROSC = 0x01,
@@ -359,7 +370,8 @@ impl From<DftclkRoscCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DftclkXoscCtrlSrc {
     NULL = 0x0,
     CLKSRC_PLL_USB_PRIMARY = 0x01,
@@ -389,7 +401,8 @@ impl From<DftclkXoscCtrlSrc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Fc0src {
     NULL = 0x0,
     PLL_SYS_CLKSRC_PRIMARY = 0x01,

--- a/src/rp235x/coresight_trace/regs.rs
+++ b/src/rp235x/coresight_trace/regs.rs
@@ -32,3 +32,29 @@ impl Default for CtrlStatus {
         CtrlStatus(0)
     }
 }
+impl core::fmt::Debug for CtrlStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CtrlStatus")
+            .field("trace_capture_fifo_flush", &self.trace_capture_fifo_flush())
+            .field(
+                "trace_capture_fifo_overflow",
+                &self.trace_capture_fifo_overflow(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CtrlStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct CtrlStatus {
+            trace_capture_fifo_flush: bool,
+            trace_capture_fifo_overflow: bool,
+        }
+        let proxy = CtrlStatus {
+            trace_capture_fifo_flush: self.trace_capture_fifo_flush(),
+            trace_capture_fifo_overflow: self.trace_capture_fifo_overflow(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}

--- a/src/rp235x/dma.rs
+++ b/src/rp235x/dma.rs
@@ -13,82 +13,82 @@ impl Channel {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "DMA Channel 12 Read Address pointer"]
+    #[doc = "DMA Channel 9 Read Address pointer"]
     #[inline(always)]
     pub const fn read_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "DMA Channel 12 Write Address pointer"]
+    #[doc = "DMA Channel 9 Write Address pointer"]
     #[inline(always)]
     pub const fn write_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
-    #[doc = "DMA Channel 12 Transfer Count"]
+    #[doc = "DMA Channel 9 Transfer Count"]
     #[inline(always)]
     pub const fn trans_count(self) -> crate::common::Reg<regs::ChTransCount, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
-    #[doc = "DMA Channel 12 Control and Status"]
+    #[doc = "DMA Channel 9 Control and Status"]
     #[inline(always)]
     pub const fn ctrl_trig(self) -> crate::common::Reg<regs::CtrlTrig, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0cusize) as _) }
     }
-    #[doc = "Alias for channel 12 CTRL register"]
+    #[doc = "Alias for channel 9 CTRL register"]
     #[inline(always)]
     pub const fn al1_ctrl(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x10usize) as _) }
     }
-    #[doc = "Alias for channel 12 READ_ADDR register"]
+    #[doc = "Alias for channel 9 READ_ADDR register"]
     #[inline(always)]
     pub const fn al1_read_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x14usize) as _) }
     }
-    #[doc = "Alias for channel 12 WRITE_ADDR register"]
+    #[doc = "Alias for channel 9 WRITE_ADDR register"]
     #[inline(always)]
     pub const fn al1_write_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x18usize) as _) }
     }
-    #[doc = "Alias for channel 12 TRANS_COUNT register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
+    #[doc = "Alias for channel 9 TRANS_COUNT register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
     #[inline(always)]
     pub const fn al1_trans_count_trig(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x1cusize) as _) }
     }
-    #[doc = "Alias for channel 12 CTRL register"]
+    #[doc = "Alias for channel 9 CTRL register"]
     #[inline(always)]
     pub const fn al2_ctrl(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x20usize) as _) }
     }
-    #[doc = "Alias for channel 12 TRANS_COUNT register"]
+    #[doc = "Alias for channel 9 TRANS_COUNT register"]
     #[inline(always)]
     pub const fn al2_trans_count(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x24usize) as _) }
     }
-    #[doc = "Alias for channel 12 READ_ADDR register"]
+    #[doc = "Alias for channel 9 READ_ADDR register"]
     #[inline(always)]
     pub const fn al2_read_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x28usize) as _) }
     }
-    #[doc = "Alias for channel 12 WRITE_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
+    #[doc = "Alias for channel 9 WRITE_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
     #[inline(always)]
     pub const fn al2_write_addr_trig(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x2cusize) as _) }
     }
-    #[doc = "Alias for channel 12 CTRL register"]
+    #[doc = "Alias for channel 9 CTRL register"]
     #[inline(always)]
     pub const fn al3_ctrl(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x30usize) as _) }
     }
-    #[doc = "Alias for channel 12 WRITE_ADDR register"]
+    #[doc = "Alias for channel 9 WRITE_ADDR register"]
     #[inline(always)]
     pub const fn al3_write_addr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x34usize) as _) }
     }
-    #[doc = "Alias for channel 12 TRANS_COUNT register"]
+    #[doc = "Alias for channel 9 TRANS_COUNT register"]
     #[inline(always)]
     pub const fn al3_trans_count(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x38usize) as _) }
     }
-    #[doc = "Alias for channel 12 READ_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
+    #[doc = "Alias for channel 9 READ_ADDR register This is a trigger register (0xc). Writing a nonzero value will reload the channel counter and start the channel."]
     #[inline(always)]
     pub const fn al3_read_addr_trig(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x3cusize) as _) }

--- a/src/rp235x/dma/regs.rs
+++ b/src/rp235x/dma/regs.rs
@@ -1,4 +1,4 @@
-#[doc = "DMA Channel 3 Transfer Count"]
+#[doc = "DMA Channel 0 Transfer Count"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ChTransCount(pub u32);
@@ -32,6 +32,29 @@ impl Default for ChTransCount {
         ChTransCount(0)
     }
 }
+impl core::fmt::Debug for ChTransCount {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChTransCount")
+            .field("count", &self.count())
+            .field("mode", &self.mode())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChTransCount {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChTransCount {
+            count: u32,
+            mode: super::vals::TransCountMode,
+        }
+        let proxy = ChTransCount {
+            count: self.count(),
+            mode: self.mode(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Abort an in-progress transfer sequence on one or more channels"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,6 +76,26 @@ impl Default for ChanAbort {
     #[inline(always)]
     fn default() -> ChanAbort {
         ChanAbort(0)
+    }
+}
+impl core::fmt::Debug for ChanAbort {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChanAbort")
+            .field("chan_abort", &self.chan_abort())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChanAbort {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChanAbort {
+            chan_abort: u16,
+        }
+        let proxy = ChanAbort {
+            chan_abort: self.chan_abort(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "DMA Channel 0 Control and Status"]
@@ -265,6 +308,77 @@ impl Default for CtrlTrig {
         CtrlTrig(0)
     }
 }
+impl core::fmt::Debug for CtrlTrig {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CtrlTrig")
+            .field("en", &self.en())
+            .field("high_priority", &self.high_priority())
+            .field("data_size", &self.data_size())
+            .field("incr_read", &self.incr_read())
+            .field("incr_read_rev", &self.incr_read_rev())
+            .field("incr_write", &self.incr_write())
+            .field("incr_write_rev", &self.incr_write_rev())
+            .field("ring_size", &self.ring_size())
+            .field("ring_sel", &self.ring_sel())
+            .field("chain_to", &self.chain_to())
+            .field("treq_sel", &self.treq_sel())
+            .field("irq_quiet", &self.irq_quiet())
+            .field("bswap", &self.bswap())
+            .field("sniff_en", &self.sniff_en())
+            .field("busy", &self.busy())
+            .field("write_error", &self.write_error())
+            .field("read_error", &self.read_error())
+            .field("ahb_error", &self.ahb_error())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CtrlTrig {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct CtrlTrig {
+            en: bool,
+            high_priority: bool,
+            data_size: super::vals::DataSize,
+            incr_read: bool,
+            incr_read_rev: bool,
+            incr_write: bool,
+            incr_write_rev: bool,
+            ring_size: u8,
+            ring_sel: bool,
+            chain_to: u8,
+            treq_sel: super::vals::TreqSel,
+            irq_quiet: bool,
+            bswap: bool,
+            sniff_en: bool,
+            busy: bool,
+            write_error: bool,
+            read_error: bool,
+            ahb_error: bool,
+        }
+        let proxy = CtrlTrig {
+            en: self.en(),
+            high_priority: self.high_priority(),
+            data_size: self.data_size(),
+            incr_read: self.incr_read(),
+            incr_read_rev: self.incr_read_rev(),
+            incr_write: self.incr_write(),
+            incr_write_rev: self.incr_write_rev(),
+            ring_size: self.ring_size(),
+            ring_sel: self.ring_sel(),
+            chain_to: self.chain_to(),
+            treq_sel: self.treq_sel(),
+            irq_quiet: self.irq_quiet(),
+            bswap: self.bswap(),
+            sniff_en: self.sniff_en(),
+            busy: self.busy(),
+            write_error: self.write_error(),
+            read_error: self.read_error(),
+            ahb_error: self.ahb_error(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Read: get channel DREQ counter (i.e. how many accesses the DMA expects it can perform on the peripheral without overflow/underflow. Write any value: clears the counter, and cause channel to re-initiate DREQ handshake."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -284,6 +398,26 @@ impl Default for DbgCtdreq {
     #[inline(always)]
     fn default() -> DbgCtdreq {
         DbgCtdreq(0)
+    }
+}
+impl core::fmt::Debug for DbgCtdreq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DbgCtdreq")
+            .field("dbg_ctdreq", &self.dbg_ctdreq())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DbgCtdreq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DbgCtdreq {
+            dbg_ctdreq: u8,
+        }
+        let proxy = DbgCtdreq {
+            dbg_ctdreq: self.dbg_ctdreq(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Debug RAF, WAF, TDF levels"]
@@ -331,6 +465,32 @@ impl Default for FifoLevels {
         FifoLevels(0)
     }
 }
+impl core::fmt::Debug for FifoLevels {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FifoLevels")
+            .field("tdf_lvl", &self.tdf_lvl())
+            .field("waf_lvl", &self.waf_lvl())
+            .field("raf_lvl", &self.raf_lvl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FifoLevels {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FifoLevels {
+            tdf_lvl: u8,
+            waf_lvl: u8,
+            raf_lvl: u8,
+        }
+        let proxy = FifoLevels {
+            tdf_lvl: self.tdf_lvl(),
+            waf_lvl: self.waf_lvl(),
+            raf_lvl: self.raf_lvl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register for DMA MPU. Accessible only from a Privileged context."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -376,6 +536,32 @@ impl Default for MpuCtrl {
         MpuCtrl(0)
     }
 }
+impl core::fmt::Debug for MpuCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MpuCtrl")
+            .field("p", &self.p())
+            .field("s", &self.s())
+            .field("ns_hide_addr", &self.ns_hide_addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for MpuCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct MpuCtrl {
+            p: bool,
+            s: bool,
+            ns_hide_addr: bool,
+        }
+        let proxy = MpuCtrl {
+            p: self.p(),
+            s: self.s(),
+            ns_hide_addr: self.ns_hide_addr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Trigger one or more channels simultaneously"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -399,6 +585,26 @@ impl Default for MultiChanTrigger {
         MultiChanTrigger(0)
     }
 }
+impl core::fmt::Debug for MultiChanTrigger {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MultiChanTrigger")
+            .field("multi_chan_trigger", &self.multi_chan_trigger())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for MultiChanTrigger {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct MultiChanTrigger {
+            multi_chan_trigger: u16,
+        }
+        let proxy = MultiChanTrigger {
+            multi_chan_trigger: self.multi_chan_trigger(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "The number of channels this DMA instance is equipped with. This DMA supports up to 16 hardware channels, but can be configured with as few as one, to minimise silicon area."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -420,7 +626,27 @@ impl Default for Nchannels {
         Nchannels(0)
     }
 }
-#[doc = "Security configuration for channel 6. Control whether this channel performs Secure/Non-secure and Privileged/Unprivileged bus accesses. If this channel generates bus accesses of some security level, an access of at least that level (in the order S+P > S+U > NS+P > NS+U) is required to program, trigger, abort, check the status of, interrupt on or acknowledge the interrupt of this channel. This register automatically locks down (becomes read-only) once software starts to configure the channel. This register is world-readable, but is writable only from a Secure, Privileged context."]
+impl core::fmt::Debug for Nchannels {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Nchannels")
+            .field("n_channels", &self.n_channels())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Nchannels {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Nchannels {
+            n_channels: u8,
+        }
+        let proxy = Nchannels {
+            n_channels: self.n_channels(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Security configuration for channel 0. Control whether this channel performs Secure/Non-secure and Privileged/Unprivileged bus accesses. If this channel generates bus accesses of some security level, an access of at least that level (in the order S+P > S+U > NS+P > NS+U) is required to program, trigger, abort, check the status of, interrupt on or acknowledge the interrupt of this channel. This register automatically locks down (becomes read-only) once software starts to configure the channel. This register is world-readable, but is writable only from a Secure, Privileged context."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SeccfgCh(pub u32);
@@ -465,7 +691,33 @@ impl Default for SeccfgCh {
         SeccfgCh(0)
     }
 }
-#[doc = "Security configuration for IRQ 3. Control whether the IRQ permits configuration by Non-secure/Unprivileged contexts, and whether it can observe Secure/Privileged channel interrupt flags."]
+impl core::fmt::Debug for SeccfgCh {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SeccfgCh")
+            .field("p", &self.p())
+            .field("s", &self.s())
+            .field("lock", &self.lock())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SeccfgCh {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SeccfgCh {
+            p: bool,
+            s: bool,
+            lock: bool,
+        }
+        let proxy = SeccfgCh {
+            p: self.p(),
+            s: self.s(),
+            lock: self.lock(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Security configuration for IRQ 0. Control whether the IRQ permits configuration by Non-secure/Unprivileged contexts, and whether it can observe Secure/Privileged channel interrupt flags."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SeccfgIrq(pub u32);
@@ -497,6 +749,29 @@ impl Default for SeccfgIrq {
     #[inline(always)]
     fn default() -> SeccfgIrq {
         SeccfgIrq(0)
+    }
+}
+impl core::fmt::Debug for SeccfgIrq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SeccfgIrq")
+            .field("p", &self.p())
+            .field("s", &self.s())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SeccfgIrq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SeccfgIrq {
+            p: bool,
+            s: bool,
+        }
+        let proxy = SeccfgIrq {
+            p: self.p(),
+            s: self.s(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Miscellaneous security configuration"]
@@ -561,6 +836,61 @@ impl Default for SeccfgMisc {
     #[inline(always)]
     fn default() -> SeccfgMisc {
         SeccfgMisc(0)
+    }
+}
+impl core::fmt::Debug for SeccfgMisc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SeccfgMisc")
+            .field("sniff_p", &self.sniff_p())
+            .field("sniff_s", &self.sniff_s())
+            .field(
+                "timer_p",
+                &[
+                    self.timer_p(0usize),
+                    self.timer_p(1usize),
+                    self.timer_p(2usize),
+                    self.timer_p(3usize),
+                ],
+            )
+            .field(
+                "timer_s",
+                &[
+                    self.timer_s(0usize),
+                    self.timer_s(1usize),
+                    self.timer_s(2usize),
+                    self.timer_s(3usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SeccfgMisc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SeccfgMisc {
+            sniff_p: bool,
+            sniff_s: bool,
+            timer_p: [bool; 4usize],
+            timer_s: [bool; 4usize],
+        }
+        let proxy = SeccfgMisc {
+            sniff_p: self.sniff_p(),
+            sniff_s: self.sniff_s(),
+            timer_p: [
+                self.timer_p(0usize),
+                self.timer_p(1usize),
+                self.timer_p(2usize),
+                self.timer_p(3usize),
+            ],
+            timer_s: [
+                self.timer_s(0usize),
+                self.timer_s(1usize),
+                self.timer_s(2usize),
+                self.timer_s(3usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Sniffer Control"]
@@ -639,6 +969,41 @@ impl Default for SniffCtrl {
         SniffCtrl(0)
     }
 }
+impl core::fmt::Debug for SniffCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SniffCtrl")
+            .field("en", &self.en())
+            .field("dmach", &self.dmach())
+            .field("calc", &self.calc())
+            .field("bswap", &self.bswap())
+            .field("out_rev", &self.out_rev())
+            .field("out_inv", &self.out_inv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SniffCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SniffCtrl {
+            en: bool,
+            dmach: u8,
+            calc: super::vals::Calc,
+            bswap: bool,
+            out_rev: bool,
+            out_inv: bool,
+        }
+        let proxy = SniffCtrl {
+            en: self.en(),
+            dmach: self.dmach(),
+            calc: self.calc(),
+            bswap: self.bswap(),
+            out_rev: self.out_rev(),
+            out_inv: self.out_inv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Pacing (X/Y) fractional timer The pacing timer produces TREQ assertions at a rate set by ((X/Y) * sys_clk). This equation is evaluated every sys_clk cycles and therefore can only generate TREQs at a rate of 1 per sys_clk (i.e. permanent TREQ) or less."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -671,5 +1036,28 @@ impl Default for Timer {
     #[inline(always)]
     fn default() -> Timer {
         Timer(0)
+    }
+}
+impl core::fmt::Debug for Timer {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer")
+            .field("y", &self.y())
+            .field("x", &self.x())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer {
+            y: u16,
+            x: u16,
+        }
+        let proxy = Timer {
+            y: self.y(),
+            x: self.x(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/dma/vals.rs
+++ b/src/rp235x/dma/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Calc {
     #[doc = "Calculate a CRC-32 (IEEE802.3 polynomial)"]
     CRC32 = 0x0,
@@ -47,7 +48,8 @@ impl From<Calc> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataSize {
     SIZE_BYTE = 0x0,
     SIZE_HALFWORD = 0x01,
@@ -77,7 +79,8 @@ impl From<DataSize> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TransCountMode {
     NORMAL = 0x0,
     TRIGGER_SELF = 0x01,
@@ -119,7 +122,8 @@ impl From<TransCountMode> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TreqSel {
     #[doc = "Select PIO0's TX FIFO 0 as TREQ"]
     PIO0_TX0 = 0x0,

--- a/src/rp235x/eppb/regs.rs
+++ b/src/rp235x/eppb/regs.rs
@@ -19,6 +19,26 @@ impl Default for NmiMask1 {
         NmiMask1(0)
     }
 }
+impl core::fmt::Debug for NmiMask1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("NmiMask1")
+            .field("nmi_mask1", &self.nmi_mask1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for NmiMask1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct NmiMask1 {
+            nmi_mask1: u32,
+        }
+        let proxy = NmiMask1 {
+            nmi_mask1: self.nmi_mask1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Nonstandard sleep control register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -62,5 +82,31 @@ impl Default for Sleepctrl {
     #[inline(always)]
     fn default() -> Sleepctrl {
         Sleepctrl(0)
+    }
+}
+impl core::fmt::Debug for Sleepctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Sleepctrl")
+            .field("light_sleep", &self.light_sleep())
+            .field("wicenreq", &self.wicenreq())
+            .field("wicenack", &self.wicenack())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sleepctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Sleepctrl {
+            light_sleep: bool,
+            wicenreq: bool,
+            wicenack: bool,
+        }
+        let proxy = Sleepctrl {
+            light_sleep: self.light_sleep(),
+            wicenreq: self.wicenreq(),
+            wicenack: self.wicenack(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/glitch_detector/regs.rs
+++ b/src/rp235x/glitch_detector/regs.rs
@@ -19,6 +19,22 @@ impl Default for Arm {
         Arm(0)
     }
 }
+impl core::fmt::Debug for Arm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Arm").field("arm", &self.arm()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Arm {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Arm {
+            arm: super::vals::Arm,
+        }
+        let proxy = Arm { arm: self.arm() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Disarm(pub u32);
@@ -41,6 +57,26 @@ impl Default for Disarm {
         Disarm(0)
     }
 }
+impl core::fmt::Debug for Disarm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Disarm")
+            .field("disarm", &self.disarm())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Disarm {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Disarm {
+            disarm: super::vals::Disarm,
+        }
+        let proxy = Disarm {
+            disarm: self.disarm(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Lock(pub u32);
@@ -61,6 +97,22 @@ impl Default for Lock {
     #[inline(always)]
     fn default() -> Lock {
         Lock(0)
+    }
+}
+impl core::fmt::Debug for Lock {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Lock").field("lock", &self.lock()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Lock {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Lock {
+            lock: u8,
+        }
+        let proxy = Lock { lock: self.lock() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Adjust the sensitivity of glitch detectors to values other than their OTP-provided defaults. This register is Secure read/write only."]
@@ -172,6 +224,50 @@ impl Default for Sensitivity {
         Sensitivity(0)
     }
 }
+impl core::fmt::Debug for Sensitivity {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Sensitivity")
+            .field("det0", &self.det0())
+            .field("det1", &self.det1())
+            .field("det2", &self.det2())
+            .field("det3", &self.det3())
+            .field("det0_inv", &self.det0_inv())
+            .field("det1_inv", &self.det1_inv())
+            .field("det2_inv", &self.det2_inv())
+            .field("det3_inv", &self.det3_inv())
+            .field("default", &self.default())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sensitivity {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Sensitivity {
+            det0: u8,
+            det1: u8,
+            det2: u8,
+            det3: u8,
+            det0_inv: u8,
+            det1_inv: u8,
+            det2_inv: u8,
+            det3_inv: u8,
+            default: super::vals::Default,
+        }
+        let proxy = Sensitivity {
+            det0: self.det0(),
+            det1: self.det1(),
+            det2: self.det2(),
+            det3: self.det3(),
+            det0_inv: self.det0_inv(),
+            det1_inv: self.det1_inv(),
+            det2_inv: self.det2_inv(),
+            det3_inv: self.det3_inv(),
+            default: self.default(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Simulate the firing of one or more detectors. Writing ones to this register will set the matching bits in STATUS_TRIG. If the glitch detectors are currently armed, writing ones will also immediately reset the switched core power domain, and set the reset reason latches in POWMAN_CHIP_RESET to indicate a glitch detector resets. This register is Secure read/write only."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -191,6 +287,26 @@ impl Default for TrigForce {
     #[inline(always)]
     fn default() -> TrigForce {
         TrigForce(0)
+    }
+}
+impl core::fmt::Debug for TrigForce {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrigForce")
+            .field("trig_force", &self.trig_force())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrigForce {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrigForce {
+            trig_force: u8,
+        }
+        let proxy = TrigForce {
+            trig_force: self.trig_force(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Set when a detector output triggers. Write-1-clear. (May immediately return high if the detector remains in a failed state. Detectors can only be cleared by a full reset of the switched core power domain.) This register is Secure read/write only."]
@@ -239,5 +355,34 @@ impl Default for TrigStatus {
     #[inline(always)]
     fn default() -> TrigStatus {
         TrigStatus(0)
+    }
+}
+impl core::fmt::Debug for TrigStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrigStatus")
+            .field("det0", &self.det0())
+            .field("det1", &self.det1())
+            .field("det2", &self.det2())
+            .field("det3", &self.det3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrigStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrigStatus {
+            det0: bool,
+            det1: bool,
+            det2: bool,
+            det3: bool,
+        }
+        let proxy = TrigStatus {
+            det0: self.det0(),
+            det1: self.det1(),
+            det2: self.det2(),
+            det3: self.det3(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/glitch_detector/vals.rs
+++ b/src/rp235x/glitch_detector/vals.rs
@@ -15,6 +15,25 @@ impl Arm {
         self.0
     }
 }
+impl core::fmt::Debug for Arm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("YES"),
+            0x5bad => f.write_str("NO"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Arm {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "YES"),
+            0x5bad => defmt::write!(f, "NO"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Arm {
     #[inline(always)]
     fn from(val: u16) -> Arm {
@@ -44,6 +63,25 @@ impl Default {
         self.0
     }
 }
+impl core::fmt::Debug for Default {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("YES"),
+            0xde => f.write_str("NO"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Default {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "YES"),
+            0xde => defmt::write!(f, "NO"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u8> for Default {
     #[inline(always)]
     fn from(val: u8) -> Default {
@@ -71,6 +109,25 @@ impl Disarm {
     }
     pub const fn to_bits(self) -> u16 {
         self.0
+    }
+}
+impl core::fmt::Debug for Disarm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("NO"),
+            0xdcaf => f.write_str("YES"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Disarm {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "NO"),
+            0xdcaf => defmt::write!(f, "YES"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u16> for Disarm {

--- a/src/rp235x/hstx_ctrl.rs
+++ b/src/rp235x/hstx_ctrl.rs
@@ -20,7 +20,7 @@ impl HstxCtrl {
     }
     #[doc = "Data control register for output bit 0"]
     #[inline(always)]
-    pub const fn bit_(self, n: usize) -> crate::common::Reg<regs::Bit, crate::common::RW> {
+    pub const fn bit(self, n: usize) -> crate::common::Reg<regs::Bit, crate::common::RW> {
         assert!(n < 8usize);
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize + n * 4usize) as _) }
     }

--- a/src/rp235x/hstx_ctrl/regs.rs
+++ b/src/rp235x/hstx_ctrl/regs.rs
@@ -1,4 +1,4 @@
-#[doc = "Data control register for output bit 7"]
+#[doc = "Data control register for output bit 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Bit(pub u32);
@@ -52,6 +52,35 @@ impl Default for Bit {
     #[inline(always)]
     fn default() -> Bit {
         Bit(0)
+    }
+}
+impl core::fmt::Debug for Bit {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Bit")
+            .field("sel_p", &self.sel_p())
+            .field("sel_n", &self.sel_n())
+            .field("inv", &self.inv())
+            .field("clk", &self.clk())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bit {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Bit {
+            sel_p: u8,
+            sel_n: u8,
+            inv: bool,
+            clk: bool,
+        }
+        let proxy = Bit {
+            sel_p: self.sel_p(),
+            sel_n: self.sel_n(),
+            inv: self.inv(),
+            clk: self.clk(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -153,6 +182,47 @@ impl Default for Csr {
         Csr(0)
     }
 }
+impl core::fmt::Debug for Csr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Csr")
+            .field("en", &self.en())
+            .field("expand_en", &self.expand_en())
+            .field("coupled_mode", &self.coupled_mode())
+            .field("coupled_sel", &self.coupled_sel())
+            .field("shift", &self.shift())
+            .field("n_shifts", &self.n_shifts())
+            .field("clkphase", &self.clkphase())
+            .field("clkdiv", &self.clkdiv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Csr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Csr {
+            en: bool,
+            expand_en: bool,
+            coupled_mode: bool,
+            coupled_sel: u8,
+            shift: u8,
+            n_shifts: u8,
+            clkphase: u8,
+            clkdiv: u8,
+        }
+        let proxy = Csr {
+            en: self.en(),
+            expand_en: self.expand_en(),
+            coupled_mode: self.coupled_mode(),
+            coupled_sel: self.coupled_sel(),
+            shift: self.shift(),
+            n_shifts: self.n_shifts(),
+            clkphase: self.clkphase(),
+            clkdiv: self.clkdiv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Configure the optional shifter inside the command expander"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -207,6 +277,35 @@ impl Default for ExpandShift {
     #[inline(always)]
     fn default() -> ExpandShift {
         ExpandShift(0)
+    }
+}
+impl core::fmt::Debug for ExpandShift {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ExpandShift")
+            .field("raw_shift", &self.raw_shift())
+            .field("raw_n_shifts", &self.raw_n_shifts())
+            .field("enc_shift", &self.enc_shift())
+            .field("enc_n_shifts", &self.enc_n_shifts())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ExpandShift {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ExpandShift {
+            raw_shift: u8,
+            raw_n_shifts: u8,
+            enc_shift: u8,
+            enc_n_shifts: u8,
+        }
+        let proxy = ExpandShift {
+            raw_shift: self.raw_shift(),
+            raw_n_shifts: self.raw_n_shifts(),
+            enc_shift: self.enc_shift(),
+            enc_n_shifts: self.enc_n_shifts(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Configure the optional TMDS encoder inside the command expander"]
@@ -285,5 +384,40 @@ impl Default for ExpandTmds {
     #[inline(always)]
     fn default() -> ExpandTmds {
         ExpandTmds(0)
+    }
+}
+impl core::fmt::Debug for ExpandTmds {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ExpandTmds")
+            .field("l0_rot", &self.l0_rot())
+            .field("l0_nbits", &self.l0_nbits())
+            .field("l1_rot", &self.l1_rot())
+            .field("l1_nbits", &self.l1_nbits())
+            .field("l2_rot", &self.l2_rot())
+            .field("l2_nbits", &self.l2_nbits())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ExpandTmds {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ExpandTmds {
+            l0_rot: u8,
+            l0_nbits: u8,
+            l1_rot: u8,
+            l1_nbits: u8,
+            l2_rot: u8,
+            l2_nbits: u8,
+        }
+        let proxy = ExpandTmds {
+            l0_rot: self.l0_rot(),
+            l0_nbits: self.l0_nbits(),
+            l1_rot: self.l1_rot(),
+            l1_nbits: self.l1_nbits(),
+            l2_rot: self.l2_rot(),
+            l2_nbits: self.l2_nbits(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/hstx_fifo/regs.rs
+++ b/src/rp235x/hstx_fifo/regs.rs
@@ -48,3 +48,32 @@ impl Default for Stat {
         Stat(0)
     }
 }
+impl core::fmt::Debug for Stat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Stat")
+            .field("level", &self.level())
+            .field("full", &self.full())
+            .field("empty", &self.empty())
+            .field("wof", &self.wof())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Stat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Stat {
+            level: u8,
+            full: bool,
+            empty: bool,
+            wof: bool,
+        }
+        let proxy = Stat {
+            level: self.level(),
+            full: self.full(),
+            empty: self.empty(),
+            wof: self.wof(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}

--- a/src/rp235x/i2c/regs.rs
+++ b/src/rp235x/i2c/regs.rs
@@ -21,6 +21,26 @@ impl Default for IcAckGeneralCall {
         IcAckGeneralCall(0)
     }
 }
+impl core::fmt::Debug for IcAckGeneralCall {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcAckGeneralCall")
+            .field("ack_gen_call", &self.ack_gen_call())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcAckGeneralCall {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcAckGeneralCall {
+            ack_gen_call: bool,
+        }
+        let proxy = IcAckGeneralCall {
+            ack_gen_call: self.ack_gen_call(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear ACTIVITY Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42,6 +62,26 @@ impl Default for IcClrActivity {
     #[inline(always)]
     fn default() -> IcClrActivity {
         IcClrActivity(0)
+    }
+}
+impl core::fmt::Debug for IcClrActivity {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrActivity")
+            .field("clr_activity", &self.clr_activity())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrActivity {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrActivity {
+            clr_activity: bool,
+        }
+        let proxy = IcClrActivity {
+            clr_activity: self.clr_activity(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear GEN_CALL Interrupt Register"]
@@ -67,6 +107,26 @@ impl Default for IcClrGenCall {
         IcClrGenCall(0)
     }
 }
+impl core::fmt::Debug for IcClrGenCall {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrGenCall")
+            .field("clr_gen_call", &self.clr_gen_call())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrGenCall {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrGenCall {
+            clr_gen_call: bool,
+        }
+        let proxy = IcClrGenCall {
+            clr_gen_call: self.clr_gen_call(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear Combined and Individual Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +148,26 @@ impl Default for IcClrIntr {
     #[inline(always)]
     fn default() -> IcClrIntr {
         IcClrIntr(0)
+    }
+}
+impl core::fmt::Debug for IcClrIntr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrIntr")
+            .field("clr_intr", &self.clr_intr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrIntr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrIntr {
+            clr_intr: bool,
+        }
+        let proxy = IcClrIntr {
+            clr_intr: self.clr_intr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear RD_REQ Interrupt Register"]
@@ -113,6 +193,26 @@ impl Default for IcClrRdReq {
         IcClrRdReq(0)
     }
 }
+impl core::fmt::Debug for IcClrRdReq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRdReq")
+            .field("clr_rd_req", &self.clr_rd_req())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRdReq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRdReq {
+            clr_rd_req: bool,
+        }
+        let proxy = IcClrRdReq {
+            clr_rd_req: self.clr_rd_req(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear RESTART_DET Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -134,6 +234,26 @@ impl Default for IcClrRestartDet {
     #[inline(always)]
     fn default() -> IcClrRestartDet {
         IcClrRestartDet(0)
+    }
+}
+impl core::fmt::Debug for IcClrRestartDet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRestartDet")
+            .field("clr_restart_det", &self.clr_restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRestartDet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRestartDet {
+            clr_restart_det: bool,
+        }
+        let proxy = IcClrRestartDet {
+            clr_restart_det: self.clr_restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear RX_DONE Interrupt Register"]
@@ -159,6 +279,26 @@ impl Default for IcClrRxDone {
         IcClrRxDone(0)
     }
 }
+impl core::fmt::Debug for IcClrRxDone {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRxDone")
+            .field("clr_rx_done", &self.clr_rx_done())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRxDone {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRxDone {
+            clr_rx_done: bool,
+        }
+        let proxy = IcClrRxDone {
+            clr_rx_done: self.clr_rx_done(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear RX_OVER Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -180,6 +320,26 @@ impl Default for IcClrRxOver {
     #[inline(always)]
     fn default() -> IcClrRxOver {
         IcClrRxOver(0)
+    }
+}
+impl core::fmt::Debug for IcClrRxOver {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRxOver")
+            .field("clr_rx_over", &self.clr_rx_over())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRxOver {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRxOver {
+            clr_rx_over: bool,
+        }
+        let proxy = IcClrRxOver {
+            clr_rx_over: self.clr_rx_over(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear RX_UNDER Interrupt Register"]
@@ -205,6 +365,26 @@ impl Default for IcClrRxUnder {
         IcClrRxUnder(0)
     }
 }
+impl core::fmt::Debug for IcClrRxUnder {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrRxUnder")
+            .field("clr_rx_under", &self.clr_rx_under())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrRxUnder {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrRxUnder {
+            clr_rx_under: bool,
+        }
+        let proxy = IcClrRxUnder {
+            clr_rx_under: self.clr_rx_under(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear START_DET Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -226,6 +406,26 @@ impl Default for IcClrStartDet {
     #[inline(always)]
     fn default() -> IcClrStartDet {
         IcClrStartDet(0)
+    }
+}
+impl core::fmt::Debug for IcClrStartDet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrStartDet")
+            .field("clr_start_det", &self.clr_start_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrStartDet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrStartDet {
+            clr_start_det: bool,
+        }
+        let proxy = IcClrStartDet {
+            clr_start_det: self.clr_start_det(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear STOP_DET Interrupt Register"]
@@ -251,6 +451,26 @@ impl Default for IcClrStopDet {
         IcClrStopDet(0)
     }
 }
+impl core::fmt::Debug for IcClrStopDet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrStopDet")
+            .field("clr_stop_det", &self.clr_stop_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrStopDet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrStopDet {
+            clr_stop_det: bool,
+        }
+        let proxy = IcClrStopDet {
+            clr_stop_det: self.clr_stop_det(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear TX_ABRT Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -274,6 +494,26 @@ impl Default for IcClrTxAbrt {
         IcClrTxAbrt(0)
     }
 }
+impl core::fmt::Debug for IcClrTxAbrt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrTxAbrt")
+            .field("clr_tx_abrt", &self.clr_tx_abrt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrTxAbrt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrTxAbrt {
+            clr_tx_abrt: bool,
+        }
+        let proxy = IcClrTxAbrt {
+            clr_tx_abrt: self.clr_tx_abrt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Clear TX_OVER Interrupt Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -295,6 +535,26 @@ impl Default for IcClrTxOver {
     #[inline(always)]
     fn default() -> IcClrTxOver {
         IcClrTxOver(0)
+    }
+}
+impl core::fmt::Debug for IcClrTxOver {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcClrTxOver")
+            .field("clr_tx_over", &self.clr_tx_over())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcClrTxOver {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcClrTxOver {
+            clr_tx_over: bool,
+        }
+        let proxy = IcClrTxOver {
+            clr_tx_over: self.clr_tx_over(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Component Parameter Register 1 Note This register is not implemented and therefore reads as 0. If it was implemented it would be a constant read-only register that contains encoded information about the component's parameter settings. Fields shown below are the settings for those parameters"]
@@ -395,6 +655,47 @@ impl Default for IcCompParam1 {
     #[inline(always)]
     fn default() -> IcCompParam1 {
         IcCompParam1(0)
+    }
+}
+impl core::fmt::Debug for IcCompParam1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcCompParam1")
+            .field("apb_data_width", &self.apb_data_width())
+            .field("max_speed_mode", &self.max_speed_mode())
+            .field("hc_count_values", &self.hc_count_values())
+            .field("intr_io", &self.intr_io())
+            .field("has_dma", &self.has_dma())
+            .field("add_encoded_params", &self.add_encoded_params())
+            .field("rx_buffer_depth", &self.rx_buffer_depth())
+            .field("tx_buffer_depth", &self.tx_buffer_depth())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcCompParam1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcCompParam1 {
+            apb_data_width: u8,
+            max_speed_mode: u8,
+            hc_count_values: bool,
+            intr_io: bool,
+            has_dma: bool,
+            add_encoded_params: bool,
+            rx_buffer_depth: u8,
+            tx_buffer_depth: u8,
+        }
+        let proxy = IcCompParam1 {
+            apb_data_width: self.apb_data_width(),
+            max_speed_mode: self.max_speed_mode(),
+            hc_count_values: self.hc_count_values(),
+            intr_io: self.intr_io(),
+            has_dma: self.has_dma(),
+            add_encoded_params: self.add_encoded_params(),
+            rx_buffer_depth: self.rx_buffer_depth(),
+            tx_buffer_depth: self.tx_buffer_depth(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Control Register. This register can be written only when the DW_apb_i2c is disabled, which corresponds to the IC_ENABLE\\[0\\] register being set to 0. Writes at other times have no effect. Read/Write Access: - bit 10 is read only. - bit 11 is read only - bit 16 is read only - bit 17 is read only - bits 18 and 19 are read only."]
@@ -519,6 +820,56 @@ impl Default for IcCon {
         IcCon(0)
     }
 }
+impl core::fmt::Debug for IcCon {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcCon")
+            .field("master_mode", &self.master_mode())
+            .field("speed", &self.speed())
+            .field("ic_10bitaddr_slave", &self.ic_10bitaddr_slave())
+            .field("ic_10bitaddr_master", &self.ic_10bitaddr_master())
+            .field("ic_restart_en", &self.ic_restart_en())
+            .field("ic_slave_disable", &self.ic_slave_disable())
+            .field("stop_det_ifaddressed", &self.stop_det_ifaddressed())
+            .field("tx_empty_ctrl", &self.tx_empty_ctrl())
+            .field("rx_fifo_full_hld_ctrl", &self.rx_fifo_full_hld_ctrl())
+            .field(
+                "stop_det_if_master_active",
+                &self.stop_det_if_master_active(),
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcCon {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcCon {
+            master_mode: bool,
+            speed: super::vals::Speed,
+            ic_10bitaddr_slave: bool,
+            ic_10bitaddr_master: bool,
+            ic_restart_en: bool,
+            ic_slave_disable: bool,
+            stop_det_ifaddressed: bool,
+            tx_empty_ctrl: bool,
+            rx_fifo_full_hld_ctrl: bool,
+            stop_det_if_master_active: bool,
+        }
+        let proxy = IcCon {
+            master_mode: self.master_mode(),
+            speed: self.speed(),
+            ic_10bitaddr_slave: self.ic_10bitaddr_slave(),
+            ic_10bitaddr_master: self.ic_10bitaddr_master(),
+            ic_restart_en: self.ic_restart_en(),
+            ic_slave_disable: self.ic_slave_disable(),
+            stop_det_ifaddressed: self.stop_det_ifaddressed(),
+            tx_empty_ctrl: self.tx_empty_ctrl(),
+            rx_fifo_full_hld_ctrl: self.rx_fifo_full_hld_ctrl(),
+            stop_det_if_master_active: self.stop_det_if_master_active(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Rx/Tx Data Buffer and Command Register; this is the register the CPU writes to when filling the TX FIFO and the CPU reads from when retrieving bytes from RX FIFO. The size of the register changes as follows: Write: - 11 bits when IC_EMPTYFIFO_HOLD_MASTER_EN=1 - 9 bits when IC_EMPTYFIFO_HOLD_MASTER_EN=0 Read: - 12 bits when IC_FIRST_DATA_BYTE_STATUS = 1 - 8 bits when IC_FIRST_DATA_BYTE_STATUS = 0 Note: In order for the DW_apb_i2c to continue acknowledging reads, a read command should be written for every byte that is to be received; otherwise the DW_apb_i2c will stop acknowledging."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -586,6 +937,38 @@ impl Default for IcDataCmd {
         IcDataCmd(0)
     }
 }
+impl core::fmt::Debug for IcDataCmd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDataCmd")
+            .field("dat", &self.dat())
+            .field("cmd", &self.cmd())
+            .field("stop", &self.stop())
+            .field("restart", &self.restart())
+            .field("first_data_byte", &self.first_data_byte())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDataCmd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDataCmd {
+            dat: u8,
+            cmd: bool,
+            stop: bool,
+            restart: bool,
+            first_data_byte: bool,
+        }
+        let proxy = IcDataCmd {
+            dat: self.dat(),
+            cmd: self.cmd(),
+            stop: self.stop(),
+            restart: self.restart(),
+            first_data_byte: self.first_data_byte(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA Control Register The register is used to enable the DMA Controller interface operation. There is a separate bit for transmit and receive. This can be programmed regardless of the state of IC_ENABLE."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -620,6 +1003,29 @@ impl Default for IcDmaCr {
         IcDmaCr(0)
     }
 }
+impl core::fmt::Debug for IcDmaCr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDmaCr")
+            .field("rdmae", &self.rdmae())
+            .field("tdmae", &self.tdmae())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDmaCr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDmaCr {
+            rdmae: bool,
+            tdmae: bool,
+        }
+        let proxy = IcDmaCr {
+            rdmae: self.rdmae(),
+            tdmae: self.tdmae(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Receive Data Level Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -643,6 +1049,26 @@ impl Default for IcDmaRdlr {
         IcDmaRdlr(0)
     }
 }
+impl core::fmt::Debug for IcDmaRdlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDmaRdlr")
+            .field("dmardl", &self.dmardl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDmaRdlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDmaRdlr {
+            dmardl: u8,
+        }
+        let proxy = IcDmaRdlr {
+            dmardl: self.dmardl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA Transmit Data Level Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -664,6 +1090,26 @@ impl Default for IcDmaTdlr {
     #[inline(always)]
     fn default() -> IcDmaTdlr {
         IcDmaTdlr(0)
+    }
+}
+impl core::fmt::Debug for IcDmaTdlr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcDmaTdlr")
+            .field("dmatdl", &self.dmatdl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcDmaTdlr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcDmaTdlr {
+            dmatdl: u8,
+        }
+        let proxy = IcDmaTdlr {
+            dmatdl: self.dmatdl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Enable Register"]
@@ -711,6 +1157,32 @@ impl Default for IcEnable {
         IcEnable(0)
     }
 }
+impl core::fmt::Debug for IcEnable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcEnable")
+            .field("enable", &self.enable())
+            .field("abort", &self.abort())
+            .field("tx_cmd_block", &self.tx_cmd_block())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcEnable {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcEnable {
+            enable: bool,
+            abort: bool,
+            tx_cmd_block: bool,
+        }
+        let proxy = IcEnable {
+            enable: self.enable(),
+            abort: self.abort(),
+            tx_cmd_block: self.tx_cmd_block(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Enable Status Register The register is used to report the DW_apb_i2c hardware status when the IC_ENABLE\\[0\\] register is set from 1 to 0; that is, when DW_apb_i2c is disabled. If IC_ENABLE\\[0\\] has been set to 1, bits 2:1 are forced to 0, and bit 0 is forced to 1. If IC_ENABLE\\[0\\] has been set to 0, bits 2:1 is only be valid as soon as bit 0 is read as '0'. Note: When IC_ENABLE\\[0\\] has been set to 0, a delay occurs for bit 0 to be read as 0 because disabling the DW_apb_i2c depends on I2C bus activities."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -756,6 +1228,32 @@ impl Default for IcEnableStatus {
         IcEnableStatus(0)
     }
 }
+impl core::fmt::Debug for IcEnableStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcEnableStatus")
+            .field("ic_en", &self.ic_en())
+            .field("slv_disabled_while_busy", &self.slv_disabled_while_busy())
+            .field("slv_rx_data_lost", &self.slv_rx_data_lost())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcEnableStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcEnableStatus {
+            ic_en: bool,
+            slv_disabled_while_busy: bool,
+            slv_rx_data_lost: bool,
+        }
+        let proxy = IcEnableStatus {
+            ic_en: self.ic_en(),
+            slv_disabled_while_busy: self.slv_disabled_while_busy(),
+            slv_rx_data_lost: self.slv_rx_data_lost(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Fast Mode or Fast Mode Plus I2C Clock SCL High Count Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -777,6 +1275,26 @@ impl Default for IcFsSclHcnt {
     #[inline(always)]
     fn default() -> IcFsSclHcnt {
         IcFsSclHcnt(0)
+    }
+}
+impl core::fmt::Debug for IcFsSclHcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcFsSclHcnt")
+            .field("ic_fs_scl_hcnt", &self.ic_fs_scl_hcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcFsSclHcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcFsSclHcnt {
+            ic_fs_scl_hcnt: u16,
+        }
+        let proxy = IcFsSclHcnt {
+            ic_fs_scl_hcnt: self.ic_fs_scl_hcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Fast Mode or Fast Mode Plus I2C Clock SCL Low Count Register"]
@@ -802,6 +1320,26 @@ impl Default for IcFsSclLcnt {
         IcFsSclLcnt(0)
     }
 }
+impl core::fmt::Debug for IcFsSclLcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcFsSclLcnt")
+            .field("ic_fs_scl_lcnt", &self.ic_fs_scl_lcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcFsSclLcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcFsSclLcnt {
+            ic_fs_scl_lcnt: u16,
+        }
+        let proxy = IcFsSclLcnt {
+            ic_fs_scl_lcnt: self.ic_fs_scl_lcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C SS, FS or FM+ spike suppression limit This register is used to store the duration, measured in ic_clk cycles, of the longest spike that is filtered out by the spike suppression logic when the component is operating in SS, FS or FM+ modes. The relevant I2C requirement is tSP (table 4) as detailed in the I2C Bus Specification. This register must be programmed with a minimum value of 1."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -823,6 +1361,26 @@ impl Default for IcFsSpklen {
     #[inline(always)]
     fn default() -> IcFsSpklen {
         IcFsSpklen(0)
+    }
+}
+impl core::fmt::Debug for IcFsSpklen {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcFsSpklen")
+            .field("ic_fs_spklen", &self.ic_fs_spklen())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcFsSpklen {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcFsSpklen {
+            ic_fs_spklen: u8,
+        }
+        let proxy = IcFsSpklen {
+            ic_fs_spklen: self.ic_fs_spklen(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Interrupt Mask Register. These bits mask their corresponding interrupt status bits. This register is active low; a value of 0 masks the interrupt, whereas a value of 1 unmasks the interrupt."]
@@ -980,6 +1538,62 @@ impl Default for IcIntrMask {
         IcIntrMask(0)
     }
 }
+impl core::fmt::Debug for IcIntrMask {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcIntrMask")
+            .field("m_rx_under", &self.m_rx_under())
+            .field("m_rx_over", &self.m_rx_over())
+            .field("m_rx_full", &self.m_rx_full())
+            .field("m_tx_over", &self.m_tx_over())
+            .field("m_tx_empty", &self.m_tx_empty())
+            .field("m_rd_req", &self.m_rd_req())
+            .field("m_tx_abrt", &self.m_tx_abrt())
+            .field("m_rx_done", &self.m_rx_done())
+            .field("m_activity", &self.m_activity())
+            .field("m_stop_det", &self.m_stop_det())
+            .field("m_start_det", &self.m_start_det())
+            .field("m_gen_call", &self.m_gen_call())
+            .field("m_restart_det", &self.m_restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcIntrMask {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcIntrMask {
+            m_rx_under: bool,
+            m_rx_over: bool,
+            m_rx_full: bool,
+            m_tx_over: bool,
+            m_tx_empty: bool,
+            m_rd_req: bool,
+            m_tx_abrt: bool,
+            m_rx_done: bool,
+            m_activity: bool,
+            m_stop_det: bool,
+            m_start_det: bool,
+            m_gen_call: bool,
+            m_restart_det: bool,
+        }
+        let proxy = IcIntrMask {
+            m_rx_under: self.m_rx_under(),
+            m_rx_over: self.m_rx_over(),
+            m_rx_full: self.m_rx_full(),
+            m_tx_over: self.m_tx_over(),
+            m_tx_empty: self.m_tx_empty(),
+            m_rd_req: self.m_rd_req(),
+            m_tx_abrt: self.m_tx_abrt(),
+            m_rx_done: self.m_rx_done(),
+            m_activity: self.m_activity(),
+            m_stop_det: self.m_stop_det(),
+            m_start_det: self.m_start_det(),
+            m_gen_call: self.m_gen_call(),
+            m_restart_det: self.m_restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Interrupt Status Register Each bit in this register has a corresponding mask bit in the IC_INTR_MASK register. These bits are cleared by reading the matching interrupt clear register. The unmasked raw versions of these bits are available in the IC_RAW_INTR_STAT register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1133,6 +1747,62 @@ impl Default for IcIntrStat {
     #[inline(always)]
     fn default() -> IcIntrStat {
         IcIntrStat(0)
+    }
+}
+impl core::fmt::Debug for IcIntrStat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcIntrStat")
+            .field("r_rx_under", &self.r_rx_under())
+            .field("r_rx_over", &self.r_rx_over())
+            .field("r_rx_full", &self.r_rx_full())
+            .field("r_tx_over", &self.r_tx_over())
+            .field("r_tx_empty", &self.r_tx_empty())
+            .field("r_rd_req", &self.r_rd_req())
+            .field("r_tx_abrt", &self.r_tx_abrt())
+            .field("r_rx_done", &self.r_rx_done())
+            .field("r_activity", &self.r_activity())
+            .field("r_stop_det", &self.r_stop_det())
+            .field("r_start_det", &self.r_start_det())
+            .field("r_gen_call", &self.r_gen_call())
+            .field("r_restart_det", &self.r_restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcIntrStat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcIntrStat {
+            r_rx_under: bool,
+            r_rx_over: bool,
+            r_rx_full: bool,
+            r_tx_over: bool,
+            r_tx_empty: bool,
+            r_rd_req: bool,
+            r_tx_abrt: bool,
+            r_rx_done: bool,
+            r_activity: bool,
+            r_stop_det: bool,
+            r_start_det: bool,
+            r_gen_call: bool,
+            r_restart_det: bool,
+        }
+        let proxy = IcIntrStat {
+            r_rx_under: self.r_rx_under(),
+            r_rx_over: self.r_rx_over(),
+            r_rx_full: self.r_rx_full(),
+            r_tx_over: self.r_tx_over(),
+            r_tx_empty: self.r_tx_empty(),
+            r_rd_req: self.r_rd_req(),
+            r_tx_abrt: self.r_tx_abrt(),
+            r_rx_done: self.r_rx_done(),
+            r_activity: self.r_activity(),
+            r_stop_det: self.r_stop_det(),
+            r_start_det: self.r_start_det(),
+            r_gen_call: self.r_gen_call(),
+            r_restart_det: self.r_restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Raw Interrupt Status Register Unlike the IC_INTR_STAT register, these bits are not masked so they always show the true status of the DW_apb_i2c."]
@@ -1290,6 +1960,62 @@ impl Default for IcRawIntrStat {
         IcRawIntrStat(0)
     }
 }
+impl core::fmt::Debug for IcRawIntrStat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcRawIntrStat")
+            .field("rx_under", &self.rx_under())
+            .field("rx_over", &self.rx_over())
+            .field("rx_full", &self.rx_full())
+            .field("tx_over", &self.tx_over())
+            .field("tx_empty", &self.tx_empty())
+            .field("rd_req", &self.rd_req())
+            .field("tx_abrt", &self.tx_abrt())
+            .field("rx_done", &self.rx_done())
+            .field("activity", &self.activity())
+            .field("stop_det", &self.stop_det())
+            .field("start_det", &self.start_det())
+            .field("gen_call", &self.gen_call())
+            .field("restart_det", &self.restart_det())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcRawIntrStat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcRawIntrStat {
+            rx_under: bool,
+            rx_over: bool,
+            rx_full: bool,
+            tx_over: bool,
+            tx_empty: bool,
+            rd_req: bool,
+            tx_abrt: bool,
+            rx_done: bool,
+            activity: bool,
+            stop_det: bool,
+            start_det: bool,
+            gen_call: bool,
+            restart_det: bool,
+        }
+        let proxy = IcRawIntrStat {
+            rx_under: self.rx_under(),
+            rx_over: self.rx_over(),
+            rx_full: self.rx_full(),
+            tx_over: self.tx_over(),
+            tx_empty: self.tx_empty(),
+            rd_req: self.rd_req(),
+            tx_abrt: self.tx_abrt(),
+            rx_done: self.rx_done(),
+            activity: self.activity(),
+            stop_det: self.stop_det(),
+            start_det: self.start_det(),
+            gen_call: self.gen_call(),
+            restart_det: self.restart_det(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Receive FIFO Threshold Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1311,6 +2037,26 @@ impl Default for IcRxTl {
     #[inline(always)]
     fn default() -> IcRxTl {
         IcRxTl(0)
+    }
+}
+impl core::fmt::Debug for IcRxTl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcRxTl")
+            .field("rx_tl", &self.rx_tl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcRxTl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcRxTl {
+            rx_tl: u8,
+        }
+        let proxy = IcRxTl {
+            rx_tl: self.rx_tl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Receive FIFO Level Register This register contains the number of valid data entries in the receive FIFO buffer. It is cleared whenever: - The I2C is disabled - Whenever there is a transmit abort caused by any of the events tracked in IC_TX_ABRT_SOURCE The register increments whenever data is placed into the receive FIFO and decrements when data is taken from the receive FIFO."]
@@ -1336,6 +2082,26 @@ impl Default for IcRxflr {
         IcRxflr(0)
     }
 }
+impl core::fmt::Debug for IcRxflr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcRxflr")
+            .field("rxflr", &self.rxflr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcRxflr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcRxflr {
+            rxflr: u8,
+        }
+        let proxy = IcRxflr {
+            rxflr: self.rxflr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Slave Address Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1357,6 +2123,26 @@ impl Default for IcSar {
     #[inline(always)]
     fn default() -> IcSar {
         IcSar(0)
+    }
+}
+impl core::fmt::Debug for IcSar {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSar")
+            .field("ic_sar", &self.ic_sar())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSar {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSar {
+            ic_sar: u16,
+        }
+        let proxy = IcSar {
+            ic_sar: self.ic_sar(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C SDA Hold Time Length Register The bits \\[15:0\\] of this register are used to control the hold time of SDA during transmit in both slave and master mode (after SCL goes from HIGH to LOW). The bits \\[23:16\\] of this register are used to extend the SDA transition (if any) whenever SCL is HIGH in the receiver in either master or slave mode. Writes to this register succeed only when IC_ENABLE\\[0\\]=0. The values in this register are in units of ic_clk period. The value programmed in IC_SDA_TX_HOLD must be greater than the minimum hold time in each mode (one cycle in master mode, seven cycles in slave mode) for the value to be implemented. The programmed SDA hold time during transmit (IC_SDA_TX_HOLD) cannot exceed at any time the duration of the low part of scl. Therefore the programmed value cannot be larger than N_SCL_LOW-2, where N_SCL_LOW is the duration of the low part of the scl period measured in ic_clk cycles."]
@@ -1393,6 +2179,29 @@ impl Default for IcSdaHold {
         IcSdaHold(0)
     }
 }
+impl core::fmt::Debug for IcSdaHold {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSdaHold")
+            .field("ic_sda_tx_hold", &self.ic_sda_tx_hold())
+            .field("ic_sda_rx_hold", &self.ic_sda_rx_hold())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSdaHold {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSdaHold {
+            ic_sda_tx_hold: u16,
+            ic_sda_rx_hold: u8,
+        }
+        let proxy = IcSdaHold {
+            ic_sda_tx_hold: self.ic_sda_tx_hold(),
+            ic_sda_rx_hold: self.ic_sda_rx_hold(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C SDA Setup Register This register controls the amount of time delay (in terms of number of ic_clk clock periods) introduced in the rising edge of SCL - relative to SDA changing - when DW_apb_i2c services a read request in a slave-transmitter operation. The relevant I2C requirement is tSU:DAT (note 4) as detailed in the I2C Bus Specification. This register must be programmed with a value equal to or greater than 2. Writes to this register succeed only when IC_ENABLE\\[0\\] = 0. Note: The length of setup time is calculated using \\[(IC_SDA_SETUP - 1) * (ic_clk_period)\\], so if the user requires 10 ic_clk periods of setup time, they should program a value of 11. The IC_SDA_SETUP register is only used by the DW_apb_i2c when operating as a slave transmitter."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1414,6 +2223,26 @@ impl Default for IcSdaSetup {
     #[inline(always)]
     fn default() -> IcSdaSetup {
         IcSdaSetup(0)
+    }
+}
+impl core::fmt::Debug for IcSdaSetup {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSdaSetup")
+            .field("sda_setup", &self.sda_setup())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSdaSetup {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSdaSetup {
+            sda_setup: u8,
+        }
+        let proxy = IcSdaSetup {
+            sda_setup: self.sda_setup(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Generate Slave Data NACK Register The register is used to generate a NACK for the data part of a transfer when DW_apb_i2c is acting as a slave-receiver. This register only exists when the IC_SLV_DATA_NACK_ONLY parameter is set to 1. When this parameter disabled, this register does not exist and writing to the register's address has no effect. A write can occur on this register if both of the following conditions are met: - DW_apb_i2c is disabled (IC_ENABLE\\[0\\] = 0) - Slave part is inactive (IC_STATUS\\[6\\] = 0) Note: The IC_STATUS\\[6\\] is a register read-back location for the internal slv_activity signal; the user should poll this before writing the ic_slv_data_nack_only bit."]
@@ -1439,6 +2268,24 @@ impl Default for IcSlvDataNackOnly {
         IcSlvDataNackOnly(0)
     }
 }
+impl core::fmt::Debug for IcSlvDataNackOnly {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSlvDataNackOnly")
+            .field("nack", &self.nack())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSlvDataNackOnly {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSlvDataNackOnly {
+            nack: bool,
+        }
+        let proxy = IcSlvDataNackOnly { nack: self.nack() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Standard Speed I2C Clock SCL High Count Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1462,6 +2309,26 @@ impl Default for IcSsSclHcnt {
         IcSsSclHcnt(0)
     }
 }
+impl core::fmt::Debug for IcSsSclHcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSsSclHcnt")
+            .field("ic_ss_scl_hcnt", &self.ic_ss_scl_hcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSsSclHcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSsSclHcnt {
+            ic_ss_scl_hcnt: u16,
+        }
+        let proxy = IcSsSclHcnt {
+            ic_ss_scl_hcnt: self.ic_ss_scl_hcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Standard Speed I2C Clock SCL Low Count Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1483,6 +2350,26 @@ impl Default for IcSsSclLcnt {
     #[inline(always)]
     fn default() -> IcSsSclLcnt {
         IcSsSclLcnt(0)
+    }
+}
+impl core::fmt::Debug for IcSsSclLcnt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcSsSclLcnt")
+            .field("ic_ss_scl_lcnt", &self.ic_ss_scl_lcnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcSsSclLcnt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcSsSclLcnt {
+            ic_ss_scl_lcnt: u16,
+        }
+        let proxy = IcSsSclLcnt {
+            ic_ss_scl_lcnt: self.ic_ss_scl_lcnt(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Status Register This is a read-only register used to indicate the current transfer status and FIFO status. The status register may be read at any time. None of the bits in this register request an interrupt. When the I2C is disabled by writing 0 in bit 0 of the IC_ENABLE register: - Bits 1 and 2 are set to 1 - Bits 3 and 10 are set to 0 When the master or slave state machines goes to idle and ic_en=0: - Bits 5 and 6 are set to 0"]
@@ -1574,6 +2461,44 @@ impl Default for IcStatus {
         IcStatus(0)
     }
 }
+impl core::fmt::Debug for IcStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcStatus")
+            .field("activity", &self.activity())
+            .field("tfnf", &self.tfnf())
+            .field("tfe", &self.tfe())
+            .field("rfne", &self.rfne())
+            .field("rff", &self.rff())
+            .field("mst_activity", &self.mst_activity())
+            .field("slv_activity", &self.slv_activity())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcStatus {
+            activity: bool,
+            tfnf: bool,
+            tfe: bool,
+            rfne: bool,
+            rff: bool,
+            mst_activity: bool,
+            slv_activity: bool,
+        }
+        let proxy = IcStatus {
+            activity: self.activity(),
+            tfnf: self.tfnf(),
+            tfe: self.tfe(),
+            rfne: self.rfne(),
+            rff: self.rff(),
+            mst_activity: self.mst_activity(),
+            slv_activity: self.slv_activity(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Target Address Register This register is 12 bits wide, and bits 31:12 are reserved. This register can be written to only when IC_ENABLE\\[0\\] is set to 0. Note: If the software or application is aware that the DW_apb_i2c is not using the TAR address for the pending commands in the Tx FIFO, then it is possible to update the TAR address even while the Tx FIFO has entries (IC_STATUS\\[2\\]= 0). - It is not necessary to perform any write to this register if DW_apb_i2c is enabled as an I2C slave only."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1617,6 +2542,32 @@ impl Default for IcTar {
     #[inline(always)]
     fn default() -> IcTar {
         IcTar(0)
+    }
+}
+impl core::fmt::Debug for IcTar {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTar")
+            .field("ic_tar", &self.ic_tar())
+            .field("gc_or_start", &self.gc_or_start())
+            .field("special", &self.special())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTar {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTar {
+            ic_tar: u16,
+            gc_or_start: bool,
+            special: bool,
+        }
+        let proxy = IcTar {
+            ic_tar: self.ic_tar(),
+            gc_or_start: self.gc_or_start(),
+            special: self.special(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "I2C Transmit Abort Source Register This register has 32 bits that indicate the source of the TX_ABRT bit. Except for Bit 9, this register is cleared whenever the IC_CLR_TX_ABRT register or the IC_CLR_INTR register is read. To clear Bit 9, the source of the ABRT_SBYTE_NORSTRT must be fixed first; RESTART must be enabled (IC_CON\\[5\\]=1), the SPECIAL bit must be cleared (IC_TAR\\[11\\]), or the GC_OR_START bit must be cleared (IC_TAR\\[10\\]). Once the source of the ABRT_SBYTE_NORSTRT is fixed, then this bit can be cleared in the same manner as other bits in this register. If the source of the ABRT_SBYTE_NORSTRT is not fixed before attempting to clear this bit, Bit 9 clears for one cycle and is then re-asserted."]
@@ -1829,6 +2780,77 @@ impl Default for IcTxAbrtSource {
         IcTxAbrtSource(0)
     }
 }
+impl core::fmt::Debug for IcTxAbrtSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTxAbrtSource")
+            .field("abrt_7b_addr_noack", &self.abrt_7b_addr_noack())
+            .field("abrt_10addr1_noack", &self.abrt_10addr1_noack())
+            .field("abrt_10addr2_noack", &self.abrt_10addr2_noack())
+            .field("abrt_txdata_noack", &self.abrt_txdata_noack())
+            .field("abrt_gcall_noack", &self.abrt_gcall_noack())
+            .field("abrt_gcall_read", &self.abrt_gcall_read())
+            .field("abrt_hs_ackdet", &self.abrt_hs_ackdet())
+            .field("abrt_sbyte_ackdet", &self.abrt_sbyte_ackdet())
+            .field("abrt_hs_norstrt", &self.abrt_hs_norstrt())
+            .field("abrt_sbyte_norstrt", &self.abrt_sbyte_norstrt())
+            .field("abrt_10b_rd_norstrt", &self.abrt_10b_rd_norstrt())
+            .field("abrt_master_dis", &self.abrt_master_dis())
+            .field("arb_lost", &self.arb_lost())
+            .field("abrt_slvflush_txfifo", &self.abrt_slvflush_txfifo())
+            .field("abrt_slv_arblost", &self.abrt_slv_arblost())
+            .field("abrt_slvrd_intx", &self.abrt_slvrd_intx())
+            .field("abrt_user_abrt", &self.abrt_user_abrt())
+            .field("tx_flush_cnt", &self.tx_flush_cnt())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTxAbrtSource {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTxAbrtSource {
+            abrt_7b_addr_noack: bool,
+            abrt_10addr1_noack: bool,
+            abrt_10addr2_noack: bool,
+            abrt_txdata_noack: bool,
+            abrt_gcall_noack: bool,
+            abrt_gcall_read: bool,
+            abrt_hs_ackdet: bool,
+            abrt_sbyte_ackdet: bool,
+            abrt_hs_norstrt: bool,
+            abrt_sbyte_norstrt: bool,
+            abrt_10b_rd_norstrt: bool,
+            abrt_master_dis: bool,
+            arb_lost: bool,
+            abrt_slvflush_txfifo: bool,
+            abrt_slv_arblost: bool,
+            abrt_slvrd_intx: bool,
+            abrt_user_abrt: bool,
+            tx_flush_cnt: u16,
+        }
+        let proxy = IcTxAbrtSource {
+            abrt_7b_addr_noack: self.abrt_7b_addr_noack(),
+            abrt_10addr1_noack: self.abrt_10addr1_noack(),
+            abrt_10addr2_noack: self.abrt_10addr2_noack(),
+            abrt_txdata_noack: self.abrt_txdata_noack(),
+            abrt_gcall_noack: self.abrt_gcall_noack(),
+            abrt_gcall_read: self.abrt_gcall_read(),
+            abrt_hs_ackdet: self.abrt_hs_ackdet(),
+            abrt_sbyte_ackdet: self.abrt_sbyte_ackdet(),
+            abrt_hs_norstrt: self.abrt_hs_norstrt(),
+            abrt_sbyte_norstrt: self.abrt_sbyte_norstrt(),
+            abrt_10b_rd_norstrt: self.abrt_10b_rd_norstrt(),
+            abrt_master_dis: self.abrt_master_dis(),
+            arb_lost: self.arb_lost(),
+            abrt_slvflush_txfifo: self.abrt_slvflush_txfifo(),
+            abrt_slv_arblost: self.abrt_slv_arblost(),
+            abrt_slvrd_intx: self.abrt_slvrd_intx(),
+            abrt_user_abrt: self.abrt_user_abrt(),
+            tx_flush_cnt: self.tx_flush_cnt(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Transmit FIFO Threshold Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1852,6 +2874,26 @@ impl Default for IcTxTl {
         IcTxTl(0)
     }
 }
+impl core::fmt::Debug for IcTxTl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTxTl")
+            .field("tx_tl", &self.tx_tl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTxTl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTxTl {
+            tx_tl: u8,
+        }
+        let proxy = IcTxTl {
+            tx_tl: self.tx_tl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "I2C Transmit FIFO Level Register This register contains the number of valid data entries in the transmit FIFO buffer. It is cleared whenever: - The I2C is disabled - There is a transmit abort - that is, TX_ABRT bit is set in the IC_RAW_INTR_STAT register - The slave bulk transmit mode is aborted The register increments whenever data is placed into the transmit FIFO and decrements when data is taken from the transmit FIFO."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1873,5 +2915,25 @@ impl Default for IcTxflr {
     #[inline(always)]
     fn default() -> IcTxflr {
         IcTxflr(0)
+    }
+}
+impl core::fmt::Debug for IcTxflr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IcTxflr")
+            .field("txflr", &self.txflr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IcTxflr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IcTxflr {
+            txflr: u8,
+        }
+        let proxy = IcTxflr {
+            txflr: self.txflr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/i2c/vals.rs
+++ b/src/rp235x/i2c/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Speed {
     _RESERVED_0 = 0x0,
     #[doc = "Standard Speed mode of operation"]

--- a/src/rp235x/io.rs
+++ b/src/rp235x/io.rs
@@ -37,19 +37,19 @@ impl Int {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "Interrupt Enable for proc0"]
+    #[doc = "Interrupt Enable for proc1"]
     #[inline(always)]
     pub const fn inte(self, n: usize) -> crate::common::Reg<regs::Int, crate::common::RW> {
         assert!(n < 6usize);
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize + n * 4usize) as _) }
     }
-    #[doc = "Interrupt Force for proc0"]
+    #[doc = "Interrupt Force for proc1"]
     #[inline(always)]
     pub const fn intf(self, n: usize) -> crate::common::Reg<regs::Int, crate::common::RW> {
         assert!(n < 6usize);
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x18usize + n * 4usize) as _) }
     }
-    #[doc = "Interrupt status after masking & forcing for proc0"]
+    #[doc = "Interrupt status after masking & forcing for proc1"]
     #[inline(always)]
     pub const fn ints(self, n: usize) -> crate::common::Reg<regs::Int, crate::common::RW> {
         assert!(n < 6usize);

--- a/src/rp235x/io/regs.rs
+++ b/src/rp235x/io/regs.rs
@@ -56,6 +56,38 @@ impl Default for GpioCtrl {
         GpioCtrl(0)
     }
 }
+impl core::fmt::Debug for GpioCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioCtrl")
+            .field("funcsel", &self.funcsel())
+            .field("outover", &self.outover())
+            .field("oeover", &self.oeover())
+            .field("inover", &self.inover())
+            .field("irqover", &self.irqover())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioCtrl {
+            funcsel: u8,
+            outover: super::vals::Outover,
+            oeover: super::vals::Oeover,
+            inover: super::vals::Inover,
+            irqover: super::vals::Irqover,
+        }
+        let proxy = GpioCtrl {
+            funcsel: self.funcsel(),
+            outover: self.outover(),
+            oeover: self.oeover(),
+            inover: self.inover(),
+            irqover: self.irqover(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct GpioStatus(pub u32);
@@ -111,7 +143,36 @@ impl Default for GpioStatus {
         GpioStatus(0)
     }
 }
-#[doc = "Interrupt status after masking & forcing for proc0"]
+impl core::fmt::Debug for GpioStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioStatus")
+            .field("outtopad", &self.outtopad())
+            .field("oetopad", &self.oetopad())
+            .field("infrompad", &self.infrompad())
+            .field("irqtoproc", &self.irqtoproc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioStatus {
+            outtopad: bool,
+            oetopad: bool,
+            infrompad: bool,
+            irqtoproc: bool,
+        }
+        let proxy = GpioStatus {
+            outtopad: self.outtopad(),
+            oetopad: self.oetopad(),
+            infrompad: self.infrompad(),
+            irqtoproc: self.irqtoproc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable for dormant_wake"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -173,5 +234,118 @@ impl Default for Int {
     #[inline(always)]
     fn default() -> Int {
         Int(0)
+    }
+}
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field(
+                "level_low",
+                &[
+                    self.level_low(0usize),
+                    self.level_low(1usize),
+                    self.level_low(2usize),
+                    self.level_low(3usize),
+                    self.level_low(4usize),
+                    self.level_low(5usize),
+                    self.level_low(6usize),
+                    self.level_low(7usize),
+                ],
+            )
+            .field(
+                "level_high",
+                &[
+                    self.level_high(0usize),
+                    self.level_high(1usize),
+                    self.level_high(2usize),
+                    self.level_high(3usize),
+                    self.level_high(4usize),
+                    self.level_high(5usize),
+                    self.level_high(6usize),
+                    self.level_high(7usize),
+                ],
+            )
+            .field(
+                "edge_low",
+                &[
+                    self.edge_low(0usize),
+                    self.edge_low(1usize),
+                    self.edge_low(2usize),
+                    self.edge_low(3usize),
+                    self.edge_low(4usize),
+                    self.edge_low(5usize),
+                    self.edge_low(6usize),
+                    self.edge_low(7usize),
+                ],
+            )
+            .field(
+                "edge_high",
+                &[
+                    self.edge_high(0usize),
+                    self.edge_high(1usize),
+                    self.edge_high(2usize),
+                    self.edge_high(3usize),
+                    self.edge_high(4usize),
+                    self.edge_high(5usize),
+                    self.edge_high(6usize),
+                    self.edge_high(7usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            level_low: [bool; 8usize],
+            level_high: [bool; 8usize],
+            edge_low: [bool; 8usize],
+            edge_high: [bool; 8usize],
+        }
+        let proxy = Int {
+            level_low: [
+                self.level_low(0usize),
+                self.level_low(1usize),
+                self.level_low(2usize),
+                self.level_low(3usize),
+                self.level_low(4usize),
+                self.level_low(5usize),
+                self.level_low(6usize),
+                self.level_low(7usize),
+            ],
+            level_high: [
+                self.level_high(0usize),
+                self.level_high(1usize),
+                self.level_high(2usize),
+                self.level_high(3usize),
+                self.level_high(4usize),
+                self.level_high(5usize),
+                self.level_high(6usize),
+                self.level_high(7usize),
+            ],
+            edge_low: [
+                self.edge_low(0usize),
+                self.edge_low(1usize),
+                self.edge_low(2usize),
+                self.edge_low(3usize),
+                self.edge_low(4usize),
+                self.edge_low(5usize),
+                self.edge_low(6usize),
+                self.edge_low(7usize),
+            ],
+            edge_high: [
+                self.edge_high(0usize),
+                self.edge_high(1usize),
+                self.edge_high(2usize),
+                self.edge_high(3usize),
+                self.edge_high(4usize),
+                self.edge_high(5usize),
+                self.edge_high(6usize),
+                self.edge_high(7usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/io/vals.rs
+++ b/src/rp235x/io/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio0ctrlFuncsel {
     JTAG_TCK = 0x0,
     SPI0_RX = 0x01,
@@ -57,7 +58,8 @@ impl From<Gpio0ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio10ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -115,7 +117,8 @@ impl From<Gpio10ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio11ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -173,7 +176,8 @@ impl From<Gpio11ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio12ctrlFuncsel {
     HSTX_0 = 0x0,
     SPI1_RX = 0x01,
@@ -231,7 +235,8 @@ impl From<Gpio12ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio13ctrlFuncsel {
     HSTX_1 = 0x0,
     SPI1_SS_N = 0x01,
@@ -289,7 +294,8 @@ impl From<Gpio13ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio14ctrlFuncsel {
     HSTX_2 = 0x0,
     SPI1_SCLK = 0x01,
@@ -347,7 +353,8 @@ impl From<Gpio14ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio15ctrlFuncsel {
     HSTX_3 = 0x0,
     SPI1_TX = 0x01,
@@ -405,7 +412,8 @@ impl From<Gpio15ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio16ctrlFuncsel {
     HSTX_4 = 0x0,
     SPI0_RX = 0x01,
@@ -463,7 +471,8 @@ impl From<Gpio16ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio17ctrlFuncsel {
     HSTX_5 = 0x0,
     SPI0_SS_N = 0x01,
@@ -521,7 +530,8 @@ impl From<Gpio17ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio18ctrlFuncsel {
     HSTX_6 = 0x0,
     SPI0_SCLK = 0x01,
@@ -579,7 +589,8 @@ impl From<Gpio18ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio19ctrlFuncsel {
     HSTX_7 = 0x0,
     SPI0_TX = 0x01,
@@ -637,7 +648,8 @@ impl From<Gpio19ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio1ctrlFuncsel {
     JTAG_TMS = 0x0,
     SPI0_SS_N = 0x01,
@@ -695,7 +707,8 @@ impl From<Gpio1ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio20ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -753,7 +766,8 @@ impl From<Gpio20ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio21ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -811,7 +825,8 @@ impl From<Gpio21ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio22ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -869,7 +884,8 @@ impl From<Gpio22ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio23ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -927,7 +943,8 @@ impl From<Gpio23ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio24ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -985,7 +1002,8 @@ impl From<Gpio24ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio25ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -1043,7 +1061,8 @@ impl From<Gpio25ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio26ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -1101,7 +1120,8 @@ impl From<Gpio26ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio27ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -1159,7 +1179,8 @@ impl From<Gpio27ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio28ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -1217,7 +1238,8 @@ impl From<Gpio28ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio29ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -1275,7 +1297,8 @@ impl From<Gpio29ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio2ctrlFuncsel {
     JTAG_TDI = 0x0,
     SPI0_SCLK = 0x01,
@@ -1333,7 +1356,8 @@ impl From<Gpio2ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio30ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -1391,7 +1415,8 @@ impl From<Gpio30ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio31ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -1449,7 +1474,8 @@ impl From<Gpio31ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio32ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -1507,7 +1533,8 @@ impl From<Gpio32ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio33ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -1565,7 +1592,8 @@ impl From<Gpio33ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio34ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -1623,7 +1651,8 @@ impl From<Gpio34ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio35ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -1681,7 +1710,8 @@ impl From<Gpio35ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio36ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -1739,7 +1769,8 @@ impl From<Gpio36ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio37ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -1797,7 +1828,8 @@ impl From<Gpio37ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio38ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -1855,7 +1887,8 @@ impl From<Gpio38ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio39ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -1913,7 +1946,8 @@ impl From<Gpio39ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio3ctrlFuncsel {
     JTAG_TDO = 0x0,
     SPI0_TX = 0x01,
@@ -1971,7 +2005,8 @@ impl From<Gpio3ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio40ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -2029,7 +2064,8 @@ impl From<Gpio40ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio41ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -2087,7 +2123,8 @@ impl From<Gpio41ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio42ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -2145,7 +2182,8 @@ impl From<Gpio42ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio43ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -2203,7 +2241,8 @@ impl From<Gpio43ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio44ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -2261,7 +2300,8 @@ impl From<Gpio44ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio45ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -2319,7 +2359,8 @@ impl From<Gpio45ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio46ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SCLK = 0x01,
@@ -2377,7 +2418,8 @@ impl From<Gpio46ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio47ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_TX = 0x01,
@@ -2435,7 +2477,8 @@ impl From<Gpio47ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio4ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_RX = 0x01,
@@ -2493,7 +2536,8 @@ impl From<Gpio4ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio5ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SS_N = 0x01,
@@ -2551,7 +2595,8 @@ impl From<Gpio5ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio6ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_SCLK = 0x01,
@@ -2609,7 +2654,8 @@ impl From<Gpio6ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio7ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI0_TX = 0x01,
@@ -2667,7 +2713,8 @@ impl From<Gpio7ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio8ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_RX = 0x01,
@@ -2725,7 +2772,8 @@ impl From<Gpio8ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Gpio9ctrlFuncsel {
     _RESERVED_0 = 0x0,
     SPI1_SS_N = 0x01,
@@ -2783,7 +2831,8 @@ impl From<Gpio9ctrlFuncsel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Inover {
     #[doc = "don't invert the peri input"]
     NORMAL = 0x0,
@@ -2817,7 +2866,8 @@ impl From<Inover> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Irqover {
     #[doc = "don't invert the interrupt"]
     NORMAL = 0x0,
@@ -2851,7 +2901,8 @@ impl From<Irqover> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Oeover {
     #[doc = "drive output enable from peripheral signal selected by funcsel"]
     NORMAL = 0x0,
@@ -2885,7 +2936,8 @@ impl From<Oeover> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Outover {
     #[doc = "drive output from peripheral signal selected by funcsel"]
     NORMAL = 0x0,

--- a/src/rp235x/mod.rs
+++ b/src/rp235x/mod.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (689341a 2024-02-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - TIMER0_IRQ_0"]
     TIMER0_IRQ_0 = 0,

--- a/src/rp235x/otp/regs.rs
+++ b/src/rp235x/otp/regs.rs
@@ -32,6 +32,29 @@ impl Default for Archsel {
         Archsel(0)
     }
 }
+impl core::fmt::Debug for Archsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Archsel")
+            .field("core0", &self.core0())
+            .field("core1", &self.core1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Archsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Archsel {
+            core0: super::vals::ArchselCore0,
+            core1: super::vals::ArchselCore1,
+        }
+        let proxy = Archsel {
+            core0: self.core0(),
+            core1: self.core1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Get the current architecture select state of each core. Cores sample the current value of the ARCHSEL register when their warm reset is released, at which point the corresponding bit in this register will also update."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -64,6 +87,29 @@ impl Default for ArchselStatus {
     #[inline(always)]
     fn default() -> ArchselStatus {
         ArchselStatus(0)
+    }
+}
+impl core::fmt::Debug for ArchselStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ArchselStatus")
+            .field("core0", &self.core0())
+            .field("core1", &self.core1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ArchselStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ArchselStatus {
+            core0: super::vals::ArchselStatusCore0,
+            core1: super::vals::ArchselStatusCore1,
+        }
+        let proxy = ArchselStatus {
+            core0: self.core0(),
+            core1: self.core1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "During BIST, count address locations that have at least one leaky bit"]
@@ -133,6 +179,38 @@ impl Default for Bist {
         Bist(0)
     }
 }
+impl core::fmt::Debug for Bist {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Bist")
+            .field("cnt", &self.cnt())
+            .field("cnt_max", &self.cnt_max())
+            .field("cnt_ena", &self.cnt_ena())
+            .field("cnt_clr", &self.cnt_clr())
+            .field("cnt_fail", &self.cnt_fail())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bist {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Bist {
+            cnt: u16,
+            cnt_max: u16,
+            cnt_ena: bool,
+            cnt_clr: bool,
+            cnt_fail: bool,
+        }
+        let proxy = Bist {
+            cnt: self.cnt(),
+            cnt_max: self.cnt_max(),
+            cnt_ena: self.cnt_ena(),
+            cnt_clr: self.cnt_clr(),
+            cnt_fail: self.cnt_fail(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Tell the bootrom to ignore scratch register boot vectors (both power manager and watchdog) on the next power up. If an early boot stage has soft-locked some OTP pages in order to protect their contents from later stages, there is a risk that Secure code running at a later stage can unlock the pages by performing a watchdog reset that resets the OTP. This register can be used to ensure that the bootloader runs as normal on the next power up, preventing Secure code at a later stage from accessing OTP in its unlocked state. Should be used in conjunction with the power manager BOOTDIS register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -165,6 +243,29 @@ impl Default for Bootdis {
     #[inline(always)]
     fn default() -> Bootdis {
         Bootdis(0)
+    }
+}
+impl core::fmt::Debug for Bootdis {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Bootdis")
+            .field("now", &self.now())
+            .field("next", &self.next())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bootdis {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Bootdis {
+            now: bool,
+            next: bool,
+        }
+        let proxy = Bootdis {
+            now: self.now(),
+            next: self.next(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Quickly check values of critical flags read during boot up"]
@@ -251,6 +352,47 @@ impl Default for Critical {
         Critical(0)
     }
 }
+impl core::fmt::Debug for Critical {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Critical")
+            .field("secure_boot_enable", &self.secure_boot_enable())
+            .field("secure_debug_disable", &self.secure_debug_disable())
+            .field("debug_disable", &self.debug_disable())
+            .field("default_archsel", &self.default_archsel())
+            .field("glitch_detector_enable", &self.glitch_detector_enable())
+            .field("glitch_detector_sens", &self.glitch_detector_sens())
+            .field("arm_disable", &self.arm_disable())
+            .field("riscv_disable", &self.riscv_disable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Critical {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Critical {
+            secure_boot_enable: bool,
+            secure_debug_disable: bool,
+            debug_disable: bool,
+            default_archsel: bool,
+            glitch_detector_enable: bool,
+            glitch_detector_sens: u8,
+            arm_disable: bool,
+            riscv_disable: bool,
+        }
+        let proxy = Critical {
+            secure_boot_enable: self.secure_boot_enable(),
+            secure_debug_disable: self.secure_debug_disable(),
+            debug_disable: self.debug_disable(),
+            default_archsel: self.default_archsel(),
+            glitch_detector_enable: self.glitch_detector_enable(),
+            glitch_detector_sens: self.glitch_detector_sens(),
+            arm_disable: self.arm_disable(),
+            riscv_disable: self.riscv_disable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Debug for OTP power-on state machine"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -329,6 +471,41 @@ impl Default for Dbg {
         Dbg(0)
     }
 }
+impl core::fmt::Debug for Dbg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dbg")
+            .field("psm_done", &self.psm_done())
+            .field("boot_done", &self.boot_done())
+            .field("rosc_up_seen", &self.rosc_up_seen())
+            .field("rosc_up", &self.rosc_up())
+            .field("psm_state", &self.psm_state())
+            .field("customer_rma_flag", &self.customer_rma_flag())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dbg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dbg {
+            psm_done: bool,
+            boot_done: bool,
+            rosc_up_seen: bool,
+            rosc_up: bool,
+            psm_state: u8,
+            customer_rma_flag: bool,
+        }
+        let proxy = Dbg {
+            psm_done: self.psm_done(),
+            boot_done: self.boot_done(),
+            rosc_up_seen: self.rosc_up_seen(),
+            rosc_up: self.rosc_up(),
+            psm_state: self.psm_state(),
+            customer_rma_flag: self.customer_rma_flag(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Enable a debug feature that has been disabled. Debug features are disabled if one of the relevant critical boot flags is set in OTP (DEBUG_DISABLE or SECURE_DEBUG_DISABLE), OR if a debug key is marked valid in OTP, and the matching key value has not been supplied over SWD. Specifically: - The DEBUG_DISABLE flag disables all debug features. This can be fully overridden by setting all bits of this register. - The SECURE_DEBUG_DISABLE flag disables secure processor debug. This can be fully overridden by setting the PROC0_SECURE and PROC1_SECURE bits of this register. - If a single debug key has been registered, and no matching key value has been supplied over SWD, then all debug features are disabled. This can be fully overridden by setting all bits of this register. - If both debug keys have been registered, and the Non-secure key's value (key 6) has been supplied over SWD, secure processor debug is disabled. This can be fully overridden by setting the PROC0_SECURE and PROC1_SECURE bits of this register. - If both debug keys have been registered, and the Secure key's value (key 5) has been supplied over SWD, then no debug features are disabled by the key mechanism. However, note that in this case debug features may still be disabled by the critical boot flags."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -394,6 +571,38 @@ impl Default for Debugen {
     #[inline(always)]
     fn default() -> Debugen {
         Debugen(0)
+    }
+}
+impl core::fmt::Debug for Debugen {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Debugen")
+            .field("proc0", &self.proc0())
+            .field("proc0_secure", &self.proc0_secure())
+            .field("proc1", &self.proc1())
+            .field("proc1_secure", &self.proc1_secure())
+            .field("misc", &self.misc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Debugen {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Debugen {
+            proc0: bool,
+            proc0_secure: bool,
+            proc1: bool,
+            proc1_secure: bool,
+            misc: bool,
+        }
+        let proxy = Debugen {
+            proc0: self.proc0(),
+            proc0_secure: self.proc0_secure(),
+            proc1: self.proc1(),
+            proc1_secure: self.proc1_secure(),
+            misc: self.misc(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Write 1s to lock corresponding bits in DEBUGEN. This register is reset by the processor cold reset."]
@@ -463,6 +672,38 @@ impl Default for DebugenLock {
         DebugenLock(0)
     }
 }
+impl core::fmt::Debug for DebugenLock {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DebugenLock")
+            .field("proc0", &self.proc0())
+            .field("proc0_secure", &self.proc0_secure())
+            .field("proc1", &self.proc1())
+            .field("proc1_secure", &self.proc1_secure())
+            .field("misc", &self.misc())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DebugenLock {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DebugenLock {
+            proc0: bool,
+            proc0_secure: bool,
+            proc1: bool,
+            proc1_secure: bool,
+            misc: bool,
+        }
+        let proxy = DebugenLock {
+            proc0: self.proc0(),
+            proc0_secure: self.proc0_secure(),
+            proc1: self.proc1(),
+            proc1_secure: self.proc1_secure(),
+            misc: self.misc(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -520,6 +761,38 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field("sbpi_flag_n", &self.sbpi_flag_n())
+            .field("sbpi_wr_fail", &self.sbpi_wr_fail())
+            .field("apb_dctrl_fail", &self.apb_dctrl_fail())
+            .field("apb_rd_sec_fail", &self.apb_rd_sec_fail())
+            .field("apb_rd_nsec_fail", &self.apb_rd_nsec_fail())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            sbpi_flag_n: bool,
+            sbpi_wr_fail: bool,
+            apb_dctrl_fail: bool,
+            apb_rd_sec_fail: bool,
+            apb_rd_nsec_fail: bool,
+        }
+        let proxy = Int {
+            sbpi_flag_n: self.sbpi_flag_n(),
+            sbpi_wr_fail: self.sbpi_wr_fail(),
+            apb_dctrl_fail: self.apb_dctrl_fail(),
+            apb_rd_sec_fail: self.apb_rd_sec_fail(),
+            apb_rd_nsec_fail: self.apb_rd_nsec_fail(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Which keys were valid (enrolled) at boot time"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -539,6 +812,26 @@ impl Default for KeyValid {
     #[inline(always)]
     fn default() -> KeyValid {
         KeyValid(0)
+    }
+}
+impl core::fmt::Debug for KeyValid {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("KeyValid")
+            .field("key_valid", &self.key_valid())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for KeyValid {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct KeyValid {
+            key_valid: u8,
+        }
+        let proxy = KeyValid {
+            key_valid: self.key_valid(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Dispatch instructions to the SBPI interface, used for programming the OTP fuses."]
@@ -628,6 +921,44 @@ impl Default for SbpiInstr {
         SbpiInstr(0)
     }
 }
+impl core::fmt::Debug for SbpiInstr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SbpiInstr")
+            .field("short_wdata", &self.short_wdata())
+            .field("cmd", &self.cmd())
+            .field("target", &self.target())
+            .field("payload_size_m1", &self.payload_size_m1())
+            .field("has_payload", &self.has_payload())
+            .field("is_wr", &self.is_wr())
+            .field("exec", &self.exec())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SbpiInstr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SbpiInstr {
+            short_wdata: u8,
+            cmd: u8,
+            target: u8,
+            payload_size_m1: u8,
+            has_payload: bool,
+            is_wr: bool,
+            exec: bool,
+        }
+        let proxy = SbpiInstr {
+            short_wdata: self.short_wdata(),
+            cmd: self.cmd(),
+            target: self.target(),
+            payload_size_m1: self.payload_size_m1(),
+            has_payload: self.has_payload(),
+            is_wr: self.is_wr(),
+            exec: self.exec(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SbpiStatus(pub u32);
@@ -694,7 +1025,39 @@ impl Default for SbpiStatus {
         SbpiStatus(0)
     }
 }
-#[doc = "Software lock register for page 2. Locks are initialised from the OTP lock pages at reset. This register can be written to further advance the lock state of each page (until next reset), and read to check the current lock state of a page."]
+impl core::fmt::Debug for SbpiStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SbpiStatus")
+            .field("rdata_vld", &self.rdata_vld())
+            .field("instr_done", &self.instr_done())
+            .field("instr_miss", &self.instr_miss())
+            .field("flag", &self.flag())
+            .field("miso", &self.miso())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SbpiStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SbpiStatus {
+            rdata_vld: bool,
+            instr_done: bool,
+            instr_miss: bool,
+            flag: bool,
+            miso: u8,
+        }
+        let proxy = SbpiStatus {
+            rdata_vld: self.rdata_vld(),
+            instr_done: self.instr_done(),
+            instr_miss: self.instr_miss(),
+            flag: self.flag(),
+            miso: self.miso(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Software lock register for page 0. Locks are initialised from the OTP lock pages at reset. This register can be written to further advance the lock state of each page (until next reset), and read to check the current lock state of a page."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SwLock(pub u32);
@@ -726,6 +1089,29 @@ impl Default for SwLock {
     #[inline(always)]
     fn default() -> SwLock {
         SwLock(0)
+    }
+}
+impl core::fmt::Debug for SwLock {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SwLock")
+            .field("sec", &self.sec())
+            .field("nsec", &self.nsec())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SwLock {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SwLock {
+            sec: super::vals::SwLockSec,
+            nsec: super::vals::SwLockNsec,
+        }
+        let proxy = SwLock {
+            sec: self.sec(),
+            nsec: self.nsec(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls for APB data read interface (USER interface)"]
@@ -760,5 +1146,28 @@ impl Default for Usr {
     #[inline(always)]
     fn default() -> Usr {
         Usr(0)
+    }
+}
+impl core::fmt::Debug for Usr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Usr")
+            .field("dctrl", &self.dctrl())
+            .field("pd", &self.pd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Usr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Usr {
+            dctrl: bool,
+            pd: bool,
+        }
+        let proxy = Usr {
+            dctrl: self.dctrl(),
+            pd: self.pd(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/otp/vals.rs
+++ b/src/rp235x/otp/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ArchselCore0 {
     #[doc = "Switch core 0 to Arm (Cortex-M33)"]
     ARM = 0x0,
@@ -29,7 +30,8 @@ impl From<ArchselCore0> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ArchselCore1 {
     #[doc = "Switch core 1 to Arm (Cortex-M33)"]
     ARM = 0x0,
@@ -59,7 +61,8 @@ impl From<ArchselCore1> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ArchselStatusCore0 {
     #[doc = "Core 0 is currently Arm (Cortex-M33)"]
     ARM = 0x0,
@@ -89,7 +92,8 @@ impl From<ArchselStatusCore0> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ArchselStatusCore1 {
     #[doc = "Core 1 is currently Arm (Cortex-M33)"]
     ARM = 0x0,
@@ -119,7 +123,8 @@ impl From<ArchselStatusCore1> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SwLockNsec {
     READ_WRITE = 0x0,
     READ_ONLY = 0x01,
@@ -149,7 +154,8 @@ impl From<SwLockNsec> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SwLockSec {
     READ_WRITE = 0x0,
     READ_ONLY = 0x01,

--- a/src/rp235x/otp_data/regs.rs
+++ b/src/rp235x/otp_data/regs.rs
@@ -32,6 +32,29 @@ impl Default for BootselLedCfg {
         BootselLedCfg(0)
     }
 }
+impl core::fmt::Debug for BootselLedCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootselLedCfg")
+            .field("pin", &self.pin())
+            .field("activelow", &self.activelow())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootselLedCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootselLedCfg {
+            pin: u8,
+            activelow: bool,
+        }
+        let proxy = BootselLedCfg {
+            pin: self.pin(),
+            activelow: self.activelow(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Optional PLL configuration for BOOTSEL mode. (ECC) This should be configured to produce an exact 48 MHz based on the crystal oscillator frequency. User mode software may also use this value to calculate the expected crystal frequency based on an assumed 48 MHz PLL output. If no configuration is given, the crystal is assumed to be 12 MHz. The PLL frequency can be calculated as: PLL out = (XOSC frequency / (REFDIV+1)) x FBDIV / (POSTDIV1 x POSTDIV2) Conversely the crystal frequency can be calculated as: XOSC frequency = 48 MHz x (REFDIV+1) x (POSTDIV1 x POSTDIV2) / FBDIV (Note the +1 on REFDIV is because the value stored in this OTP location is the actual divisor value minus one.) Used if and only if ENABLE_BOOTSEL_NON_DEFAULT_PLL_XOSC_CFG is set in BOOT_FLAGS0. That bit should be set only after this row and BOOTSEL_XOSC_CFG are both correctly programmed."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +111,35 @@ impl Default for BootselPllCfg {
         BootselPllCfg(0)
     }
 }
+impl core::fmt::Debug for BootselPllCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootselPllCfg")
+            .field("fbdiv", &self.fbdiv())
+            .field("postdiv1", &self.postdiv1())
+            .field("postdiv2", &self.postdiv2())
+            .field("refdiv", &self.refdiv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootselPllCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootselPllCfg {
+            fbdiv: u16,
+            postdiv1: u8,
+            postdiv2: u8,
+            refdiv: bool,
+        }
+        let proxy = BootselPllCfg {
+            fbdiv: self.fbdiv(),
+            postdiv1: self.postdiv1(),
+            postdiv2: self.postdiv2(),
+            refdiv: self.refdiv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Non-default crystal oscillator configuration for the USB bootloader. (ECC) These values may also be used by user code configuring the crystal oscillator. Used if and only if ENABLE_BOOTSEL_NON_DEFAULT_PLL_XOSC_CFG is set in BOOT_FLAGS0. That bit should be set only after this row and BOOTSEL_PLL_CFG are both correctly programmed."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -120,6 +172,29 @@ impl Default for BootselXoscCfg {
     #[inline(always)]
     fn default() -> BootselXoscCfg {
         BootselXoscCfg(0)
+    }
+}
+impl core::fmt::Debug for BootselXoscCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootselXoscCfg")
+            .field("startup", &self.startup())
+            .field("range", &self.range())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootselXoscCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootselXoscCfg {
+            startup: u16,
+            range: super::vals::Range,
+        }
+        let proxy = BootselXoscCfg {
+            startup: self.startup(),
+            range: self.range(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Stores information about external flash device(s). (ECC) Assumed to be valid if BOOT_FLAGS0_FLASH_DEVINFO_ENABLE is set."]
@@ -178,6 +253,35 @@ impl Default for FlashDevinfo {
         FlashDevinfo(0)
     }
 }
+impl core::fmt::Debug for FlashDevinfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FlashDevinfo")
+            .field("cs1_gpio", &self.cs1_gpio())
+            .field("d8h_erase_supported", &self.d8h_erase_supported())
+            .field("cs0_size", &self.cs0_size())
+            .field("cs1_size", &self.cs1_size())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FlashDevinfo {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FlashDevinfo {
+            cs1_gpio: u8,
+            d8h_erase_supported: bool,
+            cs0_size: super::vals::Cs0size,
+            cs1_size: super::vals::Cs1size,
+        }
+        let proxy = FlashDevinfo {
+            cs1_gpio: self.cs1_gpio(),
+            d8h_erase_supported: self.d8h_erase_supported(),
+            cs0_size: self.cs0_size(),
+            cs1_size: self.cs1_size(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "The number of main user GPIOs (bank 0). Should read 48 in the QFN80 package, and 30 in the QFN60 package. (ECC)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -199,6 +303,26 @@ impl Default for NumGpios {
         NumGpios(0)
     }
 }
+impl core::fmt::Debug for NumGpios {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("NumGpios")
+            .field("num_gpios", &self.num_gpios())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for NumGpios {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct NumGpios {
+            num_gpios: u8,
+        }
+        let proxy = NumGpios {
+            num_gpios: self.num_gpios(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Row index of the USB_WHITE_LABEL structure within OTP (ECC) The table has 16 rows, each of which are also ECC and marked valid by the corresponding valid bit in USB_BOOT_FLAGS (ECC). The entries are either _VALUEs where the 16 bit value is used as is, or _STRDEFs which acts as a pointers to a string value. The value stored in a _STRDEF is two separate bytes: The low seven bits of the first (LSB) byte indicates the number of characters in the string, and the top bit of the first (LSB) byte if set to indicate that each character in the string is two bytes (Unicode) versus one byte if unset. The second (MSB) byte represents the location of the string data, and is encoded as the number of rows from this USB_WHITE_LABEL_ADDR; i.e. the row of the start of the string is USB_WHITE_LABEL_ADDR value + msb_byte. In each case, the corresponding valid bit enables replacing the default value for the corresponding item provided by the boot rom. Note that Unicode _STRDEFs are only supported for USB_DEVICE_PRODUCT_STRDEF, USB_DEVICE_SERIAL_NUMBER_STRDEF and USB_DEVICE_MANUFACTURER_STRDEF. Unicode values will be ignored if specified for other fields, and non-unicode values for these three items will be converted to Unicode characters by setting the upper 8 bits to zero. Note that if the USB_WHITE_LABEL structure or the corresponding strings are not readable by BOOTSEL mode based on OTP permissions, or if alignment requirements are not met, then the corresponding default values are used. The index values indicate where each field is located (row USB_WHITE_LABEL_ADDR value + index):"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -218,5 +342,25 @@ impl Default for UsbWhiteLabelAddr {
     #[inline(always)]
     fn default() -> UsbWhiteLabelAddr {
         UsbWhiteLabelAddr(0)
+    }
+}
+impl core::fmt::Debug for UsbWhiteLabelAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbWhiteLabelAddr")
+            .field("usb_white_label_addr", &self.usb_white_label_addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbWhiteLabelAddr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbWhiteLabelAddr {
+            usb_white_label_addr: super::vals::UsbWhiteLabelAddr,
+        }
+        let proxy = UsbWhiteLabelAddr {
+            usb_white_label_addr: self.usb_white_label_addr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/otp_data/vals.rs
+++ b/src/rp235x/otp_data/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Cs0size {
     NONE = 0x0,
     _8K = 0x01,
@@ -41,7 +42,8 @@ impl From<Cs0size> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Cs1size {
     NONE = 0x0,
     _8K = 0x01,
@@ -83,7 +85,8 @@ impl From<Cs1size> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Range {
     _1_15MHZ = 0x0,
     _10_30MHZ = 0x01,
@@ -139,6 +142,53 @@ impl UsbWhiteLabelAddr {
     }
     pub const fn to_bits(self) -> u16 {
         self.0
+    }
+}
+impl core::fmt::Debug for UsbWhiteLabelAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("INDEX_USB_DEVICE_VID_VALUE"),
+            0x01 => f.write_str("INDEX_USB_DEVICE_PID_VALUE"),
+            0x02 => f.write_str("INDEX_USB_DEVICE_BCD_DEVICE_VALUE"),
+            0x03 => f.write_str("INDEX_USB_DEVICE_LANG_ID_VALUE"),
+            0x04 => f.write_str("INDEX_USB_DEVICE_MANUFACTURER_STRDEF"),
+            0x05 => f.write_str("INDEX_USB_DEVICE_PRODUCT_STRDEF"),
+            0x06 => f.write_str("INDEX_USB_DEVICE_SERIAL_NUMBER_STRDEF"),
+            0x07 => f.write_str("INDEX_USB_CONFIG_ATTRIBUTES_MAX_POWER_VALUES"),
+            0x08 => f.write_str("INDEX_VOLUME_LABEL_STRDEF"),
+            0x09 => f.write_str("INDEX_SCSI_INQUIRY_VENDOR_STRDEF"),
+            0x0a => f.write_str("INDEX_SCSI_INQUIRY_PRODUCT_STRDEF"),
+            0x0b => f.write_str("INDEX_SCSI_INQUIRY_VERSION_STRDEF"),
+            0x0c => f.write_str("INDEX_INDEX_HTM_REDIRECT_URL_STRDEF"),
+            0x0d => f.write_str("INDEX_INDEX_HTM_REDIRECT_NAME_STRDEF"),
+            0x0e => f.write_str("INDEX_INFO_UF2_TXT_MODEL_STRDEF"),
+            0x0f => f.write_str("INDEX_INFO_UF2_TXT_BOARD_ID_STRDEF"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbWhiteLabelAddr {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "INDEX_USB_DEVICE_VID_VALUE"),
+            0x01 => defmt::write!(f, "INDEX_USB_DEVICE_PID_VALUE"),
+            0x02 => defmt::write!(f, "INDEX_USB_DEVICE_BCD_DEVICE_VALUE"),
+            0x03 => defmt::write!(f, "INDEX_USB_DEVICE_LANG_ID_VALUE"),
+            0x04 => defmt::write!(f, "INDEX_USB_DEVICE_MANUFACTURER_STRDEF"),
+            0x05 => defmt::write!(f, "INDEX_USB_DEVICE_PRODUCT_STRDEF"),
+            0x06 => defmt::write!(f, "INDEX_USB_DEVICE_SERIAL_NUMBER_STRDEF"),
+            0x07 => defmt::write!(f, "INDEX_USB_CONFIG_ATTRIBUTES_MAX_POWER_VALUES"),
+            0x08 => defmt::write!(f, "INDEX_VOLUME_LABEL_STRDEF"),
+            0x09 => defmt::write!(f, "INDEX_SCSI_INQUIRY_VENDOR_STRDEF"),
+            0x0a => defmt::write!(f, "INDEX_SCSI_INQUIRY_PRODUCT_STRDEF"),
+            0x0b => defmt::write!(f, "INDEX_SCSI_INQUIRY_VERSION_STRDEF"),
+            0x0c => defmt::write!(f, "INDEX_INDEX_HTM_REDIRECT_URL_STRDEF"),
+            0x0d => defmt::write!(f, "INDEX_INDEX_HTM_REDIRECT_NAME_STRDEF"),
+            0x0e => defmt::write!(f, "INDEX_INFO_UF2_TXT_MODEL_STRDEF"),
+            0x0f => defmt::write!(f, "INDEX_INFO_UF2_TXT_BOARD_ID_STRDEF"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u16> for UsbWhiteLabelAddr {

--- a/src/rp235x/otp_data_raw.rs
+++ b/src/rp235x/otp_data_raw.rs
@@ -13,82 +13,82 @@ impl BootKey {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "Bits 15:0 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 15:0 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part0(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "Bits 31:16 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 31:16 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part1(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
-    #[doc = "Bits 47:32 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 47:32 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part2(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
-    #[doc = "Bits 63:48 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 63:48 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part3(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0cusize) as _) }
     }
-    #[doc = "Bits 79:64 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 79:64 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part4(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x10usize) as _) }
     }
-    #[doc = "Bits 95:80 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 95:80 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part5(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x14usize) as _) }
     }
-    #[doc = "Bits 111:96 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 111:96 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part6(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x18usize) as _) }
     }
-    #[doc = "Bits 127:112 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 127:112 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part7(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x1cusize) as _) }
     }
-    #[doc = "Bits 143:128 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 143:128 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part8(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x20usize) as _) }
     }
-    #[doc = "Bits 159:144 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 159:144 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part9(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x24usize) as _) }
     }
-    #[doc = "Bits 175:160 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 175:160 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part10(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x28usize) as _) }
     }
-    #[doc = "Bits 191:176 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 191:176 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part11(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x2cusize) as _) }
     }
-    #[doc = "Bits 207:192 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 207:192 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part12(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x30usize) as _) }
     }
-    #[doc = "Bits 223:208 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 223:208 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part13(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x34usize) as _) }
     }
-    #[doc = "Bits 239:224 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 239:224 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part14(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x38usize) as _) }
     }
-    #[doc = "Bits 255:240 of SHA-256 hash of boot key 1 (ECC)"]
+    #[doc = "Bits 255:240 of SHA-256 hash of boot key 3 (ECC)"]
     #[inline(always)]
     pub const fn part15(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x3cusize) as _) }
@@ -109,42 +109,42 @@ impl Key {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "Bits 15:0 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 15:0 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part0(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "Bits 31:16 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 31:16 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part1(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
-    #[doc = "Bits 47:32 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 47:32 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part2(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
-    #[doc = "Bits 63:48 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 63:48 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part3(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0cusize) as _) }
     }
-    #[doc = "Bits 79:64 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 79:64 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part4(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x10usize) as _) }
     }
-    #[doc = "Bits 95:80 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 95:80 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part5(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x14usize) as _) }
     }
-    #[doc = "Bits 111:96 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 111:96 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part6(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x18usize) as _) }
     }
-    #[doc = "Bits 127:112 of OTP access key 1 (ECC)"]
+    #[doc = "Bits 127:112 of OTP access key 6 (ECC)"]
     #[inline(always)]
     pub const fn part7(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x1cusize) as _) }
@@ -504,12 +504,12 @@ impl PageLock {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "Lock configuration LSBs for page 62 (rows 0xf80 through 0xfbf). Locks are stored with 3-way majority vote encoding, so that bits can be set independently. This OTP location is always readable, and is write-protected by its own permissions."]
+    #[doc = "Lock configuration LSBs for page 9 (rows 0x240 through 0x27f). Locks are stored with 3-way majority vote encoding, so that bits can be set independently. This OTP location is always readable, and is write-protected by its own permissions."]
     #[inline(always)]
     pub const fn lock0(self) -> crate::common::Reg<regs::PageLock0, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "Lock configuration MSBs for page 62 (rows 0xf80 through 0xfbf). Locks are stored with 3-way majority vote encoding, so that bits can be set independently. This OTP location is always readable, and is write-protected by its own permissions."]
+    #[doc = "Lock configuration MSBs for page 9 (rows 0x240 through 0x27f). Locks are stored with 3-way majority vote encoding, so that bits can be set independently. This OTP location is always readable, and is write-protected by its own permissions."]
     #[inline(always)]
     pub const fn lock1(self) -> crate::common::Reg<regs::PageLock1, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }

--- a/src/rp235x/otp_data_raw/regs.rs
+++ b/src/rp235x/otp_data_raw/regs.rs
@@ -236,6 +236,107 @@ impl Default for BootFlags0 {
         BootFlags0(0)
     }
 }
+impl core::fmt::Debug for BootFlags0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootFlags0")
+            .field("disable_bootsel_exec2", &self.disable_bootsel_exec2())
+            .field("enable_bootsel_led", &self.enable_bootsel_led())
+            .field(
+                "enable_bootsel_non_default_pll_xosc_cfg",
+                &self.enable_bootsel_non_default_pll_xosc_cfg(),
+            )
+            .field("flash_io_voltage_1v8", &self.flash_io_voltage_1v8())
+            .field("fast_sigcheck_rosc_div", &self.fast_sigcheck_rosc_div())
+            .field("flash_devinfo_enable", &self.flash_devinfo_enable())
+            .field(
+                "override_flash_partition_slot_size",
+                &self.override_flash_partition_slot_size(),
+            )
+            .field("single_flash_binary", &self.single_flash_binary())
+            .field("disable_auto_switch_arch", &self.disable_auto_switch_arch())
+            .field("secure_partition_table", &self.secure_partition_table())
+            .field("hashed_partition_table", &self.hashed_partition_table())
+            .field("rollback_required", &self.rollback_required())
+            .field("disable_flash_boot", &self.disable_flash_boot())
+            .field("disable_otp_boot", &self.disable_otp_boot())
+            .field("enable_otp_boot", &self.enable_otp_boot())
+            .field("disable_power_scratch", &self.disable_power_scratch())
+            .field("disable_watchdog_scratch", &self.disable_watchdog_scratch())
+            .field(
+                "disable_bootsel_usb_msd_ifc",
+                &self.disable_bootsel_usb_msd_ifc(),
+            )
+            .field(
+                "disable_bootsel_usb_picoboot_ifc",
+                &self.disable_bootsel_usb_picoboot_ifc(),
+            )
+            .field(
+                "disable_bootsel_uart_boot",
+                &self.disable_bootsel_uart_boot(),
+            )
+            .field(
+                "disable_xip_access_on_sram_entry",
+                &self.disable_xip_access_on_sram_entry(),
+            )
+            .field("disable_sram_window_boot", &self.disable_sram_window_boot())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootFlags0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootFlags0 {
+            disable_bootsel_exec2: bool,
+            enable_bootsel_led: bool,
+            enable_bootsel_non_default_pll_xosc_cfg: bool,
+            flash_io_voltage_1v8: bool,
+            fast_sigcheck_rosc_div: bool,
+            flash_devinfo_enable: bool,
+            override_flash_partition_slot_size: bool,
+            single_flash_binary: bool,
+            disable_auto_switch_arch: bool,
+            secure_partition_table: bool,
+            hashed_partition_table: bool,
+            rollback_required: bool,
+            disable_flash_boot: bool,
+            disable_otp_boot: bool,
+            enable_otp_boot: bool,
+            disable_power_scratch: bool,
+            disable_watchdog_scratch: bool,
+            disable_bootsel_usb_msd_ifc: bool,
+            disable_bootsel_usb_picoboot_ifc: bool,
+            disable_bootsel_uart_boot: bool,
+            disable_xip_access_on_sram_entry: bool,
+            disable_sram_window_boot: bool,
+        }
+        let proxy = BootFlags0 {
+            disable_bootsel_exec2: self.disable_bootsel_exec2(),
+            enable_bootsel_led: self.enable_bootsel_led(),
+            enable_bootsel_non_default_pll_xosc_cfg: self.enable_bootsel_non_default_pll_xosc_cfg(),
+            flash_io_voltage_1v8: self.flash_io_voltage_1v8(),
+            fast_sigcheck_rosc_div: self.fast_sigcheck_rosc_div(),
+            flash_devinfo_enable: self.flash_devinfo_enable(),
+            override_flash_partition_slot_size: self.override_flash_partition_slot_size(),
+            single_flash_binary: self.single_flash_binary(),
+            disable_auto_switch_arch: self.disable_auto_switch_arch(),
+            secure_partition_table: self.secure_partition_table(),
+            hashed_partition_table: self.hashed_partition_table(),
+            rollback_required: self.rollback_required(),
+            disable_flash_boot: self.disable_flash_boot(),
+            disable_otp_boot: self.disable_otp_boot(),
+            enable_otp_boot: self.enable_otp_boot(),
+            disable_power_scratch: self.disable_power_scratch(),
+            disable_watchdog_scratch: self.disable_watchdog_scratch(),
+            disable_bootsel_usb_msd_ifc: self.disable_bootsel_usb_msd_ifc(),
+            disable_bootsel_usb_picoboot_ifc: self.disable_bootsel_usb_picoboot_ifc(),
+            disable_bootsel_uart_boot: self.disable_bootsel_uart_boot(),
+            disable_xip_access_on_sram_entry: self.disable_xip_access_on_sram_entry(),
+            disable_sram_window_boot: self.disable_sram_window_boot(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Disable/Enable boot paths/features in the RP2350 mask ROM. Disables always supersede enables. Enables are provided where there are other configurations in OTP that must be valid. (RBIT-3)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -292,6 +393,35 @@ impl Default for BootFlags1 {
         BootFlags1(0)
     }
 }
+impl core::fmt::Debug for BootFlags1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootFlags1")
+            .field("key_valid", &self.key_valid())
+            .field("key_invalid", &self.key_invalid())
+            .field("double_tap_delay", &self.double_tap_delay())
+            .field("double_tap", &self.double_tap())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootFlags1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootFlags1 {
+            key_valid: u8,
+            key_invalid: u8,
+            double_tap_delay: u8,
+            double_tap: bool,
+        }
+        let proxy = BootFlags1 {
+            key_valid: self.key_valid(),
+            key_invalid: self.key_invalid(),
+            double_tap_delay: self.double_tap_delay(),
+            double_tap: self.double_tap(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Pin configuration for LED status, used by USB bootloader. (ECC) Must be valid if BOOT_FLAGS0_ENABLE_BOOTSEL_LED is set."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -324,6 +454,29 @@ impl Default for BootselLedCfg {
     #[inline(always)]
     fn default() -> BootselLedCfg {
         BootselLedCfg(0)
+    }
+}
+impl core::fmt::Debug for BootselLedCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootselLedCfg")
+            .field("pin", &self.pin())
+            .field("activelow", &self.activelow())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootselLedCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootselLedCfg {
+            pin: u8,
+            activelow: u16,
+        }
+        let proxy = BootselLedCfg {
+            pin: self.pin(),
+            activelow: self.activelow(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Optional PLL configuration for BOOTSEL mode. (ECC) This should be configured to produce an exact 48 MHz based on the crystal oscillator frequency. User mode software may also use this value to calculate the expected crystal frequency based on an assumed 48 MHz PLL output. If no configuration is given, the crystal is assumed to be 12 MHz. The PLL frequency can be calculated as: PLL out = (XOSC frequency / (REFDIV+1)) x FBDIV / (POSTDIV1 x POSTDIV2) Conversely the crystal frequency can be calculated as: XOSC frequency = 48 MHz x (REFDIV+1) x (POSTDIV1 x POSTDIV2) / FBDIV (Note the +1 on REFDIV is because the value stored in this OTP location is the actual divisor value minus one.) Used if and only if ENABLE_BOOTSEL_NON_DEFAULT_PLL_XOSC_CFG is set in BOOT_FLAGS0. That bit should be set only after this row and BOOTSEL_XOSC_CFG are both correctly programmed."]
@@ -382,6 +535,35 @@ impl Default for BootselPllCfg {
         BootselPllCfg(0)
     }
 }
+impl core::fmt::Debug for BootselPllCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootselPllCfg")
+            .field("fbdiv", &self.fbdiv())
+            .field("postdiv1", &self.postdiv1())
+            .field("postdiv2", &self.postdiv2())
+            .field("refdiv", &self.refdiv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootselPllCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootselPllCfg {
+            fbdiv: u16,
+            postdiv1: u8,
+            postdiv2: u8,
+            refdiv: u16,
+        }
+        let proxy = BootselPllCfg {
+            fbdiv: self.fbdiv(),
+            postdiv1: self.postdiv1(),
+            postdiv2: self.postdiv2(),
+            refdiv: self.refdiv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Non-default crystal oscillator configuration for the USB bootloader. (ECC) These values may also be used by user code configuring the crystal oscillator. Used if and only if ENABLE_BOOTSEL_NON_DEFAULT_PLL_XOSC_CFG is set in BOOT_FLAGS0. That bit should be set only after this row and BOOTSEL_PLL_CFG are both correctly programmed."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -416,6 +598,29 @@ impl Default for BootselXoscCfg {
         BootselXoscCfg(0)
     }
 }
+impl core::fmt::Debug for BootselXoscCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BootselXoscCfg")
+            .field("startup", &self.startup())
+            .field("range", &self.range())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BootselXoscCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BootselXoscCfg {
+            startup: u16,
+            range: super::vals::Range,
+        }
+        let proxy = BootselXoscCfg {
+            startup: self.startup(),
+            range: self.range(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Page 0 critical boot flags (RBIT-8)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -448,6 +653,29 @@ impl Default for Crit0 {
     #[inline(always)]
     fn default() -> Crit0 {
         Crit0(0)
+    }
+}
+impl core::fmt::Debug for Crit0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Crit0")
+            .field("arm_disable", &self.arm_disable())
+            .field("riscv_disable", &self.riscv_disable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Crit0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Crit0 {
+            arm_disable: bool,
+            riscv_disable: bool,
+        }
+        let proxy = Crit0 {
+            arm_disable: self.arm_disable(),
+            riscv_disable: self.riscv_disable(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Page 1 critical boot flags (RBIT-8)"]
@@ -528,6 +756,41 @@ impl Default for Crit1 {
         Crit1(0)
     }
 }
+impl core::fmt::Debug for Crit1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Crit1")
+            .field("secure_boot_enable", &self.secure_boot_enable())
+            .field("secure_debug_disable", &self.secure_debug_disable())
+            .field("debug_disable", &self.debug_disable())
+            .field("boot_arch", &self.boot_arch())
+            .field("glitch_detector_enable", &self.glitch_detector_enable())
+            .field("glitch_detector_sens", &self.glitch_detector_sens())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Crit1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Crit1 {
+            secure_boot_enable: bool,
+            secure_debug_disable: bool,
+            debug_disable: bool,
+            boot_arch: bool,
+            glitch_detector_enable: bool,
+            glitch_detector_sens: u8,
+        }
+        let proxy = Crit1 {
+            secure_boot_enable: self.secure_boot_enable(),
+            secure_debug_disable: self.secure_debug_disable(),
+            debug_disable: self.debug_disable(),
+            boot_arch: self.boot_arch(),
+            glitch_detector_enable: self.glitch_detector_enable(),
+            glitch_detector_sens: self.glitch_detector_sens(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Stores information about external flash device(s). (ECC) Assumed to be valid if BOOT_FLAGS0_FLASH_DEVINFO_ENABLE is set."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -584,7 +847,36 @@ impl Default for FlashDevinfo {
         FlashDevinfo(0)
     }
 }
-#[doc = "Valid flag for key 6. Once the valid flag is set, the key can no longer be read or written, and becomes a valid fixed key for protecting OTP pages."]
+impl core::fmt::Debug for FlashDevinfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FlashDevinfo")
+            .field("cs1_gpio", &self.cs1_gpio())
+            .field("d8h_erase_supported", &self.d8h_erase_supported())
+            .field("cs0_size", &self.cs0_size())
+            .field("cs1_size", &self.cs1_size())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FlashDevinfo {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FlashDevinfo {
+            cs1_gpio: u8,
+            d8h_erase_supported: bool,
+            cs0_size: super::vals::Cs0size,
+            cs1_size: super::vals::Cs1size,
+        }
+        let proxy = FlashDevinfo {
+            cs1_gpio: self.cs1_gpio(),
+            d8h_erase_supported: self.d8h_erase_supported(),
+            cs0_size: self.cs0_size(),
+            cs1_size: self.cs1_size(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Valid flag for key 1. Once the valid flag is set, the key can no longer be read or written, and becomes a valid fixed key for protecting OTP pages."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct KeyValid(pub u32);
@@ -625,6 +917,32 @@ impl Default for KeyValid {
     #[inline(always)]
     fn default() -> KeyValid {
         KeyValid(0)
+    }
+}
+impl core::fmt::Debug for KeyValid {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("KeyValid")
+            .field("valid", &self.valid())
+            .field("valid_r1", &self.valid_r1())
+            .field("valid_r2", &self.valid_r2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for KeyValid {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct KeyValid {
+            valid: bool,
+            valid_r1: bool,
+            valid_r2: bool,
+        }
+        let proxy = KeyValid {
+            valid: self.valid(),
+            valid_r1: self.valid_r1(),
+            valid_r2: self.valid_r2(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Lock configuration LSBs for page 63 (rows 0xfc0 through 0xfff). Locks are stored with 3-way majority vote encoding, so that bits can be set independently. This OTP location is always readable, and is write-protected by its own permissions."]
@@ -705,6 +1023,41 @@ impl Default for PageLock0 {
         PageLock0(0)
     }
 }
+impl core::fmt::Debug for PageLock0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PageLock0")
+            .field("key_w", &self.key_w())
+            .field("key_r", &self.key_r())
+            .field("no_key_state", &self.no_key_state())
+            .field("rma", &self.rma())
+            .field("r1", &self.r1())
+            .field("r2", &self.r2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PageLock0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PageLock0 {
+            key_w: u8,
+            key_r: u8,
+            no_key_state: super::vals::PageLockNoKeyState,
+            rma: bool,
+            r1: u8,
+            r2: u8,
+        }
+        let proxy = PageLock0 {
+            key_w: self.key_w(),
+            key_r: self.key_r(),
+            no_key_state: self.no_key_state(),
+            rma: self.rma(),
+            r1: self.r1(),
+            r2: self.r2(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Lock configuration MSBs for page 63 (rows 0xfc0 through 0xfff). Locks are stored with 3-way majority vote encoding, so that bits can be set independently. This OTP location is always readable, and is write-protected by its own permissions."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -770,6 +1123,38 @@ impl Default for PageLock1 {
     #[inline(always)]
     fn default() -> PageLock1 {
         PageLock1(0)
+    }
+}
+impl core::fmt::Debug for PageLock1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PageLock1")
+            .field("lock_s", &self.lock_s())
+            .field("lock_ns", &self.lock_ns())
+            .field("lock_bl", &self.lock_bl())
+            .field("r1", &self.r1())
+            .field("r2", &self.r2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PageLock1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PageLock1 {
+            lock_s: super::vals::PageLock,
+            lock_ns: super::vals::PageLock,
+            lock_bl: super::vals::PageLock,
+            r1: u8,
+            r2: u8,
+        }
+        let proxy = PageLock1 {
+            lock_s: self.lock_s(),
+            lock_ns: self.lock_ns(),
+            lock_bl: self.lock_bl(),
+            r1: self.r1(),
+            r2: self.r2(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "USB boot specific feature flags (RBIT-3)"]
@@ -982,6 +1367,127 @@ impl Default for UsbBootFlags {
         UsbBootFlags(0)
     }
 }
+impl core::fmt::Debug for UsbBootFlags {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbBootFlags")
+            .field(
+                "wl_usb_device_vid_value_valid",
+                &self.wl_usb_device_vid_value_valid(),
+            )
+            .field(
+                "wl_usb_device_pid_value_valid",
+                &self.wl_usb_device_pid_value_valid(),
+            )
+            .field(
+                "wl_usb_device_serial_number_value_valid",
+                &self.wl_usb_device_serial_number_value_valid(),
+            )
+            .field(
+                "wl_usb_device_lang_id_value_valid",
+                &self.wl_usb_device_lang_id_value_valid(),
+            )
+            .field(
+                "wl_usb_device_manufacturer_strdef_valid",
+                &self.wl_usb_device_manufacturer_strdef_valid(),
+            )
+            .field(
+                "wl_usb_device_product_strdef_valid",
+                &self.wl_usb_device_product_strdef_valid(),
+            )
+            .field(
+                "wl_usb_device_serial_number_strdef_valid",
+                &self.wl_usb_device_serial_number_strdef_valid(),
+            )
+            .field(
+                "wl_usb_config_attributes_max_power_values_valid",
+                &self.wl_usb_config_attributes_max_power_values_valid(),
+            )
+            .field(
+                "wl_volume_label_strdef_valid",
+                &self.wl_volume_label_strdef_valid(),
+            )
+            .field(
+                "wl_scsi_inquiry_vendor_strdef_valid",
+                &self.wl_scsi_inquiry_vendor_strdef_valid(),
+            )
+            .field(
+                "wl_scsi_inquiry_product_strdef_valid",
+                &self.wl_scsi_inquiry_product_strdef_valid(),
+            )
+            .field(
+                "wl_scsi_inquiry_version_strdef_valid",
+                &self.wl_scsi_inquiry_version_strdef_valid(),
+            )
+            .field(
+                "wl_index_htm_redirect_url_strdef_valid",
+                &self.wl_index_htm_redirect_url_strdef_valid(),
+            )
+            .field(
+                "wl_index_htm_redirect_name_strdef_valid",
+                &self.wl_index_htm_redirect_name_strdef_valid(),
+            )
+            .field(
+                "wl_info_uf2_txt_model_strdef_valid",
+                &self.wl_info_uf2_txt_model_strdef_valid(),
+            )
+            .field(
+                "wl_info_uf2_txt_board_id_strdef_valid",
+                &self.wl_info_uf2_txt_board_id_strdef_valid(),
+            )
+            .field("white_label_addr_valid", &self.white_label_addr_valid())
+            .field("dp_dm_swap", &self.dp_dm_swap())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbBootFlags {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbBootFlags {
+            wl_usb_device_vid_value_valid: bool,
+            wl_usb_device_pid_value_valid: bool,
+            wl_usb_device_serial_number_value_valid: bool,
+            wl_usb_device_lang_id_value_valid: bool,
+            wl_usb_device_manufacturer_strdef_valid: bool,
+            wl_usb_device_product_strdef_valid: bool,
+            wl_usb_device_serial_number_strdef_valid: bool,
+            wl_usb_config_attributes_max_power_values_valid: bool,
+            wl_volume_label_strdef_valid: bool,
+            wl_scsi_inquiry_vendor_strdef_valid: bool,
+            wl_scsi_inquiry_product_strdef_valid: bool,
+            wl_scsi_inquiry_version_strdef_valid: bool,
+            wl_index_htm_redirect_url_strdef_valid: bool,
+            wl_index_htm_redirect_name_strdef_valid: bool,
+            wl_info_uf2_txt_model_strdef_valid: bool,
+            wl_info_uf2_txt_board_id_strdef_valid: bool,
+            white_label_addr_valid: bool,
+            dp_dm_swap: bool,
+        }
+        let proxy = UsbBootFlags {
+            wl_usb_device_vid_value_valid: self.wl_usb_device_vid_value_valid(),
+            wl_usb_device_pid_value_valid: self.wl_usb_device_pid_value_valid(),
+            wl_usb_device_serial_number_value_valid: self.wl_usb_device_serial_number_value_valid(),
+            wl_usb_device_lang_id_value_valid: self.wl_usb_device_lang_id_value_valid(),
+            wl_usb_device_manufacturer_strdef_valid: self.wl_usb_device_manufacturer_strdef_valid(),
+            wl_usb_device_product_strdef_valid: self.wl_usb_device_product_strdef_valid(),
+            wl_usb_device_serial_number_strdef_valid: self
+                .wl_usb_device_serial_number_strdef_valid(),
+            wl_usb_config_attributes_max_power_values_valid: self
+                .wl_usb_config_attributes_max_power_values_valid(),
+            wl_volume_label_strdef_valid: self.wl_volume_label_strdef_valid(),
+            wl_scsi_inquiry_vendor_strdef_valid: self.wl_scsi_inquiry_vendor_strdef_valid(),
+            wl_scsi_inquiry_product_strdef_valid: self.wl_scsi_inquiry_product_strdef_valid(),
+            wl_scsi_inquiry_version_strdef_valid: self.wl_scsi_inquiry_version_strdef_valid(),
+            wl_index_htm_redirect_url_strdef_valid: self.wl_index_htm_redirect_url_strdef_valid(),
+            wl_index_htm_redirect_name_strdef_valid: self.wl_index_htm_redirect_name_strdef_valid(),
+            wl_info_uf2_txt_model_strdef_valid: self.wl_info_uf2_txt_model_strdef_valid(),
+            wl_info_uf2_txt_board_id_strdef_valid: self.wl_info_uf2_txt_board_id_strdef_valid(),
+            white_label_addr_valid: self.white_label_addr_valid(),
+            dp_dm_swap: self.dp_dm_swap(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Row index of the USB_WHITE_LABEL structure within OTP (ECC) The table has 16 rows, each of which are also ECC and marked valid by the corresponding valid bit in USB_BOOT_FLAGS (ECC). The entries are either _VALUEs where the 16 bit value is used as is, or _STRDEFs which acts as a pointers to a string value. The value stored in a _STRDEF is two separate bytes: The low seven bits of the first (LSB) byte indicates the number of characters in the string, and the top bit of the first (LSB) byte if set to indicate that each character in the string is two bytes (Unicode) versus one byte if unset. The second (MSB) byte represents the location of the string data, and is encoded as the number of rows from this USB_WHITE_LABEL_ADDR; i.e. the row of the start of the string is USB_WHITE_LABEL_ADDR value + msb_byte. In each case, the corresponding valid bit enables replacing the default value for the corresponding item provided by the boot rom. Note that Unicode _STRDEFs are only supported for USB_DEVICE_PRODUCT_STRDEF, USB_DEVICE_SERIAL_NUMBER_STRDEF and USB_DEVICE_MANUFACTURER_STRDEF. Unicode values will be ignored if specified for other fields, and non-unicode values for these three items will be converted to Unicode characters by setting the upper 8 bits to zero. Note that if the USB_WHITE_LABEL structure or the corresponding strings are not readable by BOOTSEL mode based on OTP permissions, or if alignment requirements are not met, then the corresponding default values are used. The index values indicate where each field is located (row USB_WHITE_LABEL_ADDR value + index):"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1002,5 +1508,25 @@ impl Default for UsbWhiteLabelAddr {
     #[inline(always)]
     fn default() -> UsbWhiteLabelAddr {
         UsbWhiteLabelAddr(0)
+    }
+}
+impl core::fmt::Debug for UsbWhiteLabelAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbWhiteLabelAddr")
+            .field("usb_white_label_addr", &self.usb_white_label_addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbWhiteLabelAddr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbWhiteLabelAddr {
+            usb_white_label_addr: super::vals::UsbWhiteLabelAddr,
+        }
+        let proxy = UsbWhiteLabelAddr {
+            usb_white_label_addr: self.usb_white_label_addr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/otp_data_raw/vals.rs
+++ b/src/rp235x/otp_data_raw/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Cs0size {
     NONE = 0x0,
     _8K = 0x01,
@@ -66,6 +67,47 @@ impl Cs1size {
         self.0
     }
 }
+impl core::fmt::Debug for Cs1size {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("NONE"),
+            0x01 => f.write_str("_8K"),
+            0x02 => f.write_str("_16K"),
+            0x03 => f.write_str("_32K"),
+            0x04 => f.write_str("_64K"),
+            0x05 => f.write_str("_128K"),
+            0x06 => f.write_str("_256K"),
+            0x07 => f.write_str("_512K"),
+            0x08 => f.write_str("_1M"),
+            0x09 => f.write_str("_2M"),
+            0x0a => f.write_str("_4M"),
+            0x0b => f.write_str("_8M"),
+            0x0c => f.write_str("_16M"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cs1size {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "NONE"),
+            0x01 => defmt::write!(f, "_8K"),
+            0x02 => defmt::write!(f, "_16K"),
+            0x03 => defmt::write!(f, "_32K"),
+            0x04 => defmt::write!(f, "_64K"),
+            0x05 => defmt::write!(f, "_128K"),
+            0x06 => defmt::write!(f, "_256K"),
+            0x07 => defmt::write!(f, "_512K"),
+            0x08 => defmt::write!(f, "_1M"),
+            0x09 => defmt::write!(f, "_2M"),
+            0x0a => defmt::write!(f, "_4M"),
+            0x0b => defmt::write!(f, "_8M"),
+            0x0c => defmt::write!(f, "_16M"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Cs1size {
     #[inline(always)]
     fn from(val: u16) -> Cs1size {
@@ -79,7 +121,8 @@ impl From<Cs1size> for u16 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PageLock {
     #[doc = "Bootloader permits user reads and writes to this page"]
     READ_WRITE = 0x0,
@@ -113,7 +156,8 @@ impl From<PageLock> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PageLockNoKeyState {
     READ_ONLY = 0x0,
     INACCESSIBLE = 0x01,
@@ -157,6 +201,29 @@ impl Range {
         self.0
     }
 }
+impl core::fmt::Debug for Range {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("_1_15MHZ"),
+            0x01 => f.write_str("_10_30MHZ"),
+            0x02 => f.write_str("_25_60MHZ"),
+            0x03 => f.write_str("_40_100MHZ"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Range {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "_1_15MHZ"),
+            0x01 => defmt::write!(f, "_10_30MHZ"),
+            0x02 => defmt::write!(f, "_25_60MHZ"),
+            0x03 => defmt::write!(f, "_40_100MHZ"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Range {
     #[inline(always)]
     fn from(val: u16) -> Range {
@@ -196,6 +263,53 @@ impl UsbWhiteLabelAddr {
     }
     pub const fn to_bits(self) -> u32 {
         self.0
+    }
+}
+impl core::fmt::Debug for UsbWhiteLabelAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("INDEX_USB_DEVICE_VID_VALUE"),
+            0x01 => f.write_str("INDEX_USB_DEVICE_PID_VALUE"),
+            0x02 => f.write_str("INDEX_USB_DEVICE_BCD_DEVICE_VALUE"),
+            0x03 => f.write_str("INDEX_USB_DEVICE_LANG_ID_VALUE"),
+            0x04 => f.write_str("INDEX_USB_DEVICE_MANUFACTURER_STRDEF"),
+            0x05 => f.write_str("INDEX_USB_DEVICE_PRODUCT_STRDEF"),
+            0x06 => f.write_str("INDEX_USB_DEVICE_SERIAL_NUMBER_STRDEF"),
+            0x07 => f.write_str("INDEX_USB_CONFIG_ATTRIBUTES_MAX_POWER_VALUES"),
+            0x08 => f.write_str("INDEX_VOLUME_LABEL_STRDEF"),
+            0x09 => f.write_str("INDEX_SCSI_INQUIRY_VENDOR_STRDEF"),
+            0x0a => f.write_str("INDEX_SCSI_INQUIRY_PRODUCT_STRDEF"),
+            0x0b => f.write_str("INDEX_SCSI_INQUIRY_VERSION_STRDEF"),
+            0x0c => f.write_str("INDEX_INDEX_HTM_REDIRECT_URL_STRDEF"),
+            0x0d => f.write_str("INDEX_INDEX_HTM_REDIRECT_NAME_STRDEF"),
+            0x0e => f.write_str("INDEX_INFO_UF2_TXT_MODEL_STRDEF"),
+            0x0f => f.write_str("INDEX_INFO_UF2_TXT_BOARD_ID_STRDEF"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbWhiteLabelAddr {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "INDEX_USB_DEVICE_VID_VALUE"),
+            0x01 => defmt::write!(f, "INDEX_USB_DEVICE_PID_VALUE"),
+            0x02 => defmt::write!(f, "INDEX_USB_DEVICE_BCD_DEVICE_VALUE"),
+            0x03 => defmt::write!(f, "INDEX_USB_DEVICE_LANG_ID_VALUE"),
+            0x04 => defmt::write!(f, "INDEX_USB_DEVICE_MANUFACTURER_STRDEF"),
+            0x05 => defmt::write!(f, "INDEX_USB_DEVICE_PRODUCT_STRDEF"),
+            0x06 => defmt::write!(f, "INDEX_USB_DEVICE_SERIAL_NUMBER_STRDEF"),
+            0x07 => defmt::write!(f, "INDEX_USB_CONFIG_ATTRIBUTES_MAX_POWER_VALUES"),
+            0x08 => defmt::write!(f, "INDEX_VOLUME_LABEL_STRDEF"),
+            0x09 => defmt::write!(f, "INDEX_SCSI_INQUIRY_VENDOR_STRDEF"),
+            0x0a => defmt::write!(f, "INDEX_SCSI_INQUIRY_PRODUCT_STRDEF"),
+            0x0b => defmt::write!(f, "INDEX_SCSI_INQUIRY_VERSION_STRDEF"),
+            0x0c => defmt::write!(f, "INDEX_INDEX_HTM_REDIRECT_URL_STRDEF"),
+            0x0d => defmt::write!(f, "INDEX_INDEX_HTM_REDIRECT_NAME_STRDEF"),
+            0x0e => defmt::write!(f, "INDEX_INFO_UF2_TXT_MODEL_STRDEF"),
+            0x0f => defmt::write!(f, "INDEX_INFO_UF2_TXT_BOARD_ID_STRDEF"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u32> for UsbWhiteLabelAddr {

--- a/src/rp235x/pads/regs.rs
+++ b/src/rp235x/pads/regs.rs
@@ -97,6 +97,47 @@ impl Default for GpioCtrl {
         GpioCtrl(0)
     }
 }
+impl core::fmt::Debug for GpioCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("GpioCtrl")
+            .field("slewfast", &self.slewfast())
+            .field("schmitt", &self.schmitt())
+            .field("pde", &self.pde())
+            .field("pue", &self.pue())
+            .field("drive", &self.drive())
+            .field("ie", &self.ie())
+            .field("od", &self.od())
+            .field("iso", &self.iso())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for GpioCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct GpioCtrl {
+            slewfast: bool,
+            schmitt: bool,
+            pde: bool,
+            pue: bool,
+            drive: super::vals::Drive,
+            ie: bool,
+            od: bool,
+            iso: bool,
+        }
+        let proxy = GpioCtrl {
+            slewfast: self.slewfast(),
+            schmitt: self.schmitt(),
+            pde: self.pde(),
+            pue: self.pue(),
+            drive: self.drive(),
+            ie: self.ie(),
+            od: self.od(),
+            iso: self.iso(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Voltage select. Per bank control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -116,5 +157,25 @@ impl Default for VoltageSelect {
     #[inline(always)]
     fn default() -> VoltageSelect {
         VoltageSelect(0)
+    }
+}
+impl core::fmt::Debug for VoltageSelect {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VoltageSelect")
+            .field("voltage_select", &self.voltage_select())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VoltageSelect {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct VoltageSelect {
+            voltage_select: super::vals::VoltageSelect,
+        }
+        let proxy = VoltageSelect {
+            voltage_select: self.voltage_select(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/pads/vals.rs
+++ b/src/rp235x/pads/vals.rs
@@ -1,10 +1,11 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Drive {
-    _2MA = 0x0,
-    _4MA = 0x01,
-    _8MA = 0x02,
-    _12MA = 0x03,
+    _2M_A = 0x0,
+    _4M_A = 0x01,
+    _8M_A = 0x02,
+    _12M_A = 0x03,
 }
 impl Drive {
     #[inline(always)]
@@ -29,7 +30,8 @@ impl From<Drive> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum VoltageSelect {
     #[doc = "Set voltage to 3.3V (DVDD >= 2V5)"]
     _3V3 = 0x0,

--- a/src/rp235x/pio.rs
+++ b/src/rp235x/pio.rs
@@ -13,17 +13,17 @@ impl Irq {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "Interrupt Enable for irq0"]
+    #[doc = "Interrupt Enable for irq1"]
     #[inline(always)]
     pub const fn inte(self) -> crate::common::Reg<regs::Intr, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "Interrupt Force for irq0"]
+    #[doc = "Interrupt Force for irq1"]
     #[inline(always)]
     pub const fn intf(self) -> crate::common::Reg<regs::Intr, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
-    #[doc = "Interrupt status after masking & forcing for irq0"]
+    #[doc = "Interrupt status after masking & forcing for irq1"]
     #[inline(always)]
     pub const fn ints(self) -> crate::common::Reg<regs::Intr, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
@@ -157,7 +157,7 @@ impl RxfPutGet {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "Direct read/write access to entry 0 of SM2's RX FIFO, if SHIFTCTRL_FJOIN_RX_PUT xor SHIFTCTRL_FJOIN_RX_GET is set."]
+    #[doc = "Direct read/write access to entry 0 of SM3's RX FIFO, if SHIFTCTRL_FJOIN_RX_PUT xor SHIFTCTRL_FJOIN_RX_GET is set."]
     #[inline(always)]
     pub const fn putget(self, n: usize) -> crate::common::Reg<u32, crate::common::RW> {
         assert!(n < 4usize);

--- a/src/rp235x/pio/regs.rs
+++ b/src/rp235x/pio/regs.rs
@@ -98,6 +98,47 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("sm_enable", &self.sm_enable())
+            .field("sm_restart", &self.sm_restart())
+            .field("clkdiv_restart", &self.clkdiv_restart())
+            .field("prev_pio_mask", &self.prev_pio_mask())
+            .field("next_pio_mask", &self.next_pio_mask())
+            .field("nextprev_sm_enable", &self.nextprev_sm_enable())
+            .field("nextprev_sm_disable", &self.nextprev_sm_disable())
+            .field("nextprev_clkdiv_restart", &self.nextprev_clkdiv_restart())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            sm_enable: u8,
+            sm_restart: u8,
+            clkdiv_restart: u8,
+            prev_pio_mask: u8,
+            next_pio_mask: u8,
+            nextprev_sm_enable: bool,
+            nextprev_sm_disable: bool,
+            nextprev_clkdiv_restart: bool,
+        }
+        let proxy = Ctrl {
+            sm_enable: self.sm_enable(),
+            sm_restart: self.sm_restart(),
+            clkdiv_restart: self.clkdiv_restart(),
+            prev_pio_mask: self.prev_pio_mask(),
+            next_pio_mask: self.next_pio_mask(),
+            nextprev_sm_enable: self.nextprev_sm_enable(),
+            nextprev_sm_disable: self.nextprev_sm_disable(),
+            nextprev_clkdiv_restart: self.nextprev_clkdiv_restart(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "The PIO hardware has some free parameters that may vary between chip products. These should be provided in the chip datasheet, but are also exposed here."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -154,6 +195,35 @@ impl Default for DbgCfginfo {
         DbgCfginfo(0)
     }
 }
+impl core::fmt::Debug for DbgCfginfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DbgCfginfo")
+            .field("fifo_depth", &self.fifo_depth())
+            .field("sm_count", &self.sm_count())
+            .field("imem_size", &self.imem_size())
+            .field("version", &self.version())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DbgCfginfo {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DbgCfginfo {
+            fifo_depth: u8,
+            sm_count: u8,
+            imem_size: u8,
+            version: super::vals::Version,
+        }
+        let proxy = DbgCfginfo {
+            fifo_depth: self.fifo_depth(),
+            sm_count: self.sm_count(),
+            imem_size: self.imem_size(),
+            version: self.version(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO debug register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -208,6 +278,35 @@ impl Default for Fdebug {
     #[inline(always)]
     fn default() -> Fdebug {
         Fdebug(0)
+    }
+}
+impl core::fmt::Debug for Fdebug {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fdebug")
+            .field("rxstall", &self.rxstall())
+            .field("rxunder", &self.rxunder())
+            .field("txover", &self.txover())
+            .field("txstall", &self.txstall())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fdebug {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fdebug {
+            rxstall: u8,
+            rxunder: u8,
+            txover: u8,
+            txstall: u8,
+        }
+        let proxy = Fdebug {
+            rxstall: self.rxstall(),
+            rxunder: self.rxunder(),
+            txover: self.txover(),
+            txstall: self.txstall(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "FIFO levels"]
@@ -294,6 +393,47 @@ impl Default for Flevel {
         Flevel(0)
     }
 }
+impl core::fmt::Debug for Flevel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Flevel")
+            .field("tx0", &self.tx0())
+            .field("rx0", &self.rx0())
+            .field("tx1", &self.tx1())
+            .field("rx1", &self.rx1())
+            .field("tx2", &self.tx2())
+            .field("rx2", &self.rx2())
+            .field("tx3", &self.tx3())
+            .field("rx3", &self.rx3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Flevel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Flevel {
+            tx0: u8,
+            rx0: u8,
+            tx1: u8,
+            rx1: u8,
+            tx2: u8,
+            rx2: u8,
+            tx3: u8,
+            rx3: u8,
+        }
+        let proxy = Flevel {
+            tx0: self.tx0(),
+            rx0: self.rx0(),
+            tx1: self.tx1(),
+            rx1: self.rx1(),
+            tx2: self.tx2(),
+            rx2: self.rx2(),
+            tx3: self.tx3(),
+            rx3: self.rx3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -350,6 +490,35 @@ impl Default for Fstat {
         Fstat(0)
     }
 }
+impl core::fmt::Debug for Fstat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Fstat")
+            .field("rxfull", &self.rxfull())
+            .field("rxempty", &self.rxempty())
+            .field("txfull", &self.txfull())
+            .field("txempty", &self.txempty())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fstat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Fstat {
+            rxfull: u8,
+            rxempty: u8,
+            txfull: u8,
+            txempty: u8,
+        }
+        let proxy = Fstat {
+            rxfull: self.rxfull(),
+            rxempty: self.rxempty(),
+            txfull: self.txfull(),
+            txempty: self.txempty(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Relocate GPIO 0 (from PIO's point of view) in the system GPIO numbering, to access more than 32 GPIOs from PIO. Only the values 0 and 16 are supported (only bit 4 is writable)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -371,7 +540,27 @@ impl Default for Gpiobase {
         Gpiobase(0)
     }
 }
-#[doc = "Write-only access to instruction memory location 24"]
+impl core::fmt::Debug for Gpiobase {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Gpiobase")
+            .field("gpiobase", &self.gpiobase())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Gpiobase {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Gpiobase {
+            gpiobase: bool,
+        }
+        let proxy = Gpiobase {
+            gpiobase: self.gpiobase(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Write-only access to instruction memory location 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct InstrMem(pub u32);
@@ -390,6 +579,26 @@ impl Default for InstrMem {
     #[inline(always)]
     fn default() -> InstrMem {
         InstrMem(0)
+    }
+}
+impl core::fmt::Debug for InstrMem {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("InstrMem")
+            .field("instr_mem", &self.instr_mem())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for InstrMem {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct InstrMem {
+            instr_mem: u16,
+        }
+        let proxy = InstrMem {
+            instr_mem: self.instr_mem(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Raw Interrupts"]
@@ -548,6 +757,71 @@ impl Default for Intr {
         Intr(0)
     }
 }
+impl core::fmt::Debug for Intr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intr")
+            .field("sm0_rxnempty", &self.sm0_rxnempty())
+            .field("sm1_rxnempty", &self.sm1_rxnempty())
+            .field("sm2_rxnempty", &self.sm2_rxnempty())
+            .field("sm3_rxnempty", &self.sm3_rxnempty())
+            .field("sm0_txnfull", &self.sm0_txnfull())
+            .field("sm1_txnfull", &self.sm1_txnfull())
+            .field("sm2_txnfull", &self.sm2_txnfull())
+            .field("sm3_txnfull", &self.sm3_txnfull())
+            .field("sm0", &self.sm0())
+            .field("sm1", &self.sm1())
+            .field("sm2", &self.sm2())
+            .field("sm3", &self.sm3())
+            .field("sm4", &self.sm4())
+            .field("sm5", &self.sm5())
+            .field("sm6", &self.sm6())
+            .field("sm7", &self.sm7())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intr {
+            sm0_rxnempty: bool,
+            sm1_rxnempty: bool,
+            sm2_rxnempty: bool,
+            sm3_rxnempty: bool,
+            sm0_txnfull: bool,
+            sm1_txnfull: bool,
+            sm2_txnfull: bool,
+            sm3_txnfull: bool,
+            sm0: bool,
+            sm1: bool,
+            sm2: bool,
+            sm3: bool,
+            sm4: bool,
+            sm5: bool,
+            sm6: bool,
+            sm7: bool,
+        }
+        let proxy = Intr {
+            sm0_rxnempty: self.sm0_rxnempty(),
+            sm1_rxnempty: self.sm1_rxnempty(),
+            sm2_rxnempty: self.sm2_rxnempty(),
+            sm3_rxnempty: self.sm3_rxnempty(),
+            sm0_txnfull: self.sm0_txnfull(),
+            sm1_txnfull: self.sm1_txnfull(),
+            sm2_txnfull: self.sm2_txnfull(),
+            sm3_txnfull: self.sm3_txnfull(),
+            sm0: self.sm0(),
+            sm1: self.sm1(),
+            sm2: self.sm2(),
+            sm3: self.sm3(),
+            sm4: self.sm4(),
+            sm5: self.sm5(),
+            sm6: self.sm6(),
+            sm7: self.sm7(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "State machine IRQ flags register. Write 1 to clear. There are eight state machine IRQ flags, which can be set, cleared, and waited on by the state machines. There's no fixed association between flags and state machines -- any state machine can use any flag. Any of the eight flags can be used for timing synchronisation between state machines, using IRQ and WAIT instructions. Any combination of the eight flags can also routed out to either of the two system-level interrupt requests, alongside FIFO status interrupts -- see e.g. IRQ0_INTE."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -567,6 +841,22 @@ impl Default for Irq {
     #[inline(always)]
     fn default() -> Irq {
         Irq(0)
+    }
+}
+impl core::fmt::Debug for Irq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq").field("irq", &self.irq()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq {
+            irq: u8,
+        }
+        let proxy = Irq { irq: self.irq() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Writing a 1 to each of these bits will forcibly assert the corresponding IRQ. Note this is different to the INTF register: writing here affects PIO internal state. INTF just asserts the processor-facing IRQ signal for testing ISRs, and is not visible to the state machines."]
@@ -590,7 +880,27 @@ impl Default for IrqForce {
         IrqForce(0)
     }
 }
-#[doc = "Current instruction address of state machine 1"]
+impl core::fmt::Debug for IrqForce {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IrqForce")
+            .field("irq_force", &self.irq_force())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IrqForce {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IrqForce {
+            irq_force: u8,
+        }
+        let proxy = IrqForce {
+            irq_force: self.irq_force(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Current instruction address of state machine 0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SmAddr(pub u32);
@@ -611,7 +921,25 @@ impl Default for SmAddr {
         SmAddr(0)
     }
 }
-#[doc = "Clock divisor register for state machine 1 Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)"]
+impl core::fmt::Debug for SmAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmAddr")
+            .field("addr", &self.addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmAddr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmAddr {
+            addr: u8,
+        }
+        let proxy = SmAddr { addr: self.addr() };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Clock divisor register for state machine 0 Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SmClkdiv(pub u32);
@@ -643,6 +971,29 @@ impl Default for SmClkdiv {
     #[inline(always)]
     fn default() -> SmClkdiv {
         SmClkdiv(0)
+    }
+}
+impl core::fmt::Debug for SmClkdiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmClkdiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmClkdiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmClkdiv {
+            frac: u8,
+            int: u16,
+        }
+        let proxy = SmClkdiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Execution/behavioural settings for state machine 0"]
@@ -778,7 +1129,57 @@ impl Default for SmExecctrl {
         SmExecctrl(0)
     }
 }
-#[doc = "Read to see the instruction currently addressed by state machine 2's program counter Write to execute an instruction immediately (including jumps) and then resume execution."]
+impl core::fmt::Debug for SmExecctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmExecctrl")
+            .field("status_n", &self.status_n())
+            .field("status_sel", &self.status_sel())
+            .field("wrap_bottom", &self.wrap_bottom())
+            .field("wrap_top", &self.wrap_top())
+            .field("out_sticky", &self.out_sticky())
+            .field("inline_out_en", &self.inline_out_en())
+            .field("out_en_sel", &self.out_en_sel())
+            .field("jmp_pin", &self.jmp_pin())
+            .field("side_pindir", &self.side_pindir())
+            .field("side_en", &self.side_en())
+            .field("exec_stalled", &self.exec_stalled())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmExecctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmExecctrl {
+            status_n: super::vals::ExecctrlStatusN,
+            status_sel: super::vals::ExecctrlStatusSel,
+            wrap_bottom: u8,
+            wrap_top: u8,
+            out_sticky: bool,
+            inline_out_en: bool,
+            out_en_sel: u8,
+            jmp_pin: u8,
+            side_pindir: bool,
+            side_en: bool,
+            exec_stalled: bool,
+        }
+        let proxy = SmExecctrl {
+            status_n: self.status_n(),
+            status_sel: self.status_sel(),
+            wrap_bottom: self.wrap_bottom(),
+            wrap_top: self.wrap_top(),
+            out_sticky: self.out_sticky(),
+            inline_out_en: self.inline_out_en(),
+            out_en_sel: self.out_en_sel(),
+            jmp_pin: self.jmp_pin(),
+            side_pindir: self.side_pindir(),
+            side_en: self.side_en(),
+            exec_stalled: self.exec_stalled(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Read to see the instruction currently addressed by state machine 0's program counter Write to execute an instruction immediately (including jumps) and then resume execution."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SmInstr(pub u32);
@@ -797,6 +1198,26 @@ impl Default for SmInstr {
     #[inline(always)]
     fn default() -> SmInstr {
         SmInstr(0)
+    }
+}
+impl core::fmt::Debug for SmInstr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmInstr")
+            .field("instr", &self.instr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmInstr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmInstr {
+            instr: u16,
+        }
+        let proxy = SmInstr {
+            instr: self.instr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "State machine pin control"]
@@ -886,6 +1307,44 @@ impl Default for SmPinctrl {
     #[inline(always)]
     fn default() -> SmPinctrl {
         SmPinctrl(0)
+    }
+}
+impl core::fmt::Debug for SmPinctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmPinctrl")
+            .field("out_base", &self.out_base())
+            .field("set_base", &self.set_base())
+            .field("sideset_base", &self.sideset_base())
+            .field("in_base", &self.in_base())
+            .field("out_count", &self.out_count())
+            .field("set_count", &self.set_count())
+            .field("sideset_count", &self.sideset_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmPinctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmPinctrl {
+            out_base: u8,
+            set_base: u8,
+            sideset_base: u8,
+            in_base: u8,
+            out_count: u8,
+            set_count: u8,
+            sideset_count: u8,
+        }
+        let proxy = SmPinctrl {
+            out_base: self.out_base(),
+            set_base: self.set_base(),
+            sideset_base: self.sideset_base(),
+            in_base: self.in_base(),
+            out_count: self.out_count(),
+            set_count: self.set_count(),
+            sideset_count: self.sideset_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control behaviour of the input/output shift registers for state machine 0"]
@@ -1019,5 +1478,55 @@ impl Default for SmShiftctrl {
     #[inline(always)]
     fn default() -> SmShiftctrl {
         SmShiftctrl(0)
+    }
+}
+impl core::fmt::Debug for SmShiftctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmShiftctrl")
+            .field("in_count", &self.in_count())
+            .field("fjoin_rx_get", &self.fjoin_rx_get())
+            .field("fjoin_rx_put", &self.fjoin_rx_put())
+            .field("autopush", &self.autopush())
+            .field("autopull", &self.autopull())
+            .field("in_shiftdir", &self.in_shiftdir())
+            .field("out_shiftdir", &self.out_shiftdir())
+            .field("push_thresh", &self.push_thresh())
+            .field("pull_thresh", &self.pull_thresh())
+            .field("fjoin_tx", &self.fjoin_tx())
+            .field("fjoin_rx", &self.fjoin_rx())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmShiftctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmShiftctrl {
+            in_count: u8,
+            fjoin_rx_get: bool,
+            fjoin_rx_put: bool,
+            autopush: bool,
+            autopull: bool,
+            in_shiftdir: bool,
+            out_shiftdir: bool,
+            push_thresh: u8,
+            pull_thresh: u8,
+            fjoin_tx: bool,
+            fjoin_rx: bool,
+        }
+        let proxy = SmShiftctrl {
+            in_count: self.in_count(),
+            fjoin_rx_get: self.fjoin_rx_get(),
+            fjoin_rx_put: self.fjoin_rx_put(),
+            autopush: self.autopush(),
+            autopull: self.autopull(),
+            in_shiftdir: self.in_shiftdir(),
+            out_shiftdir: self.out_shiftdir(),
+            push_thresh: self.push_thresh(),
+            pull_thresh: self.pull_thresh(),
+            fjoin_tx: self.fjoin_tx(),
+            fjoin_rx: self.fjoin_rx(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/pio/vals.rs
+++ b/src/rp235x/pio/vals.rs
@@ -17,6 +17,27 @@ impl ExecctrlStatusN {
         self.0
     }
 }
+impl core::fmt::Debug for ExecctrlStatusN {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0 => f.write_str("IRQ"),
+            0x08 => f.write_str("IRQ_PREVPIO"),
+            0x10 => f.write_str("IRQ_NEXTPIO"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ExecctrlStatusN {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0 => defmt::write!(f, "IRQ"),
+            0x08 => defmt::write!(f, "IRQ_PREVPIO"),
+            0x10 => defmt::write!(f, "IRQ_NEXTPIO"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u8> for ExecctrlStatusN {
     #[inline(always)]
     fn from(val: u8) -> ExecctrlStatusN {
@@ -30,7 +51,8 @@ impl From<ExecctrlStatusN> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ExecctrlStatusSel {
     #[doc = "All-ones if TX FIFO level < N, otherwise all-zeroes"]
     TXLEVEL = 0x0,
@@ -63,7 +85,8 @@ impl From<ExecctrlStatusSel> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Version {
     #[doc = "Version 0 (RP2040)"]
     V0 = 0x0,

--- a/src/rp235x/pll/regs.rs
+++ b/src/rp235x/pll/regs.rs
@@ -54,6 +54,35 @@ impl Default for Cs {
         Cs(0)
     }
 }
+impl core::fmt::Debug for Cs {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cs")
+            .field("refdiv", &self.refdiv())
+            .field("bypass", &self.bypass())
+            .field("lock_n", &self.lock_n())
+            .field("lock", &self.lock())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cs {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cs {
+            refdiv: u8,
+            bypass: bool,
+            lock_n: bool,
+            lock: bool,
+        }
+        let proxy = Cs {
+            refdiv: self.refdiv(),
+            bypass: self.bypass(),
+            lock_n: self.lock_n(),
+            lock: self.lock(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Feedback divisor (note: this PLL does not support fractional division)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -77,6 +106,26 @@ impl Default for FbdivInt {
         FbdivInt(0)
     }
 }
+impl core::fmt::Debug for FbdivInt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FbdivInt")
+            .field("fbdiv_int", &self.fbdiv_int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FbdivInt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FbdivInt {
+            fbdiv_int: u16,
+        }
+        let proxy = FbdivInt {
+            fbdiv_int: self.fbdiv_int(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -96,6 +145,26 @@ impl Default for Inte {
     #[inline(always)]
     fn default() -> Inte {
         Inte(0)
+    }
+}
+impl core::fmt::Debug for Inte {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Inte")
+            .field("lock_n_sticky", &self.lock_n_sticky())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Inte {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Inte {
+            lock_n_sticky: bool,
+        }
+        let proxy = Inte {
+            lock_n_sticky: self.lock_n_sticky(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Force"]
@@ -119,6 +188,26 @@ impl Default for Intf {
         Intf(0)
     }
 }
+impl core::fmt::Debug for Intf {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intf")
+            .field("lock_n_sticky", &self.lock_n_sticky())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intf {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intf {
+            lock_n_sticky: bool,
+        }
+        let proxy = Intf {
+            lock_n_sticky: self.lock_n_sticky(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Raw Interrupts"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -140,6 +229,26 @@ impl Default for Intr {
         Intr(0)
     }
 }
+impl core::fmt::Debug for Intr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intr")
+            .field("lock_n_sticky", &self.lock_n_sticky())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intr {
+            lock_n_sticky: bool,
+        }
+        let proxy = Intr {
+            lock_n_sticky: self.lock_n_sticky(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt status after masking & forcing"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -159,6 +268,26 @@ impl Default for Ints {
     #[inline(always)]
     fn default() -> Ints {
         Ints(0)
+    }
+}
+impl core::fmt::Debug for Ints {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ints")
+            .field("lock_n_sticky", &self.lock_n_sticky())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ints {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ints {
+            lock_n_sticky: bool,
+        }
+        let proxy = Ints {
+            lock_n_sticky: self.lock_n_sticky(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the PLL post dividers for the primary output (note: this PLL does not have a secondary output) the primary output is driven from VCO divided by postdiv1*postdiv2"]
@@ -193,6 +322,29 @@ impl Default for Prim {
     #[inline(always)]
     fn default() -> Prim {
         Prim(0)
+    }
+}
+impl core::fmt::Debug for Prim {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Prim")
+            .field("postdiv2", &self.postdiv2())
+            .field("postdiv1", &self.postdiv1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Prim {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Prim {
+            postdiv2: u8,
+            postdiv1: u8,
+        }
+        let proxy = Prim {
+            postdiv2: self.postdiv2(),
+            postdiv1: self.postdiv1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the PLL power modes."]
@@ -249,5 +401,34 @@ impl Default for Pwr {
     #[inline(always)]
     fn default() -> Pwr {
         Pwr(0)
+    }
+}
+impl core::fmt::Debug for Pwr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pwr")
+            .field("pd", &self.pd())
+            .field("dsmpd", &self.dsmpd())
+            .field("postdivpd", &self.postdivpd())
+            .field("vcopd", &self.vcopd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pwr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pwr {
+            pd: bool,
+            dsmpd: bool,
+            postdivpd: bool,
+            vcopd: bool,
+        }
+        let proxy = Pwr {
+            pd: self.pd(),
+            dsmpd: self.dsmpd(),
+            postdivpd: self.postdivpd(),
+            vcopd: self.vcopd(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/powman/regs.rs
+++ b/src/rp235x/powman/regs.rs
@@ -20,6 +20,26 @@ impl Default for AlarmTime15to0 {
         AlarmTime15to0(0)
     }
 }
+impl core::fmt::Debug for AlarmTime15to0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AlarmTime15to0")
+            .field("alarm_time_15to0", &self.alarm_time_15to0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AlarmTime15to0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AlarmTime15to0 {
+            alarm_time_15to0: u16,
+        }
+        let proxy = AlarmTime15to0 {
+            alarm_time_15to0: self.alarm_time_15to0(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct AlarmTime31to16(pub u32);
@@ -40,6 +60,26 @@ impl Default for AlarmTime31to16 {
     #[inline(always)]
     fn default() -> AlarmTime31to16 {
         AlarmTime31to16(0)
+    }
+}
+impl core::fmt::Debug for AlarmTime31to16 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AlarmTime31to16")
+            .field("alarm_time_31to16", &self.alarm_time_31to16())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AlarmTime31to16 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AlarmTime31to16 {
+            alarm_time_31to16: u16,
+        }
+        let proxy = AlarmTime31to16 {
+            alarm_time_31to16: self.alarm_time_31to16(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -64,6 +104,26 @@ impl Default for AlarmTime47to32 {
         AlarmTime47to32(0)
     }
 }
+impl core::fmt::Debug for AlarmTime47to32 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AlarmTime47to32")
+            .field("alarm_time_47to32", &self.alarm_time_47to32())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AlarmTime47to32 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AlarmTime47to32 {
+            alarm_time_47to32: u16,
+        }
+        let proxy = AlarmTime47to32 {
+            alarm_time_47to32: self.alarm_time_47to32(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct AlarmTime63to48(pub u32);
@@ -86,6 +146,26 @@ impl Default for AlarmTime63to48 {
         AlarmTime63to48(0)
     }
 }
+impl core::fmt::Debug for AlarmTime63to48 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AlarmTime63to48")
+            .field("alarm_time_63to48", &self.alarm_time_63to48())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AlarmTime63to48 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AlarmTime63to48 {
+            alarm_time_63to48: u16,
+        }
+        let proxy = AlarmTime63to48 {
+            alarm_time_63to48: self.alarm_time_63to48(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Indicates a bad password has been used"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -105,6 +185,26 @@ impl Default for Badpasswd {
     #[inline(always)]
     fn default() -> Badpasswd {
         Badpasswd(0)
+    }
+}
+impl core::fmt::Debug for Badpasswd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Badpasswd")
+            .field("badpasswd", &self.badpasswd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Badpasswd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Badpasswd {
+            badpasswd: bool,
+        }
+        let proxy = Badpasswd {
+            badpasswd: self.badpasswd(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Brown-out Detection Settings"]
@@ -141,6 +241,29 @@ impl Default for Bod {
         Bod(0)
     }
 }
+impl core::fmt::Debug for Bod {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Bod")
+            .field("en", &self.en())
+            .field("vsel", &self.vsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bod {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Bod {
+            en: bool,
+            vsel: u8,
+        }
+        let proxy = Bod {
+            en: self.en(),
+            vsel: self.vsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Brown-out Detection Control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -162,6 +285,26 @@ impl Default for BodCtrl {
     #[inline(always)]
     fn default() -> BodCtrl {
         BodCtrl(0)
+    }
+}
+impl core::fmt::Debug for BodCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BodCtrl")
+            .field("isolate", &self.isolate())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BodCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BodCtrl {
+            isolate: bool,
+        }
+        let proxy = BodCtrl {
+            isolate: self.isolate(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Brown-out Detection Low Power Entry Settings"]
@@ -198,6 +341,29 @@ impl Default for BodLpEntry {
         BodLpEntry(0)
     }
 }
+impl core::fmt::Debug for BodLpEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BodLpEntry")
+            .field("en", &self.en())
+            .field("vsel", &self.vsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BodLpEntry {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BodLpEntry {
+            en: bool,
+            vsel: u8,
+        }
+        let proxy = BodLpEntry {
+            en: self.en(),
+            vsel: self.vsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Brown-out Detection Low Power Exit Settings"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -232,6 +398,29 @@ impl Default for BodLpExit {
         BodLpExit(0)
     }
 }
+impl core::fmt::Debug for BodLpExit {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BodLpExit")
+            .field("en", &self.en())
+            .field("vsel", &self.vsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BodLpExit {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BodLpExit {
+            en: bool,
+            vsel: u8,
+        }
+        let proxy = BodLpExit {
+            en: self.en(),
+            vsel: self.vsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Tell the bootrom to ignore the BOOT0..3 registers following the next RSM reset (e.g. the next core power down/up). If an early boot stage has soft-locked some OTP pages in order to protect their contents from later stages, there is a risk that Secure code running at a later stage can unlock the pages by powering the core up and down. This register can be used to ensure that the bootloader runs as normal on the next power up, preventing Secure code at a later stage from accessing OTP in its unlocked state. Should be used in conjunction with the OTP BOOTDIS register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -264,6 +453,29 @@ impl Default for Bootdis {
     #[inline(always)]
     fn default() -> Bootdis {
         Bootdis(0)
+    }
+}
+impl core::fmt::Debug for Bootdis {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Bootdis")
+            .field("now", &self.now())
+            .field("next", &self.next())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bootdis {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Bootdis {
+            now: bool,
+            next: bool,
+        }
+        let proxy = Bootdis {
+            now: self.now(),
+            next: self.next(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Chip reset control and status"]
@@ -432,6 +644,74 @@ impl Default for ChipReset {
         ChipReset(0)
     }
 }
+impl core::fmt::Debug for ChipReset {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChipReset")
+            .field("double_tap", &self.double_tap())
+            .field("rescue_flag", &self.rescue_flag())
+            .field("had_por", &self.had_por())
+            .field("had_bor", &self.had_bor())
+            .field("had_run_low", &self.had_run_low())
+            .field("had_dp_reset_req", &self.had_dp_reset_req())
+            .field("had_rescue", &self.had_rescue())
+            .field(
+                "had_watchdog_reset_powman_async",
+                &self.had_watchdog_reset_powman_async(),
+            )
+            .field(
+                "had_watchdog_reset_powman",
+                &self.had_watchdog_reset_powman(),
+            )
+            .field(
+                "had_watchdog_reset_swcore",
+                &self.had_watchdog_reset_swcore(),
+            )
+            .field("had_swcore_pd", &self.had_swcore_pd())
+            .field("had_glitch_detect", &self.had_glitch_detect())
+            .field("had_hzd_sys_reset_req", &self.had_hzd_sys_reset_req())
+            .field("had_watchdog_reset_rsm", &self.had_watchdog_reset_rsm())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChipReset {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChipReset {
+            double_tap: bool,
+            rescue_flag: bool,
+            had_por: bool,
+            had_bor: bool,
+            had_run_low: bool,
+            had_dp_reset_req: bool,
+            had_rescue: bool,
+            had_watchdog_reset_powman_async: bool,
+            had_watchdog_reset_powman: bool,
+            had_watchdog_reset_swcore: bool,
+            had_swcore_pd: bool,
+            had_glitch_detect: bool,
+            had_hzd_sys_reset_req: bool,
+            had_watchdog_reset_rsm: bool,
+        }
+        let proxy = ChipReset {
+            double_tap: self.double_tap(),
+            rescue_flag: self.rescue_flag(),
+            had_por: self.had_por(),
+            had_bor: self.had_bor(),
+            had_run_low: self.had_run_low(),
+            had_dp_reset_req: self.had_dp_reset_req(),
+            had_rescue: self.had_rescue(),
+            had_watchdog_reset_powman_async: self.had_watchdog_reset_powman_async(),
+            had_watchdog_reset_powman: self.had_watchdog_reset_powman(),
+            had_watchdog_reset_swcore: self.had_watchdog_reset_swcore(),
+            had_swcore_pd: self.had_swcore_pd(),
+            had_glitch_detect: self.had_glitch_detect(),
+            had_hzd_sys_reset_req: self.had_hzd_sys_reset_req(),
+            had_watchdog_reset_rsm: self.had_watchdog_reset_rsm(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Indicates current powerup request state pwrup events can be cleared by removing the enable from the pwrup register. The alarm pwrup req can be cleared by clearing timer.alarm_enab 0 = chip reset, for the source of the last reset see POWMAN_CHIP_RESET 1 = pwrup0 2 = pwrup1 3 = pwrup2 4 = pwrup3 5 = coresight_pwrup 6 = alarm_pwrup"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -451,6 +731,26 @@ impl Default for CurrentPwrupReq {
     #[inline(always)]
     fn default() -> CurrentPwrupReq {
         CurrentPwrupReq(0)
+    }
+}
+impl core::fmt::Debug for CurrentPwrupReq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CurrentPwrupReq")
+            .field("current_pwrup_req", &self.current_pwrup_req())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CurrentPwrupReq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct CurrentPwrupReq {
+            current_pwrup_req: u8,
+        }
+        let proxy = CurrentPwrupReq {
+            current_pwrup_req: self.current_pwrup_req(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -475,6 +775,26 @@ impl Default for DbgPwrcfg {
         DbgPwrcfg(0)
     }
 }
+impl core::fmt::Debug for DbgPwrcfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DbgPwrcfg")
+            .field("ignore", &self.ignore())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DbgPwrcfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DbgPwrcfg {
+            ignore: bool,
+        }
+        let proxy = DbgPwrcfg {
+            ignore: self.ignore(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Dbgconfig(pub u32);
@@ -495,6 +815,26 @@ impl Default for Dbgconfig {
     #[inline(always)]
     fn default() -> Dbgconfig {
         Dbgconfig(0)
+    }
+}
+impl core::fmt::Debug for Dbgconfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dbgconfig")
+            .field("dp_instid", &self.dp_instid())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dbgconfig {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dbgconfig {
+            dp_instid: u8,
+        }
+        let proxy = Dbgconfig {
+            dp_instid: self.dp_instid(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Configures a gpio as a power mode aware control output"]
@@ -560,6 +900,38 @@ impl Default for ExtCtrl {
         ExtCtrl(0)
     }
 }
+impl core::fmt::Debug for ExtCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ExtCtrl")
+            .field("gpio_select", &self.gpio_select())
+            .field("init", &self.init())
+            .field("init_state", &self.init_state())
+            .field("lp_entry_state", &self.lp_entry_state())
+            .field("lp_exit_state", &self.lp_exit_state())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ExtCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ExtCtrl {
+            gpio_select: u8,
+            init: bool,
+            init_state: bool,
+            lp_entry_state: bool,
+            lp_exit_state: bool,
+        }
+        let proxy = ExtCtrl {
+            gpio_select: self.gpio_select(),
+            init: self.init(),
+            init_state: self.init_state(),
+            lp_entry_state: self.lp_entry_state(),
+            lp_exit_state: self.lp_exit_state(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Select a GPIO to use as a time reference, the source can be used to drive the low power clock at 32kHz, or to provide a 1ms tick to the timer, or provide a 1Hz tick to the timer. The tick selection is controlled by the POWMAN_TIMER register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -592,6 +964,29 @@ impl Default for ExtTimeRef {
     #[inline(always)]
     fn default() -> ExtTimeRef {
         ExtTimeRef(0)
+    }
+}
+impl core::fmt::Debug for ExtTimeRef {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ExtTimeRef")
+            .field("source_sel", &self.source_sel())
+            .field("drive_lpck", &self.drive_lpck())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ExtTimeRef {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ExtTimeRef {
+            source_sel: u8,
+            drive_lpck: bool,
+        }
+        let proxy = ExtTimeRef {
+            source_sel: self.source_sel(),
+            drive_lpck: self.drive_lpck(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Enable"]
@@ -646,6 +1041,35 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field("vreg_output_low", &self.vreg_output_low())
+            .field("timer", &self.timer())
+            .field("state_req_ignored", &self.state_req_ignored())
+            .field("pwrup_while_waiting", &self.pwrup_while_waiting())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            vreg_output_low: bool,
+            timer: bool,
+            state_req_ignored: bool,
+            pwrup_while_waiting: bool,
+        }
+        let proxy = Int {
+            vreg_output_low: self.vreg_output_low(),
+            timer: self.timer(),
+            state_req_ignored: self.state_req_ignored(),
+            pwrup_while_waiting: self.pwrup_while_waiting(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Indicates which pwrup source triggered the last switched-core power up 0 = chip reset, for the source of the last reset see POWMAN_CHIP_RESET 1 = pwrup0 2 = pwrup1 3 = pwrup2 4 = pwrup3 5 = coresight_pwrup 6 = alarm_pwrup"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -665,6 +1089,26 @@ impl Default for LastSwcorePwrup {
     #[inline(always)]
     fn default() -> LastSwcorePwrup {
         LastSwcorePwrup(0)
+    }
+}
+impl core::fmt::Debug for LastSwcorePwrup {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LastSwcorePwrup")
+            .field("last_swcore_pwrup", &self.last_swcore_pwrup())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LastSwcorePwrup {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct LastSwcorePwrup {
+            last_swcore_pwrup: u8,
+        }
+        let proxy = LastSwcorePwrup {
+            last_swcore_pwrup: self.last_swcore_pwrup(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Low power oscillator control register."]
@@ -701,6 +1145,29 @@ impl Default for Lposc {
         Lposc(0)
     }
 }
+impl core::fmt::Debug for Lposc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Lposc")
+            .field("mode", &self.mode())
+            .field("trim", &self.trim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Lposc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Lposc {
+            mode: u8,
+            trim: u8,
+        }
+        let proxy = Lposc {
+            mode: self.mode(),
+            trim: self.trim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Informs the AON Timer of the fractional component of the clock frequency when running off the LPOSC."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -724,6 +1191,26 @@ impl Default for LposcFreqKhzFrac {
         LposcFreqKhzFrac(0)
     }
 }
+impl core::fmt::Debug for LposcFreqKhzFrac {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LposcFreqKhzFrac")
+            .field("lposc_freq_khz_frac", &self.lposc_freq_khz_frac())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LposcFreqKhzFrac {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct LposcFreqKhzFrac {
+            lposc_freq_khz_frac: u16,
+        }
+        let proxy = LposcFreqKhzFrac {
+            lposc_freq_khz_frac: self.lposc_freq_khz_frac(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Informs the AON Timer of the integer component of the clock frequency when running off the LPOSC."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -745,6 +1232,26 @@ impl Default for LposcFreqKhzInt {
     #[inline(always)]
     fn default() -> LposcFreqKhzInt {
         LposcFreqKhzInt(0)
+    }
+}
+impl core::fmt::Debug for LposcFreqKhzInt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LposcFreqKhzInt")
+            .field("lposc_freq_khz_int", &self.lposc_freq_khz_int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LposcFreqKhzInt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct LposcFreqKhzInt {
+            lposc_freq_khz_int: u8,
+        }
+        let proxy = LposcFreqKhzInt {
+            lposc_freq_khz_int: self.lposc_freq_khz_int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "power state machine delays"]
@@ -792,6 +1299,32 @@ impl Default for PowDelay {
         PowDelay(0)
     }
 }
+impl core::fmt::Debug for PowDelay {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PowDelay")
+            .field("swcore_step", &self.swcore_step())
+            .field("xip_step", &self.xip_step())
+            .field("sram_step", &self.sram_step())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PowDelay {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PowDelay {
+            swcore_step: u8,
+            xip_step: u8,
+            sram_step: u8,
+        }
+        let proxy = PowDelay {
+            swcore_step: self.swcore_step(),
+            xip_step: self.xip_step(),
+            sram_step: self.sram_step(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct PowFastdiv(pub u32);
@@ -812,6 +1345,26 @@ impl Default for PowFastdiv {
     #[inline(always)]
     fn default() -> PowFastdiv {
         PowFastdiv(0)
+    }
+}
+impl core::fmt::Debug for PowFastdiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PowFastdiv")
+            .field("pow_fastdiv", &self.pow_fastdiv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PowFastdiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PowFastdiv {
+            pow_fastdiv: u16,
+        }
+        let proxy = PowFastdiv {
+            pow_fastdiv: self.pow_fastdiv(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "4 GPIO powerup events can be configured to wake the chip up from a low power state. The pwrups are level/edge sensitive and can be set to trigger on a high/rising or low/falling event The number of gpios available depends on the package option. An invalid selection will be ignored source = 0 selects gpio0 . . source = 47 selects gpio47 source = 48 selects qspi_ss source = 49 selects qspi_sd0 source = 50 selects qspi_sd1 source = 51 selects qspi_sd2 source = 52 selects qspi_sd3 source = 53 selects qspi_sclk level = 0 triggers the pwrup when the source is low level = 1 triggers the pwrup when the source is high"]
@@ -886,6 +1439,41 @@ impl Default for Pwrup {
     #[inline(always)]
     fn default() -> Pwrup {
         Pwrup(0)
+    }
+}
+impl core::fmt::Debug for Pwrup {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pwrup")
+            .field("source", &self.source())
+            .field("enable", &self.enable())
+            .field("direction", &self.direction())
+            .field("mode", &self.mode())
+            .field("status", &self.status())
+            .field("raw_status", &self.raw_status())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pwrup {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pwrup {
+            source: u8,
+            enable: bool,
+            direction: super::vals::Direction,
+            mode: super::vals::Mode,
+            status: bool,
+            raw_status: bool,
+        }
+        let proxy = Pwrup {
+            source: self.source(),
+            enable: self.enable(),
+            direction: self.direction(),
+            mode: self.mode(),
+            status: self.status(),
+            raw_status: self.raw_status(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "For configuration of the power sequencer Writes are ignored while POWMAN_STATE_CHANGING=1"]
@@ -1021,6 +1609,56 @@ impl Default for SeqCfg {
         SeqCfg(0)
     }
 }
+impl core::fmt::Debug for SeqCfg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SeqCfg")
+            .field("hw_pwrup_sram1", &self.hw_pwrup_sram1())
+            .field("hw_pwrup_sram0", &self.hw_pwrup_sram0())
+            .field("use_vreg_lp", &self.use_vreg_lp())
+            .field("use_vreg_hp", &self.use_vreg_hp())
+            .field("use_bod_lp", &self.use_bod_lp())
+            .field("use_bod_hp", &self.use_bod_hp())
+            .field("run_lposc_in_lp", &self.run_lposc_in_lp())
+            .field("use_fast_powck", &self.use_fast_powck())
+            .field("using_vreg_lp", &self.using_vreg_lp())
+            .field("using_bod_lp", &self.using_bod_lp())
+            .field("using_fast_powck", &self.using_fast_powck())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SeqCfg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SeqCfg {
+            hw_pwrup_sram1: bool,
+            hw_pwrup_sram0: bool,
+            use_vreg_lp: bool,
+            use_vreg_hp: bool,
+            use_bod_lp: bool,
+            use_bod_hp: bool,
+            run_lposc_in_lp: bool,
+            use_fast_powck: bool,
+            using_vreg_lp: bool,
+            using_bod_lp: bool,
+            using_fast_powck: bool,
+        }
+        let proxy = SeqCfg {
+            hw_pwrup_sram1: self.hw_pwrup_sram1(),
+            hw_pwrup_sram0: self.hw_pwrup_sram0(),
+            use_vreg_lp: self.use_vreg_lp(),
+            use_vreg_hp: self.use_vreg_hp(),
+            use_bod_lp: self.use_bod_lp(),
+            use_bod_hp: self.use_bod_hp(),
+            run_lposc_in_lp: self.run_lposc_in_lp(),
+            use_fast_powck: self.use_fast_powck(),
+            using_vreg_lp: self.using_vreg_lp(),
+            using_bod_lp: self.using_bod_lp(),
+            using_fast_powck: self.using_fast_powck(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SetTime15to0(pub u32);
@@ -1041,6 +1679,26 @@ impl Default for SetTime15to0 {
     #[inline(always)]
     fn default() -> SetTime15to0 {
         SetTime15to0(0)
+    }
+}
+impl core::fmt::Debug for SetTime15to0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetTime15to0")
+            .field("set_time_15to0", &self.set_time_15to0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetTime15to0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetTime15to0 {
+            set_time_15to0: u16,
+        }
+        let proxy = SetTime15to0 {
+            set_time_15to0: self.set_time_15to0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -1065,6 +1723,26 @@ impl Default for SetTime31to16 {
         SetTime31to16(0)
     }
 }
+impl core::fmt::Debug for SetTime31to16 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetTime31to16")
+            .field("set_time_31to16", &self.set_time_31to16())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetTime31to16 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetTime31to16 {
+            set_time_31to16: u16,
+        }
+        let proxy = SetTime31to16 {
+            set_time_31to16: self.set_time_31to16(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SetTime47to32(pub u32);
@@ -1087,6 +1765,26 @@ impl Default for SetTime47to32 {
         SetTime47to32(0)
     }
 }
+impl core::fmt::Debug for SetTime47to32 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetTime47to32")
+            .field("set_time_47to32", &self.set_time_47to32())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetTime47to32 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetTime47to32 {
+            set_time_47to32: u16,
+        }
+        let proxy = SetTime47to32 {
+            set_time_47to32: self.set_time_47to32(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SetTime63to48(pub u32);
@@ -1107,6 +1805,26 @@ impl Default for SetTime63to48 {
     #[inline(always)]
     fn default() -> SetTime63to48 {
         SetTime63to48(0)
+    }
+}
+impl core::fmt::Debug for SetTime63to48 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetTime63to48")
+            .field("set_time_63to48", &self.set_time_63to48())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetTime63to48 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetTime63to48 {
+            set_time_63to48: u16,
+        }
+        let proxy = SetTime63to48 {
+            set_time_63to48: self.set_time_63to48(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "This register controls the power state of the 4 power domains. The current power state is indicated in POWMAN_STATE_CURRENT which is read-only. To change the state, write to POWMAN_STATE_REQ. The coding of POWMAN_STATE_CURRENT & POWMAN_STATE_REQ corresponds to the power states defined in the datasheet: bit 3 = SWCORE bit 2 = XIP cache bit 1 = SRAM0 bit 0 = SRAM1 0 = powered up 1 = powered down When POWMAN_STATE_REQ is written, the POWMAN_STATE_WAITING flag is set while the Power Manager determines what is required. If an invalid transition is requested the Power Manager will still register the request in POWMAN_STATE_REQ but will also set the POWMAN_BAD_REQ flag. It will then implement the power-up requests and ignore the power down requests. To do nothing would risk entering an unrecoverable lock-up state. Invalid requests are: any combination of power up and power down requests any request that results in swcore boing powered and xip unpowered If the request is to power down the switched-core domain then POWMAN_STATE_WAITING stays active until the processors halt. During this time the POWMAN_STATE_REQ field can be re-written to change or cancel the request. When the power state transition begins the POWMAN_STATE_WAITING_flag is cleared, the POWMAN_STATE_CHANGING flag is set and POWMAN register writes are ignored until the transition completes."]
@@ -1197,6 +1915,47 @@ impl Default for State {
     #[inline(always)]
     fn default() -> State {
         State(0)
+    }
+}
+impl core::fmt::Debug for State {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("State")
+            .field("current", &self.current())
+            .field("req", &self.req())
+            .field("req_ignored", &self.req_ignored())
+            .field("pwrup_while_waiting", &self.pwrup_while_waiting())
+            .field("bad_sw_req", &self.bad_sw_req())
+            .field("bad_hw_req", &self.bad_hw_req())
+            .field("waiting", &self.waiting())
+            .field("changing", &self.changing())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for State {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct State {
+            current: u8,
+            req: u8,
+            req_ignored: bool,
+            pwrup_while_waiting: bool,
+            bad_sw_req: bool,
+            bad_hw_req: bool,
+            waiting: bool,
+            changing: bool,
+        }
+        let proxy = State {
+            current: self.current(),
+            req: self.req(),
+            req_ignored: self.req_ignored(),
+            pwrup_while_waiting: self.pwrup_while_waiting(),
+            bad_sw_req: self.bad_sw_req(),
+            bad_hw_req: self.bad_hw_req(),
+            waiting: self.waiting(),
+            changing: self.changing(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[repr(transparent)]
@@ -1364,6 +2123,65 @@ impl Default for Timer {
         Timer(0)
     }
 }
+impl core::fmt::Debug for Timer {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer")
+            .field("nonsec_write", &self.nonsec_write())
+            .field("run", &self.run())
+            .field("clear", &self.clear())
+            .field("alarm_enab", &self.alarm_enab())
+            .field("pwrup_on_alarm", &self.pwrup_on_alarm())
+            .field("alarm", &self.alarm())
+            .field("use_lposc", &self.use_lposc())
+            .field("use_xosc", &self.use_xosc())
+            .field("use_gpio_1khz", &self.use_gpio_1khz())
+            .field("use_gpio_1hz", &self.use_gpio_1hz())
+            .field("using_xosc", &self.using_xosc())
+            .field("using_lposc", &self.using_lposc())
+            .field("using_gpio_1khz", &self.using_gpio_1khz())
+            .field("using_gpio_1hz", &self.using_gpio_1hz())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer {
+            nonsec_write: bool,
+            run: bool,
+            clear: bool,
+            alarm_enab: bool,
+            pwrup_on_alarm: bool,
+            alarm: bool,
+            use_lposc: bool,
+            use_xosc: bool,
+            use_gpio_1khz: bool,
+            use_gpio_1hz: bool,
+            using_xosc: bool,
+            using_lposc: bool,
+            using_gpio_1khz: bool,
+            using_gpio_1hz: bool,
+        }
+        let proxy = Timer {
+            nonsec_write: self.nonsec_write(),
+            run: self.run(),
+            clear: self.clear(),
+            alarm_enab: self.alarm_enab(),
+            pwrup_on_alarm: self.pwrup_on_alarm(),
+            alarm: self.alarm(),
+            use_lposc: self.use_lposc(),
+            use_xosc: self.use_xosc(),
+            use_gpio_1khz: self.use_gpio_1khz(),
+            use_gpio_1hz: self.use_gpio_1hz(),
+            using_xosc: self.using_xosc(),
+            using_lposc: self.using_lposc(),
+            using_gpio_1khz: self.using_gpio_1khz(),
+            using_gpio_1hz: self.using_gpio_1hz(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Voltage Regulator Settings"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1407,6 +2225,32 @@ impl Default for Vreg {
     #[inline(always)]
     fn default() -> Vreg {
         Vreg(0)
+    }
+}
+impl core::fmt::Debug for Vreg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Vreg")
+            .field("hiz", &self.hiz())
+            .field("vsel", &self.vsel())
+            .field("update_in_progress", &self.update_in_progress())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Vreg {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Vreg {
+            hiz: bool,
+            vsel: u8,
+            update_in_progress: bool,
+        }
+        let proxy = Vreg {
+            hiz: self.hiz(),
+            vsel: self.vsel(),
+            update_in_progress: self.update_in_progress(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Voltage Regulator Control"]
@@ -1476,6 +2320,38 @@ impl Default for VregCtrl {
         VregCtrl(0)
     }
 }
+impl core::fmt::Debug for VregCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VregCtrl")
+            .field("ht_th", &self.ht_th())
+            .field("disable_voltage_limit", &self.disable_voltage_limit())
+            .field("isolate", &self.isolate())
+            .field("unlock", &self.unlock())
+            .field("rst_n", &self.rst_n())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VregCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct VregCtrl {
+            ht_th: u8,
+            disable_voltage_limit: bool,
+            isolate: bool,
+            unlock: bool,
+            rst_n: bool,
+        }
+        let proxy = VregCtrl {
+            ht_th: self.ht_th(),
+            disable_voltage_limit: self.disable_voltage_limit(),
+            isolate: self.isolate(),
+            unlock: self.unlock(),
+            rst_n: self.rst_n(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Voltage Regulator Low Power Entry Settings"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1519,6 +2395,32 @@ impl Default for VregLpEntry {
     #[inline(always)]
     fn default() -> VregLpEntry {
         VregLpEntry(0)
+    }
+}
+impl core::fmt::Debug for VregLpEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VregLpEntry")
+            .field("hiz", &self.hiz())
+            .field("mode", &self.mode())
+            .field("vsel", &self.vsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VregLpEntry {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct VregLpEntry {
+            hiz: bool,
+            mode: bool,
+            vsel: u8,
+        }
+        let proxy = VregLpEntry {
+            hiz: self.hiz(),
+            mode: self.mode(),
+            vsel: self.vsel(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Voltage Regulator Low Power Exit Settings"]
@@ -1566,6 +2468,32 @@ impl Default for VregLpExit {
         VregLpExit(0)
     }
 }
+impl core::fmt::Debug for VregLpExit {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VregLpExit")
+            .field("hiz", &self.hiz())
+            .field("mode", &self.mode())
+            .field("vsel", &self.vsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VregLpExit {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct VregLpExit {
+            hiz: bool,
+            mode: bool,
+            vsel: u8,
+        }
+        let proxy = VregLpExit {
+            hiz: self.hiz(),
+            mode: self.mode(),
+            vsel: self.vsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Voltage Regulator Status"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1598,6 +2526,29 @@ impl Default for VregSts {
     #[inline(always)]
     fn default() -> VregSts {
         VregSts(0)
+    }
+}
+impl core::fmt::Debug for VregSts {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("VregSts")
+            .field("startup", &self.startup())
+            .field("vout_ok", &self.vout_ok())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for VregSts {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct VregSts {
+            startup: bool,
+            vout_ok: bool,
+        }
+        let proxy = VregSts {
+            startup: self.startup(),
+            vout_ok: self.vout_ok(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Allows a watchdog reset to reset the internal state of powman in addition to the power-on state machine (PSM). Note that powman ignores watchdog resets that do not select at least the CLOCKS stage or earlier stages in the PSM. If using these bits, it's recommended to set PSM_WDSEL to all-ones in addition to the desired bits in this register. Failing to select CLOCKS or earlier will result in the POWMAN_WDSEL register having no effect."]
@@ -1656,6 +2607,35 @@ impl Default for Wdsel {
         Wdsel(0)
     }
 }
+impl core::fmt::Debug for Wdsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wdsel")
+            .field("reset_powman_async", &self.reset_powman_async())
+            .field("reset_powman", &self.reset_powman())
+            .field("reset_swcore", &self.reset_swcore())
+            .field("reset_rsm", &self.reset_rsm())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wdsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wdsel {
+            reset_powman_async: bool,
+            reset_powman: bool,
+            reset_swcore: bool,
+            reset_rsm: bool,
+        }
+        let proxy = Wdsel {
+            reset_powman_async: self.reset_powman_async(),
+            reset_powman: self.reset_powman(),
+            reset_swcore: self.reset_swcore(),
+            reset_rsm: self.reset_rsm(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Informs the AON Timer of the fractional component of the clock frequency when running off the XOSC."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1679,6 +2659,26 @@ impl Default for XoscFreqKhzFrac {
         XoscFreqKhzFrac(0)
     }
 }
+impl core::fmt::Debug for XoscFreqKhzFrac {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("XoscFreqKhzFrac")
+            .field("xosc_freq_khz_frac", &self.xosc_freq_khz_frac())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for XoscFreqKhzFrac {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct XoscFreqKhzFrac {
+            xosc_freq_khz_frac: u16,
+        }
+        let proxy = XoscFreqKhzFrac {
+            xosc_freq_khz_frac: self.xosc_freq_khz_frac(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Informs the AON Timer of the integer component of the clock frequency when running off the XOSC."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1700,5 +2700,25 @@ impl Default for XoscFreqKhzInt {
     #[inline(always)]
     fn default() -> XoscFreqKhzInt {
         XoscFreqKhzInt(0)
+    }
+}
+impl core::fmt::Debug for XoscFreqKhzInt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("XoscFreqKhzInt")
+            .field("xosc_freq_khz_int", &self.xosc_freq_khz_int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for XoscFreqKhzInt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct XoscFreqKhzInt {
+            xosc_freq_khz_int: u16,
+        }
+        let proxy = XoscFreqKhzInt {
+            xosc_freq_khz_int: self.xosc_freq_khz_int(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/powman/vals.rs
+++ b/src/rp235x/powman/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Direction {
     LOW_FALLING = 0x0,
     HIGH_RISING = 0x01,
@@ -27,7 +28,8 @@ impl From<Direction> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Mode {
     LEVEL = 0x0,
     EDGE = 0x01,

--- a/src/rp235x/psm/regs.rs
+++ b/src/rp235x/psm/regs.rs
@@ -235,6 +235,98 @@ impl Default for Done {
         Done(0)
     }
 }
+impl core::fmt::Debug for Done {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Done")
+            .field("proc_cold", &self.proc_cold())
+            .field("otp", &self.otp())
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("resets", &self.resets())
+            .field("clocks", &self.clocks())
+            .field("psm_ready", &self.psm_ready())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("bootram", &self.bootram())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("sram6", &self.sram6())
+            .field("sram7", &self.sram7())
+            .field("sram8", &self.sram8())
+            .field("sram9", &self.sram9())
+            .field("xip", &self.xip())
+            .field("sio", &self.sio())
+            .field("accessctrl", &self.accessctrl())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Done {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Done {
+            proc_cold: bool,
+            otp: bool,
+            rosc: bool,
+            xosc: bool,
+            resets: bool,
+            clocks: bool,
+            psm_ready: bool,
+            busfabric: bool,
+            rom: bool,
+            bootram: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            sram6: bool,
+            sram7: bool,
+            sram8: bool,
+            sram9: bool,
+            xip: bool,
+            sio: bool,
+            accessctrl: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = Done {
+            proc_cold: self.proc_cold(),
+            otp: self.otp(),
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            resets: self.resets(),
+            clocks: self.clocks(),
+            psm_ready: self.psm_ready(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            bootram: self.bootram(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            sram6: self.sram6(),
+            sram7: self.sram7(),
+            sram8: self.sram8(),
+            sram9: self.sram9(),
+            xip: self.xip(),
+            sio: self.sio(),
+            accessctrl: self.accessctrl(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Force into reset (i.e. power it off)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -470,6 +562,98 @@ impl Default for FrceOff {
     #[inline(always)]
     fn default() -> FrceOff {
         FrceOff(0)
+    }
+}
+impl core::fmt::Debug for FrceOff {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FrceOff")
+            .field("proc_cold", &self.proc_cold())
+            .field("otp", &self.otp())
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("resets", &self.resets())
+            .field("clocks", &self.clocks())
+            .field("psm_ready", &self.psm_ready())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("bootram", &self.bootram())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("sram6", &self.sram6())
+            .field("sram7", &self.sram7())
+            .field("sram8", &self.sram8())
+            .field("sram9", &self.sram9())
+            .field("xip", &self.xip())
+            .field("sio", &self.sio())
+            .field("accessctrl", &self.accessctrl())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FrceOff {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FrceOff {
+            proc_cold: bool,
+            otp: bool,
+            rosc: bool,
+            xosc: bool,
+            resets: bool,
+            clocks: bool,
+            psm_ready: bool,
+            busfabric: bool,
+            rom: bool,
+            bootram: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            sram6: bool,
+            sram7: bool,
+            sram8: bool,
+            sram9: bool,
+            xip: bool,
+            sio: bool,
+            accessctrl: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = FrceOff {
+            proc_cold: self.proc_cold(),
+            otp: self.otp(),
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            resets: self.resets(),
+            clocks: self.clocks(),
+            psm_ready: self.psm_ready(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            bootram: self.bootram(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            sram6: self.sram6(),
+            sram7: self.sram7(),
+            sram8: self.sram8(),
+            sram9: self.sram9(),
+            xip: self.xip(),
+            sio: self.sio(),
+            accessctrl: self.accessctrl(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Force block out of reset (i.e. power it on)"]
@@ -709,6 +893,98 @@ impl Default for FrceOn {
         FrceOn(0)
     }
 }
+impl core::fmt::Debug for FrceOn {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FrceOn")
+            .field("proc_cold", &self.proc_cold())
+            .field("otp", &self.otp())
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("resets", &self.resets())
+            .field("clocks", &self.clocks())
+            .field("psm_ready", &self.psm_ready())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("bootram", &self.bootram())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("sram6", &self.sram6())
+            .field("sram7", &self.sram7())
+            .field("sram8", &self.sram8())
+            .field("sram9", &self.sram9())
+            .field("xip", &self.xip())
+            .field("sio", &self.sio())
+            .field("accessctrl", &self.accessctrl())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FrceOn {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FrceOn {
+            proc_cold: bool,
+            otp: bool,
+            rosc: bool,
+            xosc: bool,
+            resets: bool,
+            clocks: bool,
+            psm_ready: bool,
+            busfabric: bool,
+            rom: bool,
+            bootram: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            sram6: bool,
+            sram7: bool,
+            sram8: bool,
+            sram9: bool,
+            xip: bool,
+            sio: bool,
+            accessctrl: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = FrceOn {
+            proc_cold: self.proc_cold(),
+            otp: self.otp(),
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            resets: self.resets(),
+            clocks: self.clocks(),
+            psm_ready: self.psm_ready(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            bootram: self.bootram(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            sram6: self.sram6(),
+            sram7: self.sram7(),
+            sram8: self.sram8(),
+            sram9: self.sram9(),
+            xip: self.xip(),
+            sio: self.sio(),
+            accessctrl: self.accessctrl(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set to 1 if the watchdog should reset this"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -944,5 +1220,97 @@ impl Default for Wdsel {
     #[inline(always)]
     fn default() -> Wdsel {
         Wdsel(0)
+    }
+}
+impl core::fmt::Debug for Wdsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wdsel")
+            .field("proc_cold", &self.proc_cold())
+            .field("otp", &self.otp())
+            .field("rosc", &self.rosc())
+            .field("xosc", &self.xosc())
+            .field("resets", &self.resets())
+            .field("clocks", &self.clocks())
+            .field("psm_ready", &self.psm_ready())
+            .field("busfabric", &self.busfabric())
+            .field("rom", &self.rom())
+            .field("bootram", &self.bootram())
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("sram6", &self.sram6())
+            .field("sram7", &self.sram7())
+            .field("sram8", &self.sram8())
+            .field("sram9", &self.sram9())
+            .field("xip", &self.xip())
+            .field("sio", &self.sio())
+            .field("accessctrl", &self.accessctrl())
+            .field("proc0", &self.proc0())
+            .field("proc1", &self.proc1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wdsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wdsel {
+            proc_cold: bool,
+            otp: bool,
+            rosc: bool,
+            xosc: bool,
+            resets: bool,
+            clocks: bool,
+            psm_ready: bool,
+            busfabric: bool,
+            rom: bool,
+            bootram: bool,
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            sram6: bool,
+            sram7: bool,
+            sram8: bool,
+            sram9: bool,
+            xip: bool,
+            sio: bool,
+            accessctrl: bool,
+            proc0: bool,
+            proc1: bool,
+        }
+        let proxy = Wdsel {
+            proc_cold: self.proc_cold(),
+            otp: self.otp(),
+            rosc: self.rosc(),
+            xosc: self.xosc(),
+            resets: self.resets(),
+            clocks: self.clocks(),
+            psm_ready: self.psm_ready(),
+            busfabric: self.busfabric(),
+            rom: self.rom(),
+            bootram: self.bootram(),
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            sram6: self.sram6(),
+            sram7: self.sram7(),
+            sram8: self.sram8(),
+            sram9: self.sram9(),
+            xip: self.xip(),
+            sio: self.sio(),
+            accessctrl: self.accessctrl(),
+            proc0: self.proc0(),
+            proc1: self.proc1(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/pwm/regs.rs
+++ b/src/rp235x/pwm/regs.rs
@@ -28,6 +28,29 @@ impl Default for ChCc {
         ChCc(0)
     }
 }
+impl core::fmt::Debug for ChCc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChCc")
+            .field("a", &self.a())
+            .field("b", &self.b())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChCc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChCc {
+            a: u16,
+            b: u16,
+        }
+        let proxy = ChCc {
+            a: self.a(),
+            b: self.b(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control and status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -115,6 +138,44 @@ impl Default for ChCsr {
         ChCsr(0)
     }
 }
+impl core::fmt::Debug for ChCsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChCsr")
+            .field("en", &self.en())
+            .field("ph_correct", &self.ph_correct())
+            .field("a_inv", &self.a_inv())
+            .field("b_inv", &self.b_inv())
+            .field("divmode", &self.divmode())
+            .field("ph_ret", &self.ph_ret())
+            .field("ph_adv", &self.ph_adv())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChCsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChCsr {
+            en: bool,
+            ph_correct: bool,
+            a_inv: bool,
+            b_inv: bool,
+            divmode: super::vals::Divmode,
+            ph_ret: bool,
+            ph_adv: bool,
+        }
+        let proxy = ChCsr {
+            en: self.en(),
+            ph_correct: self.ph_correct(),
+            a_inv: self.a_inv(),
+            b_inv: self.b_inv(),
+            divmode: self.divmode(),
+            ph_ret: self.ph_ret(),
+            ph_adv: self.ph_adv(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Direct access to the PWM counter"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -134,6 +195,22 @@ impl Default for ChCtr {
     #[inline(always)]
     fn default() -> ChCtr {
         ChCtr(0)
+    }
+}
+impl core::fmt::Debug for ChCtr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChCtr").field("ctr", &self.ctr()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChCtr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChCtr {
+            ctr: u16,
+        }
+        let proxy = ChCtr { ctr: self.ctr() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "INT and FRAC form a fixed-point fractional number. Counting rate is system clock frequency divided by this number. Fractional division uses simple 1st-order sigma-delta."]
@@ -166,6 +243,29 @@ impl Default for ChDiv {
         ChDiv(0)
     }
 }
+impl core::fmt::Debug for ChDiv {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChDiv")
+            .field("frac", &self.frac())
+            .field("int", &self.int())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChDiv {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChDiv {
+            frac: u8,
+            int: u8,
+        }
+        let proxy = ChDiv {
+            frac: self.frac(),
+            int: self.int(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Counter wrap value"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -185,6 +285,22 @@ impl Default for ChTop {
     #[inline(always)]
     fn default() -> ChTop {
         ChTop(0)
+    }
+}
+impl core::fmt::Debug for ChTop {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChTop").field("top", &self.top()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChTop {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChTop {
+            top: u16,
+        }
+        let proxy = ChTop { top: self.top() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "This register aliases the CSR_EN bits for all channels. Writing to this register allows multiple channels to be enabled or disabled simultaneously, so they can run in perfect sync. For each channel, there is only one physical EN register bit, which can be accessed through here or CHx_CSR."]
@@ -307,6 +423,59 @@ impl Default for En {
         En(0)
     }
 }
+impl core::fmt::Debug for En {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("En")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for En {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct En {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = En {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Raw Interrupts"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -425,6 +594,59 @@ impl Default for Intr {
     #[inline(always)]
     fn default() -> Intr {
         Intr(0)
+    }
+}
+impl core::fmt::Debug for Intr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Intr")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Intr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Intr {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Intr {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Enable for irq0"]
@@ -547,6 +769,59 @@ impl Default for Irq0inte {
         Irq0inte(0)
     }
 }
+impl core::fmt::Debug for Irq0inte {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq0inte")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq0inte {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq0inte {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Irq0inte {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Force for irq0"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -665,6 +940,59 @@ impl Default for Irq0intf {
     #[inline(always)]
     fn default() -> Irq0intf {
         Irq0intf(0)
+    }
+}
+impl core::fmt::Debug for Irq0intf {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq0intf")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq0intf {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq0intf {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Irq0intf {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt status after masking & forcing for irq0"]
@@ -787,6 +1115,59 @@ impl Default for Irq0ints {
         Irq0ints(0)
     }
 }
+impl core::fmt::Debug for Irq0ints {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq0ints")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq0ints {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq0ints {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Irq0ints {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt Enable for irq1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -905,6 +1286,59 @@ impl Default for Irq1inte {
     #[inline(always)]
     fn default() -> Irq1inte {
         Irq1inte(0)
+    }
+}
+impl core::fmt::Debug for Irq1inte {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq1inte")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq1inte {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq1inte {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Irq1inte {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Force for irq1"]
@@ -1027,6 +1461,59 @@ impl Default for Irq1intf {
         Irq1intf(0)
     }
 }
+impl core::fmt::Debug for Irq1intf {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq1intf")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq1intf {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq1intf {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Irq1intf {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt status after masking & forcing for irq1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1145,5 +1632,58 @@ impl Default for Irq1ints {
     #[inline(always)]
     fn default() -> Irq1ints {
         Irq1ints(0)
+    }
+}
+impl core::fmt::Debug for Irq1ints {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Irq1ints")
+            .field("ch0", &self.ch0())
+            .field("ch1", &self.ch1())
+            .field("ch2", &self.ch2())
+            .field("ch3", &self.ch3())
+            .field("ch4", &self.ch4())
+            .field("ch5", &self.ch5())
+            .field("ch6", &self.ch6())
+            .field("ch7", &self.ch7())
+            .field("ch8", &self.ch8())
+            .field("ch9", &self.ch9())
+            .field("ch10", &self.ch10())
+            .field("ch11", &self.ch11())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Irq1ints {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Irq1ints {
+            ch0: bool,
+            ch1: bool,
+            ch2: bool,
+            ch3: bool,
+            ch4: bool,
+            ch5: bool,
+            ch6: bool,
+            ch7: bool,
+            ch8: bool,
+            ch9: bool,
+            ch10: bool,
+            ch11: bool,
+        }
+        let proxy = Irq1ints {
+            ch0: self.ch0(),
+            ch1: self.ch1(),
+            ch2: self.ch2(),
+            ch3: self.ch3(),
+            ch4: self.ch4(),
+            ch5: self.ch5(),
+            ch6: self.ch6(),
+            ch7: self.ch7(),
+            ch8: self.ch8(),
+            ch9: self.ch9(),
+            ch10: self.ch10(),
+            ch11: self.ch11(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/pwm/vals.rs
+++ b/src/rp235x/pwm/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Ch10csrDivmode {
     #[doc = "Free-running counting at rate dictated by fractional divider"]
     DIV = 0x0,
@@ -33,7 +34,8 @@ impl From<Ch10csrDivmode> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Ch11csrDivmode {
     #[doc = "Free-running counting at rate dictated by fractional divider"]
     DIV = 0x0,
@@ -67,7 +69,8 @@ impl From<Ch11csrDivmode> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Divmode {
     #[doc = "Free-running counting at rate dictated by fractional divider"]
     DIV = 0x0,

--- a/src/rp235x/qmi/regs.rs
+++ b/src/rp235x/qmi/regs.rs
@@ -1,4 +1,4 @@
-#[doc = "Configure address translation for XIP virtual addresses 0x1000000 through 0x13fffff (a 4 MiB window starting at +16 MiB). Address translation allows a program image to be executed in place at multiple physical flash addresses (for example, a double-buffered flash image for over-the-air updates), without the overhead of position-independent code. At reset, the address translation registers are initialised to an identity mapping, so that they can be ignored if address translation is not required. Note that the XIP cache is fully virtually addressed, so a cache flush is required after changing the address translation."]
+#[doc = "Configure address translation for XIP virtual addresses 0x000000 through 0x3fffff (a 4 MiB window starting at +0 MiB). Address translation allows a program image to be executed in place at multiple physical flash addresses (for example, a double-buffered flash image for over-the-air updates), without the overhead of position-independent code. At reset, the address translation registers are initialised to an identity mapping, so that they can be ignored if address translation is not required. Note that the XIP cache is fully virtually addressed, so a cache flush is required after changing the address translation."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Atrans(pub u32);
@@ -30,6 +30,29 @@ impl Default for Atrans {
     #[inline(always)]
     fn default() -> Atrans {
         Atrans(0)
+    }
+}
+impl core::fmt::Debug for Atrans {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Atrans")
+            .field("base", &self.base())
+            .field("size", &self.size())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Atrans {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Atrans {
+            base: u16,
+            size: u16,
+        }
+        let proxy = Atrans {
+            base: self.base(),
+            size: self.size(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control and status for direct serial mode Direct serial mode allows the processor to send and receive raw serial frames, for programming, configuration and control of the external memory devices. Only SPI mode 0 (CPOL=0 CPHA=0) is supported."]
@@ -198,6 +221,65 @@ impl Default for DirectCsr {
         DirectCsr(0)
     }
 }
+impl core::fmt::Debug for DirectCsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DirectCsr")
+            .field("en", &self.en())
+            .field("busy", &self.busy())
+            .field("assert_cs0n", &self.assert_cs0n())
+            .field("assert_cs1n", &self.assert_cs1n())
+            .field("auto_cs0n", &self.auto_cs0n())
+            .field("auto_cs1n", &self.auto_cs1n())
+            .field("txfull", &self.txfull())
+            .field("txempty", &self.txempty())
+            .field("txlevel", &self.txlevel())
+            .field("rxempty", &self.rxempty())
+            .field("rxfull", &self.rxfull())
+            .field("rxlevel", &self.rxlevel())
+            .field("clkdiv", &self.clkdiv())
+            .field("rxdelay", &self.rxdelay())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DirectCsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DirectCsr {
+            en: bool,
+            busy: bool,
+            assert_cs0n: bool,
+            assert_cs1n: bool,
+            auto_cs0n: bool,
+            auto_cs1n: bool,
+            txfull: bool,
+            txempty: bool,
+            txlevel: u8,
+            rxempty: bool,
+            rxfull: bool,
+            rxlevel: u8,
+            clkdiv: u8,
+            rxdelay: u8,
+        }
+        let proxy = DirectCsr {
+            en: self.en(),
+            busy: self.busy(),
+            assert_cs0n: self.assert_cs0n(),
+            assert_cs1n: self.assert_cs1n(),
+            auto_cs0n: self.auto_cs0n(),
+            auto_cs1n: self.auto_cs1n(),
+            txfull: self.txfull(),
+            txempty: self.txempty(),
+            txlevel: self.txlevel(),
+            rxempty: self.rxempty(),
+            rxfull: self.rxfull(),
+            rxlevel: self.rxlevel(),
+            clkdiv: self.clkdiv(),
+            rxdelay: self.rxdelay(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Receive FIFO for direct mode"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -219,6 +301,26 @@ impl Default for DirectRx {
     #[inline(always)]
     fn default() -> DirectRx {
         DirectRx(0)
+    }
+}
+impl core::fmt::Debug for DirectRx {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DirectRx")
+            .field("direct_rx", &self.direct_rx())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DirectRx {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DirectRx {
+            direct_rx: u16,
+        }
+        let proxy = DirectRx {
+            direct_rx: self.direct_rx(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Transmit FIFO for direct mode"]
@@ -288,7 +390,39 @@ impl Default for DirectTx {
         DirectTx(0)
     }
 }
-#[doc = "Command constants used for reads from memory address window 1. The reset value of the M1_RCMD register is configured to support a basic 03h serial read transfer with no additional configuration."]
+impl core::fmt::Debug for DirectTx {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DirectTx")
+            .field("data", &self.data())
+            .field("iwidth", &self.iwidth())
+            .field("dwidth", &self.dwidth())
+            .field("oe", &self.oe())
+            .field("nopush", &self.nopush())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DirectTx {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DirectTx {
+            data: u16,
+            iwidth: super::vals::Iwidth,
+            dwidth: bool,
+            oe: bool,
+            nopush: bool,
+        }
+        let proxy = DirectTx {
+            data: self.data(),
+            iwidth: self.iwidth(),
+            dwidth: self.dwidth(),
+            oe: self.oe(),
+            nopush: self.nopush(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Command constants used for reads from memory address window 0. The reset value of the M0_RCMD register is configured to support a basic 03h serial read transfer with no additional configuration."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Rcmd(pub u32);
@@ -320,6 +454,29 @@ impl Default for Rcmd {
     #[inline(always)]
     fn default() -> Rcmd {
         Rcmd(0)
+    }
+}
+impl core::fmt::Debug for Rcmd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rcmd")
+            .field("prefix", &self.prefix())
+            .field("suffix", &self.suffix())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rcmd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rcmd {
+            prefix: u8,
+            suffix: u8,
+        }
+        let proxy = Rcmd {
+            prefix: self.prefix(),
+            suffix: self.suffix(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Read transfer format configuration for memory address window 0. Configure the bus width of each transfer phase individually, and configure the length or presence of the command prefix, command suffix and dummy/turnaround transfer phases. Only 24-bit addresses are supported. The reset value of the M0_RFMT register is configured to support a basic 03h serial read transfer with no additional configuration."]
@@ -433,7 +590,51 @@ impl Default for Rfmt {
         Rfmt(0)
     }
 }
-#[doc = "Timing configuration register for memory address window 1."]
+impl core::fmt::Debug for Rfmt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Rfmt")
+            .field("prefix_width", &self.prefix_width())
+            .field("addr_width", &self.addr_width())
+            .field("suffix_width", &self.suffix_width())
+            .field("dummy_width", &self.dummy_width())
+            .field("data_width", &self.data_width())
+            .field("prefix_len", &self.prefix_len())
+            .field("suffix_len", &self.suffix_len())
+            .field("dummy_len", &self.dummy_len())
+            .field("dtr", &self.dtr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Rfmt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Rfmt {
+            prefix_width: super::vals::PrefixWidth,
+            addr_width: super::vals::AddrWidth,
+            suffix_width: super::vals::SuffixWidth,
+            dummy_width: super::vals::DummyWidth,
+            data_width: super::vals::DataWidth,
+            prefix_len: super::vals::PrefixLen,
+            suffix_len: super::vals::SuffixLen,
+            dummy_len: super::vals::DummyLen,
+            dtr: bool,
+        }
+        let proxy = Rfmt {
+            prefix_width: self.prefix_width(),
+            addr_width: self.addr_width(),
+            suffix_width: self.suffix_width(),
+            dummy_width: self.dummy_width(),
+            data_width: self.data_width(),
+            prefix_len: self.prefix_len(),
+            suffix_len: self.suffix_len(),
+            dummy_len: self.dummy_len(),
+            dtr: self.dtr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Timing configuration register for memory address window 0."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timing(pub u32);
@@ -533,7 +734,48 @@ impl Default for Timing {
         Timing(0)
     }
 }
-#[doc = "Command constants used for writes to memory address window 1. The reset value of the M1_WCMD register is configured to support a basic 02h serial write transfer with no additional configuration."]
+impl core::fmt::Debug for Timing {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timing")
+            .field("clkdiv", &self.clkdiv())
+            .field("rxdelay", &self.rxdelay())
+            .field("min_deselect", &self.min_deselect())
+            .field("max_select", &self.max_select())
+            .field("select_hold", &self.select_hold())
+            .field("select_setup", &self.select_setup())
+            .field("pagebreak", &self.pagebreak())
+            .field("cooldown", &self.cooldown())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timing {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timing {
+            clkdiv: u8,
+            rxdelay: u8,
+            min_deselect: u8,
+            max_select: u8,
+            select_hold: u8,
+            select_setup: bool,
+            pagebreak: super::vals::Pagebreak,
+            cooldown: u8,
+        }
+        let proxy = Timing {
+            clkdiv: self.clkdiv(),
+            rxdelay: self.rxdelay(),
+            min_deselect: self.min_deselect(),
+            max_select: self.max_select(),
+            select_hold: self.select_hold(),
+            select_setup: self.select_setup(),
+            pagebreak: self.pagebreak(),
+            cooldown: self.cooldown(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Command constants used for writes to memory address window 0. The reset value of the M0_WCMD register is configured to support a basic 02h serial write transfer with no additional configuration."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Wcmd(pub u32);
@@ -567,7 +809,30 @@ impl Default for Wcmd {
         Wcmd(0)
     }
 }
-#[doc = "Write transfer format configuration for memory address window 1. Configure the bus width of each transfer phase individually, and configure the length or presence of the command prefix, command suffix and dummy/turnaround transfer phases. Only 24-bit addresses are supported. The reset value of the M1_WFMT register is configured to support a basic 02h serial write transfer. However, writes to this window must first be enabled via the XIP_CTRL_WRITABLE_M1 bit, as XIP memory is read-only by default."]
+impl core::fmt::Debug for Wcmd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wcmd")
+            .field("prefix", &self.prefix())
+            .field("suffix", &self.suffix())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wcmd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wcmd {
+            prefix: u8,
+            suffix: u8,
+        }
+        let proxy = Wcmd {
+            prefix: self.prefix(),
+            suffix: self.suffix(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Write transfer format configuration for memory address window 0. Configure the bus width of each transfer phase individually, and configure the length or presence of the command prefix, command suffix and dummy/turnaround transfer phases. Only 24-bit addresses are supported. The reset value of the M0_WFMT register is configured to support a basic 02h serial write transfer. However, writes to this window must first be enabled via the XIP_CTRL_WRITABLE_M0 bit, as XIP memory is read-only by default."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Wfmt(pub u32);
@@ -676,5 +941,49 @@ impl Default for Wfmt {
     #[inline(always)]
     fn default() -> Wfmt {
         Wfmt(0)
+    }
+}
+impl core::fmt::Debug for Wfmt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wfmt")
+            .field("prefix_width", &self.prefix_width())
+            .field("addr_width", &self.addr_width())
+            .field("suffix_width", &self.suffix_width())
+            .field("dummy_width", &self.dummy_width())
+            .field("data_width", &self.data_width())
+            .field("prefix_len", &self.prefix_len())
+            .field("suffix_len", &self.suffix_len())
+            .field("dummy_len", &self.dummy_len())
+            .field("dtr", &self.dtr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wfmt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wfmt {
+            prefix_width: super::vals::PrefixWidth,
+            addr_width: super::vals::AddrWidth,
+            suffix_width: super::vals::SuffixWidth,
+            dummy_width: super::vals::DummyWidth,
+            data_width: super::vals::DataWidth,
+            prefix_len: super::vals::PrefixLen,
+            suffix_len: super::vals::SuffixLen,
+            dummy_len: super::vals::DummyLen,
+            dtr: bool,
+        }
+        let proxy = Wfmt {
+            prefix_width: self.prefix_width(),
+            addr_width: self.addr_width(),
+            suffix_width: self.suffix_width(),
+            dummy_width: self.dummy_width(),
+            data_width: self.data_width(),
+            prefix_len: self.prefix_len(),
+            suffix_len: self.suffix_len(),
+            dummy_len: self.dummy_len(),
+            dtr: self.dtr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/qmi/vals.rs
+++ b/src/rp235x/qmi/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AddrWidth {
     #[doc = "Single width"]
     S = 0x0,
@@ -32,7 +33,8 @@ impl From<AddrWidth> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataWidth {
     #[doc = "Single width"]
     S = 0x0,
@@ -65,7 +67,8 @@ impl From<DataWidth> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DummyLen {
     #[doc = "No dummy phase"]
     NONE = 0x0,
@@ -107,7 +110,8 @@ impl From<DummyLen> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DummyWidth {
     #[doc = "Single width"]
     S = 0x0,
@@ -140,7 +144,8 @@ impl From<DummyWidth> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Iwidth {
     #[doc = "Single width"]
     S = 0x0,
@@ -173,7 +178,8 @@ impl From<Iwidth> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Pagebreak {
     #[doc = "No page boundary is enforced"]
     NONE = 0x0,
@@ -207,7 +213,8 @@ impl From<Pagebreak> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PrefixLen {
     #[doc = "No prefix"]
     NONE = 0x0,
@@ -237,7 +244,8 @@ impl From<PrefixLen> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PrefixWidth {
     #[doc = "Single width"]
     S = 0x0,
@@ -270,7 +278,8 @@ impl From<PrefixWidth> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SuffixLen {
     #[doc = "No suffix"]
     NONE = 0x0,
@@ -302,7 +311,8 @@ impl From<SuffixLen> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SuffixWidth {
     #[doc = "Single width"]
     S = 0x0,

--- a/src/rp235x/resets/regs.rs
+++ b/src/rp235x/resets/regs.rs
@@ -270,6 +270,110 @@ impl Default for Peripherals {
         Peripherals(0)
     }
 }
+impl core::fmt::Debug for Peripherals {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Peripherals")
+            .field("adc", &self.adc())
+            .field("busctrl", &self.busctrl())
+            .field("dma", &self.dma())
+            .field("hstx", &self.hstx())
+            .field("i2c0", &self.i2c0())
+            .field("i2c1", &self.i2c1())
+            .field("io_bank0", &self.io_bank0())
+            .field("io_qspi", &self.io_qspi())
+            .field("jtag", &self.jtag())
+            .field("pads_bank0", &self.pads_bank0())
+            .field("pads_qspi", &self.pads_qspi())
+            .field("pio0", &self.pio0())
+            .field("pio1", &self.pio1())
+            .field("pio2", &self.pio2())
+            .field("pll_sys", &self.pll_sys())
+            .field("pll_usb", &self.pll_usb())
+            .field("pwm", &self.pwm())
+            .field("sha256", &self.sha256())
+            .field("spi0", &self.spi0())
+            .field("spi1", &self.spi1())
+            .field("syscfg", &self.syscfg())
+            .field("sysinfo", &self.sysinfo())
+            .field("tbman", &self.tbman())
+            .field("timer0", &self.timer0())
+            .field("timer1", &self.timer1())
+            .field("trng", &self.trng())
+            .field("uart0", &self.uart0())
+            .field("uart1", &self.uart1())
+            .field("usbctrl", &self.usbctrl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Peripherals {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Peripherals {
+            adc: bool,
+            busctrl: bool,
+            dma: bool,
+            hstx: bool,
+            i2c0: bool,
+            i2c1: bool,
+            io_bank0: bool,
+            io_qspi: bool,
+            jtag: bool,
+            pads_bank0: bool,
+            pads_qspi: bool,
+            pio0: bool,
+            pio1: bool,
+            pio2: bool,
+            pll_sys: bool,
+            pll_usb: bool,
+            pwm: bool,
+            sha256: bool,
+            spi0: bool,
+            spi1: bool,
+            syscfg: bool,
+            sysinfo: bool,
+            tbman: bool,
+            timer0: bool,
+            timer1: bool,
+            trng: bool,
+            uart0: bool,
+            uart1: bool,
+            usbctrl: bool,
+        }
+        let proxy = Peripherals {
+            adc: self.adc(),
+            busctrl: self.busctrl(),
+            dma: self.dma(),
+            hstx: self.hstx(),
+            i2c0: self.i2c0(),
+            i2c1: self.i2c1(),
+            io_bank0: self.io_bank0(),
+            io_qspi: self.io_qspi(),
+            jtag: self.jtag(),
+            pads_bank0: self.pads_bank0(),
+            pads_qspi: self.pads_qspi(),
+            pio0: self.pio0(),
+            pio1: self.pio1(),
+            pio2: self.pio2(),
+            pll_sys: self.pll_sys(),
+            pll_usb: self.pll_usb(),
+            pwm: self.pwm(),
+            sha256: self.sha256(),
+            spi0: self.spi0(),
+            spi1: self.spi1(),
+            syscfg: self.syscfg(),
+            sysinfo: self.sysinfo(),
+            tbman: self.tbman(),
+            timer0: self.timer0(),
+            timer1: self.timer1(),
+            trng: self.trng(),
+            uart0: self.uart0(),
+            uart1: self.uart1(),
+            usbctrl: self.usbctrl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Wdsel(pub u32);
@@ -540,5 +644,109 @@ impl Default for Wdsel {
     #[inline(always)]
     fn default() -> Wdsel {
         Wdsel(0)
+    }
+}
+impl core::fmt::Debug for Wdsel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Wdsel")
+            .field("adc", &self.adc())
+            .field("busctrl", &self.busctrl())
+            .field("dma", &self.dma())
+            .field("hstx", &self.hstx())
+            .field("i2c0", &self.i2c0())
+            .field("i2c1", &self.i2c1())
+            .field("io_bank0", &self.io_bank0())
+            .field("io_qspi", &self.io_qspi())
+            .field("jtag", &self.jtag())
+            .field("pads_bank0", &self.pads_bank0())
+            .field("pads_qspi", &self.pads_qspi())
+            .field("pio0", &self.pio0())
+            .field("pio1", &self.pio1())
+            .field("pio2", &self.pio2())
+            .field("pll_sys", &self.pll_sys())
+            .field("pll_usb", &self.pll_usb())
+            .field("pwm", &self.pwm())
+            .field("sha256", &self.sha256())
+            .field("spi0", &self.spi0())
+            .field("spi1", &self.spi1())
+            .field("syscfg", &self.syscfg())
+            .field("sysinfo", &self.sysinfo())
+            .field("tbman", &self.tbman())
+            .field("timer0", &self.timer0())
+            .field("timer1", &self.timer1())
+            .field("trng", &self.trng())
+            .field("uart0", &self.uart0())
+            .field("uart1", &self.uart1())
+            .field("usbctrl", &self.usbctrl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Wdsel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Wdsel {
+            adc: bool,
+            busctrl: bool,
+            dma: bool,
+            hstx: bool,
+            i2c0: bool,
+            i2c1: bool,
+            io_bank0: bool,
+            io_qspi: bool,
+            jtag: bool,
+            pads_bank0: bool,
+            pads_qspi: bool,
+            pio0: bool,
+            pio1: bool,
+            pio2: bool,
+            pll_sys: bool,
+            pll_usb: bool,
+            pwm: bool,
+            sha256: bool,
+            spi0: bool,
+            spi1: bool,
+            syscfg: bool,
+            sysinfo: bool,
+            tbman: bool,
+            timer0: bool,
+            timer1: bool,
+            trng: bool,
+            uart0: bool,
+            uart1: bool,
+            usbctrl: bool,
+        }
+        let proxy = Wdsel {
+            adc: self.adc(),
+            busctrl: self.busctrl(),
+            dma: self.dma(),
+            hstx: self.hstx(),
+            i2c0: self.i2c0(),
+            i2c1: self.i2c1(),
+            io_bank0: self.io_bank0(),
+            io_qspi: self.io_qspi(),
+            jtag: self.jtag(),
+            pads_bank0: self.pads_bank0(),
+            pads_qspi: self.pads_qspi(),
+            pio0: self.pio0(),
+            pio1: self.pio1(),
+            pio2: self.pio2(),
+            pll_sys: self.pll_sys(),
+            pll_usb: self.pll_usb(),
+            pwm: self.pwm(),
+            sha256: self.sha256(),
+            spi0: self.spi0(),
+            spi1: self.spi1(),
+            syscfg: self.syscfg(),
+            sysinfo: self.sysinfo(),
+            tbman: self.tbman(),
+            timer0: self.timer0(),
+            timer1: self.timer1(),
+            trng: self.trng(),
+            uart0: self.uart0(),
+            uart1: self.uart1(),
+            usbctrl: self.usbctrl(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/rosc/regs.rs
+++ b/src/rp235x/rosc/regs.rs
@@ -19,6 +19,26 @@ impl Default for Count {
         Count(0)
     }
 }
+impl core::fmt::Debug for Count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Count")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Count {
+            count: u16,
+        }
+        let proxy = Count {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Ring Oscillator control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,6 +73,29 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("freq_range", &self.freq_range())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            freq_range: super::vals::FreqRange,
+            enable: super::vals::Enable,
+        }
+        let proxy = Ctrl {
+            freq_range: self.freq_range(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Controls the output divider"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -74,6 +117,22 @@ impl Default for Div {
     #[inline(always)]
     fn default() -> Div {
         Div(0)
+    }
+}
+impl core::fmt::Debug for Div {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Div").field("div", &self.div()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Div {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Div {
+            div: super::vals::Div,
+        }
+        let proxy = Div { div: self.div() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Ring Oscillator pause control"]
@@ -98,6 +157,26 @@ impl Default for Dormant {
     #[inline(always)]
     fn default() -> Dormant {
         Dormant(0)
+    }
+}
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dormant")
+            .field("dormant", &self.dormant())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dormant {
+            dormant: super::vals::Dormant,
+        }
+        let proxy = Dormant {
+            dormant: self.dormant(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "The FREQA & FREQB registers control the frequency by controlling the drive strength of each stage The drive strength has 4 levels determined by the number of bits set Increasing the number of bits set increases the drive strength and increases the oscillation frequency 0 bits set is the default drive strength 1 bit set doubles the drive strength 2 bits set triples drive strength 3 bits set quadruples drive strength For frequency randomisation set both DS0_RANDOM=1 & DS1_RANDOM=1"]
@@ -189,6 +268,44 @@ impl Default for Freqa {
         Freqa(0)
     }
 }
+impl core::fmt::Debug for Freqa {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Freqa")
+            .field("ds0", &self.ds0())
+            .field("ds0_random", &self.ds0_random())
+            .field("ds1", &self.ds1())
+            .field("ds1_random", &self.ds1_random())
+            .field("ds2", &self.ds2())
+            .field("ds3", &self.ds3())
+            .field("passwd", &self.passwd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Freqa {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Freqa {
+            ds0: u8,
+            ds0_random: bool,
+            ds1: u8,
+            ds1_random: bool,
+            ds2: u8,
+            ds3: u8,
+            passwd: super::vals::Passwd,
+        }
+        let proxy = Freqa {
+            ds0: self.ds0(),
+            ds0_random: self.ds0_random(),
+            ds1: self.ds1(),
+            ds1_random: self.ds1_random(),
+            ds2: self.ds2(),
+            ds3: self.ds3(),
+            passwd: self.passwd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "For a detailed description see freqa register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -256,6 +373,38 @@ impl Default for Freqb {
         Freqb(0)
     }
 }
+impl core::fmt::Debug for Freqb {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Freqb")
+            .field("ds4", &self.ds4())
+            .field("ds5", &self.ds5())
+            .field("ds6", &self.ds6())
+            .field("ds7", &self.ds7())
+            .field("passwd", &self.passwd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Freqb {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Freqb {
+            ds4: u8,
+            ds5: u8,
+            ds6: u8,
+            ds7: u8,
+            passwd: super::vals::Passwd,
+        }
+        let proxy = Freqb {
+            ds4: self.ds4(),
+            ds5: self.ds5(),
+            ds6: self.ds6(),
+            ds7: self.ds7(),
+            passwd: self.passwd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Controls the phase shifted output"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -312,6 +461,35 @@ impl Default for Phase {
         Phase(0)
     }
 }
+impl core::fmt::Debug for Phase {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Phase")
+            .field("shift", &self.shift())
+            .field("flip", &self.flip())
+            .field("enable", &self.enable())
+            .field("passwd", &self.passwd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Phase {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Phase {
+            shift: u8,
+            flip: bool,
+            enable: bool,
+            passwd: u8,
+        }
+        let proxy = Phase {
+            shift: self.shift(),
+            flip: self.flip(),
+            enable: self.enable(),
+            passwd: self.passwd(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "This just reads the state of the oscillator output so randomness is compromised if the ring oscillator is stopped or run at a harmonic of the bus frequency"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -331,6 +509,26 @@ impl Default for Randombit {
     #[inline(always)]
     fn default() -> Randombit {
         Randombit(0)
+    }
+}
+impl core::fmt::Debug for Randombit {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Randombit")
+            .field("randombit", &self.randombit())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Randombit {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Randombit {
+            randombit: bool,
+        }
+        let proxy = Randombit {
+            randombit: self.randombit(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Ring Oscillator Status"]
@@ -387,5 +585,34 @@ impl Default for Status {
     #[inline(always)]
     fn default() -> Status {
         Status(0)
+    }
+}
+impl core::fmt::Debug for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Status")
+            .field("enabled", &self.enabled())
+            .field("div_running", &self.div_running())
+            .field("badwrite", &self.badwrite())
+            .field("stable", &self.stable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Status {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Status {
+            enabled: bool,
+            div_running: bool,
+            badwrite: bool,
+            stable: bool,
+        }
+        let proxy = Status {
+            enabled: self.enabled(),
+            div_running: self.div_running(),
+            badwrite: self.badwrite(),
+            stable: self.stable(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/rosc/vals.rs
+++ b/src/rp235x/rosc/vals.rs
@@ -12,6 +12,23 @@ impl Div {
         self.0
     }
 }
+impl core::fmt::Debug for Div {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0xaa00 => f.write_str("PASS"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Div {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0xaa00 => defmt::write!(f, "PASS"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Div {
     #[inline(always)]
     fn from(val: u16) -> Div {
@@ -39,6 +56,25 @@ impl Dormant {
         self.0
     }
 }
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x636f_6d61 => f.write_str("DORMANT"),
+            0x7761_6b65 => f.write_str("WAKE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x636f_6d61 => defmt::write!(f, "DORMANT"),
+            0x7761_6b65 => defmt::write!(f, "WAKE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u32> for Dormant {
     #[inline(always)]
     fn from(val: u32) -> Dormant {
@@ -64,6 +100,25 @@ impl Enable {
     }
     pub const fn to_bits(self) -> u16 {
         self.0
+    }
+}
+impl core::fmt::Debug for Enable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0d1e => f.write_str("DISABLE"),
+            0x0fab => f.write_str("ENABLE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enable {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0d1e => defmt::write!(f, "DISABLE"),
+            0x0fab => defmt::write!(f, "ENABLE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u16> for Enable {
@@ -95,6 +150,29 @@ impl FreqRange {
         self.0
     }
 }
+impl core::fmt::Debug for FreqRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0fa4 => f.write_str("LOW"),
+            0x0fa5 => f.write_str("MEDIUM"),
+            0x0fa6 => f.write_str("TOOHIGH"),
+            0x0fa7 => f.write_str("HIGH"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FreqRange {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0fa4 => defmt::write!(f, "LOW"),
+            0x0fa5 => defmt::write!(f, "MEDIUM"),
+            0x0fa6 => defmt::write!(f, "TOOHIGH"),
+            0x0fa7 => defmt::write!(f, "HIGH"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for FreqRange {
     #[inline(always)]
     fn from(val: u16) -> FreqRange {
@@ -119,6 +197,23 @@ impl Passwd {
     }
     pub const fn to_bits(self) -> u16 {
         self.0
+    }
+}
+impl core::fmt::Debug for Passwd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x9696 => f.write_str("PASS"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Passwd {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x9696 => defmt::write!(f, "PASS"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u16> for Passwd {

--- a/src/rp235x/sha256/regs.rs
+++ b/src/rp235x/sha256/regs.rs
@@ -76,3 +76,38 @@ impl Default for Csr {
         Csr(0)
     }
 }
+impl core::fmt::Debug for Csr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Csr")
+            .field("start", &self.start())
+            .field("wdata_rdy", &self.wdata_rdy())
+            .field("sum_vld", &self.sum_vld())
+            .field("err_wdata_not_rdy", &self.err_wdata_not_rdy())
+            .field("dma_size", &self.dma_size())
+            .field("bswap", &self.bswap())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Csr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Csr {
+            start: bool,
+            wdata_rdy: bool,
+            sum_vld: bool,
+            err_wdata_not_rdy: bool,
+            dma_size: super::vals::DmaSize,
+            bswap: bool,
+        }
+        let proxy = Csr {
+            start: self.start(),
+            wdata_rdy: self.wdata_rdy(),
+            sum_vld: self.sum_vld(),
+            err_wdata_not_rdy: self.err_wdata_not_rdy(),
+            dma_size: self.dma_size(),
+            bswap: self.bswap(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}

--- a/src/rp235x/sha256/vals.rs
+++ b/src/rp235x/sha256/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaSize {
     _8BIT = 0x0,
     _16BIT = 0x01,

--- a/src/rp235x/sio.rs
+++ b/src/rp235x/sio.rs
@@ -44,22 +44,22 @@ impl Gpio {
     pub const fn as_ptr(&self) -> *mut () {
         self.ptr as _
     }
-    #[doc = "GPIO0...31 output enable"]
+    #[doc = "GPIO0...31 output value"]
     #[inline(always)]
     pub const fn value(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
-    #[doc = "GPIO0...31 output enable set"]
+    #[doc = "GPIO0...31 output value set"]
     #[inline(always)]
     pub const fn value_set(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
-    #[doc = "GPIO0...31 output enable clear"]
+    #[doc = "GPIO0...31 output value clear"]
     #[inline(always)]
     pub const fn value_clr(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x10usize) as _) }
     }
-    #[doc = "GPIO0...31 output enable XOR"]
+    #[doc = "GPIO0...31 output value XOR"]
     #[inline(always)]
     pub const fn value_xor(self) -> crate::common::Reg<u32, crate::common::RW> {
         unsafe { crate::common::Reg::from_ptr(self.ptr.add(0x18usize) as _) }

--- a/src/rp235x/sio/regs.rs
+++ b/src/rp235x/sio/regs.rs
@@ -19,6 +19,26 @@ impl Default for DoorbellInClr {
         DoorbellInClr(0)
     }
 }
+impl core::fmt::Debug for DoorbellInClr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DoorbellInClr")
+            .field("doorbell_in_clr", &self.doorbell_in_clr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DoorbellInClr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DoorbellInClr {
+            doorbell_in_clr: u8,
+        }
+        let proxy = DoorbellInClr {
+            doorbell_in_clr: self.doorbell_in_clr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Write 1s to trigger doorbell interrupts on this core. Read to get status of doorbells currently asserted on this core."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38,6 +58,26 @@ impl Default for DoorbellInSet {
     #[inline(always)]
     fn default() -> DoorbellInSet {
         DoorbellInSet(0)
+    }
+}
+impl core::fmt::Debug for DoorbellInSet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DoorbellInSet")
+            .field("doorbell_in_set", &self.doorbell_in_set())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DoorbellInSet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DoorbellInSet {
+            doorbell_in_set: u8,
+        }
+        let proxy = DoorbellInSet {
+            doorbell_in_set: self.doorbell_in_set(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Clear doorbells which have been posted to the opposite core. This register is intended for debugging and initialisation purposes. Writing 1 to a bit in DOORBELL_OUT_CLR clears the corresponding bit in DOORBELL_IN on the opposite core. Clearing all bits will cause that core's doorbell interrupt to deassert. Since the usual order of events is for software to send events using DOORBELL_OUT_SET, and acknowledge incoming events by writing to DOORBELL_IN_CLR, this register should be used with caution to avoid race conditions. Reading returns the status of the doorbells currently asserted on the other core, i.e. is equivalent to that core reading its own DOORBELL_IN status."]
@@ -61,6 +101,26 @@ impl Default for DoorbellOutClr {
         DoorbellOutClr(0)
     }
 }
+impl core::fmt::Debug for DoorbellOutClr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DoorbellOutClr")
+            .field("doorbell_out_clr", &self.doorbell_out_clr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DoorbellOutClr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DoorbellOutClr {
+            doorbell_out_clr: u8,
+        }
+        let proxy = DoorbellOutClr {
+            doorbell_out_clr: self.doorbell_out_clr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Trigger a doorbell interrupt on the opposite core. Write 1 to a bit to set the corresponding bit in DOORBELL_IN on the opposite core. This raises the opposite core's doorbell interrupt. Read to get the status of the doorbells currently asserted on the opposite core. This is equivalent to that core reading its own DOORBELL_IN status."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -80,6 +140,26 @@ impl Default for DoorbellOutSet {
     #[inline(always)]
     fn default() -> DoorbellOutSet {
         DoorbellOutSet(0)
+    }
+}
+impl core::fmt::Debug for DoorbellOutSet {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DoorbellOutSet")
+            .field("doorbell_out_set", &self.doorbell_out_set())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DoorbellOutSet {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DoorbellOutSet {
+            doorbell_out_set: u8,
+        }
+        let proxy = DoorbellOutSet {
+            doorbell_out_set: self.doorbell_out_set(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Status register for inter-core FIFOs (mailboxes). There is one FIFO in the core 0 -> core 1 direction, and one core 1 -> core 0. Both are 32 bits wide and 8 words deep. Core 0 can see the read side of the 1->0 FIFO (RX), and the write side of 0->1 FIFO (TX). Core 1 can see the read side of the 0->1 FIFO (RX), and the write side of 1->0 FIFO (TX). The SIO IRQ for each core is the logical OR of the VLD, WOF and ROE fields of its FIFO_ST register."]
@@ -138,6 +218,35 @@ impl Default for FifoSt {
         FifoSt(0)
     }
 }
+impl core::fmt::Debug for FifoSt {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("FifoSt")
+            .field("vld", &self.vld())
+            .field("rdy", &self.rdy())
+            .field("wof", &self.wof())
+            .field("roe", &self.roe())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for FifoSt {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct FifoSt {
+            vld: bool,
+            rdy: bool,
+            wof: bool,
+            roe: bool,
+        }
+        let proxy = FifoSt {
+            vld: self.vld(),
+            rdy: self.rdy(),
+            wof: self.wof(),
+            roe: self.roe(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM0 Reading yields lane 0's raw shift and mask value (BASE0 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -159,6 +268,26 @@ impl Default for Interp0accum0add {
         Interp0accum0add(0)
     }
 }
+impl core::fmt::Debug for Interp0accum0add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0accum0add")
+            .field("interp0_accum0_add", &self.interp0_accum0_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0accum0add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0accum0add {
+            interp0_accum0_add: u32,
+        }
+        let proxy = Interp0accum0add {
+            interp0_accum0_add: self.interp0_accum0_add(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM1 Reading yields lane 1's raw shift and mask value (BASE1 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -178,6 +307,26 @@ impl Default for Interp0accum1add {
     #[inline(always)]
     fn default() -> Interp0accum1add {
         Interp0accum1add(0)
+    }
+}
+impl core::fmt::Debug for Interp0accum1add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0accum1add")
+            .field("interp0_accum1_add", &self.interp0_accum1_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0accum1add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0accum1add {
+            interp0_accum1_add: u32,
+        }
+        let proxy = Interp0accum1add {
+            interp0_accum1_add: self.interp0_accum1_add(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control register for lane 0"]
@@ -324,6 +473,59 @@ impl Default for Interp0ctrlLane0 {
         Interp0ctrlLane0(0)
     }
 }
+impl core::fmt::Debug for Interp0ctrlLane0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0ctrlLane0")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .field("blend", &self.blend())
+            .field("overf0", &self.overf0())
+            .field("overf1", &self.overf1())
+            .field("overf", &self.overf())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0ctrlLane0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0ctrlLane0 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+            blend: bool,
+            overf0: bool,
+            overf1: bool,
+            overf: bool,
+        }
+        let proxy = Interp0ctrlLane0 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+            blend: self.blend(),
+            overf0: self.overf0(),
+            overf1: self.overf1(),
+            overf: self.overf(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register for lane 1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -424,6 +626,47 @@ impl Default for Interp0ctrlLane1 {
         Interp0ctrlLane1(0)
     }
 }
+impl core::fmt::Debug for Interp0ctrlLane1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp0ctrlLane1")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp0ctrlLane1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp0ctrlLane1 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+        }
+        let proxy = Interp0ctrlLane1 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM0 Reading yields lane 0's raw shift and mask value (BASE0 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -445,6 +688,26 @@ impl Default for Interp1accum0add {
         Interp1accum0add(0)
     }
 }
+impl core::fmt::Debug for Interp1accum0add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1accum0add")
+            .field("interp1_accum0_add", &self.interp1_accum0_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1accum0add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1accum0add {
+            interp1_accum0_add: u32,
+        }
+        let proxy = Interp1accum0add {
+            interp1_accum0_add: self.interp1_accum0_add(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Values written here are atomically added to ACCUM1 Reading yields lane 1's raw shift and mask value (BASE1 not added)."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -464,6 +727,26 @@ impl Default for Interp1accum1add {
     #[inline(always)]
     fn default() -> Interp1accum1add {
         Interp1accum1add(0)
+    }
+}
+impl core::fmt::Debug for Interp1accum1add {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1accum1add")
+            .field("interp1_accum1_add", &self.interp1_accum1_add())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1accum1add {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1accum1add {
+            interp1_accum1_add: u32,
+        }
+        let proxy = Interp1accum1add {
+            interp1_accum1_add: self.interp1_accum1_add(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control register for lane 0"]
@@ -610,6 +893,59 @@ impl Default for Interp1ctrlLane0 {
         Interp1ctrlLane0(0)
     }
 }
+impl core::fmt::Debug for Interp1ctrlLane0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1ctrlLane0")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .field("clamp", &self.clamp())
+            .field("overf0", &self.overf0())
+            .field("overf1", &self.overf1())
+            .field("overf", &self.overf())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1ctrlLane0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1ctrlLane0 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+            clamp: bool,
+            overf0: bool,
+            overf1: bool,
+            overf: bool,
+        }
+        let proxy = Interp1ctrlLane0 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+            clamp: self.clamp(),
+            overf0: self.overf0(),
+            overf1: self.overf1(),
+            overf: self.overf(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register for lane 1"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -710,6 +1046,47 @@ impl Default for Interp1ctrlLane1 {
         Interp1ctrlLane1(0)
     }
 }
+impl core::fmt::Debug for Interp1ctrlLane1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Interp1ctrlLane1")
+            .field("shift", &self.shift())
+            .field("mask_lsb", &self.mask_lsb())
+            .field("mask_msb", &self.mask_msb())
+            .field("signed", &self.signed())
+            .field("cross_input", &self.cross_input())
+            .field("cross_result", &self.cross_result())
+            .field("add_raw", &self.add_raw())
+            .field("force_msb", &self.force_msb())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Interp1ctrlLane1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Interp1ctrlLane1 {
+            shift: u8,
+            mask_lsb: u8,
+            mask_msb: u8,
+            signed: bool,
+            cross_input: bool,
+            cross_result: bool,
+            add_raw: bool,
+            force_msb: u8,
+        }
+        let proxy = Interp1ctrlLane1 {
+            shift: self.shift(),
+            mask_lsb: self.mask_lsb(),
+            mask_msb: self.mask_msb(),
+            signed: self.signed(),
+            cross_input: self.cross_input(),
+            cross_result: self.cross_result(),
+            add_raw: self.add_raw(),
+            force_msb: self.force_msb(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register for the RISC-V 64-bit Machine-mode timer. This timer is only present in the Secure SIO, so is only accessible to an Arm core in Secure mode or a RISC-V core in Machine mode. Note whilst this timer follows the RISC-V privileged specification, it is equally usable by the Arm cores. The interrupts are routed to normal system-level interrupt lines as well as to the MIP.MTIP inputs on the RISC-V cores."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -766,6 +1143,35 @@ impl Default for MtimeCtrl {
         MtimeCtrl(0)
     }
 }
+impl core::fmt::Debug for MtimeCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MtimeCtrl")
+            .field("en", &self.en())
+            .field("fullspeed", &self.fullspeed())
+            .field("dbgpause_core0", &self.dbgpause_core0())
+            .field("dbgpause_core1", &self.dbgpause_core1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for MtimeCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct MtimeCtrl {
+            en: bool,
+            fullspeed: bool,
+            dbgpause_core0: bool,
+            dbgpause_core1: bool,
+        }
+        let proxy = MtimeCtrl {
+            en: self.en(),
+            fullspeed: self.fullspeed(),
+            dbgpause_core0: self.dbgpause_core0(),
+            dbgpause_core1: self.dbgpause_core1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Detach certain core-local peripherals from Secure SIO, and attach them to Non-secure SIO, so that Non-secure software can use them. Attempting to access one of these peripherals from the Secure SIO when it is attached to the Non-secure SIO, or vice versa, will generate a bus error. This register is per-core, and is only present on the Secure SIO. Most SIO hardware is duplicated across the Secure and Non-secure SIO, so is not listed in this register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -809,6 +1215,32 @@ impl Default for PeriNonsec {
     #[inline(always)]
     fn default() -> PeriNonsec {
         PeriNonsec(0)
+    }
+}
+impl core::fmt::Debug for PeriNonsec {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PeriNonsec")
+            .field("interp0", &self.interp0())
+            .field("interp1", &self.interp1())
+            .field("tmds", &self.tmds())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PeriNonsec {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PeriNonsec {
+            interp0: bool,
+            interp1: bool,
+            tmds: bool,
+        }
+        let proxy = PeriNonsec {
+            interp0: self.interp0(),
+            interp1: self.interp1(),
+            tmds: self.tmds(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control the assertion of the standard software interrupt (MIP.MSIP) on the RISC-V cores. Unlike the RISC-V timer, this interrupt is not routed to a normal system-level interrupt line, so can not be used by the Arm cores. It is safe for both cores to write to this register on the same cycle. The set/clear effect is accumulated across both cores, and then applied. If a flag is both set and cleared on the same cycle, only the set takes effect."]
@@ -865,6 +1297,35 @@ impl Default for RiscvSoftirq {
     #[inline(always)]
     fn default() -> RiscvSoftirq {
         RiscvSoftirq(0)
+    }
+}
+impl core::fmt::Debug for RiscvSoftirq {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RiscvSoftirq")
+            .field("core0_set", &self.core0_set())
+            .field("core1_set", &self.core1_set())
+            .field("core0_clr", &self.core0_clr())
+            .field("core1_clr", &self.core1_clr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RiscvSoftirq {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RiscvSoftirq {
+            core0_set: bool,
+            core1_set: bool,
+            core0_clr: bool,
+            core1_clr: bool,
+        }
+        let proxy = RiscvSoftirq {
+            core0_set: self.core0_set(),
+            core1_set: self.core1_set(),
+            core0_clr: self.core0_clr(),
+            core1_clr: self.core1_clr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control register for TMDS encoder."]
@@ -987,5 +1448,52 @@ impl Default for TmdsCtrl {
     #[inline(always)]
     fn default() -> TmdsCtrl {
         TmdsCtrl(0)
+    }
+}
+impl core::fmt::Debug for TmdsCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TmdsCtrl")
+            .field("l0_rot", &self.l0_rot())
+            .field("l1_rot", &self.l1_rot())
+            .field("l2_rot", &self.l2_rot())
+            .field("l0_nbits", &self.l0_nbits())
+            .field("l1_nbits", &self.l1_nbits())
+            .field("l2_nbits", &self.l2_nbits())
+            .field("interleave", &self.interleave())
+            .field("pix_shift", &self.pix_shift())
+            .field("pix2_noshift", &self.pix2_noshift())
+            .field("clear_balance", &self.clear_balance())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TmdsCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TmdsCtrl {
+            l0_rot: u8,
+            l1_rot: u8,
+            l2_rot: u8,
+            l0_nbits: u8,
+            l1_nbits: u8,
+            l2_nbits: u8,
+            interleave: bool,
+            pix_shift: super::vals::PixShift,
+            pix2_noshift: bool,
+            clear_balance: bool,
+        }
+        let proxy = TmdsCtrl {
+            l0_rot: self.l0_rot(),
+            l1_rot: self.l1_rot(),
+            l2_rot: self.l2_rot(),
+            l0_nbits: self.l0_nbits(),
+            l1_nbits: self.l1_nbits(),
+            l2_nbits: self.l2_nbits(),
+            interleave: self.interleave(),
+            pix_shift: self.pix_shift(),
+            pix2_noshift: self.pix2_noshift(),
+            clear_balance: self.clear_balance(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/sio/vals.rs
+++ b/src/rp235x/sio/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PixShift {
     #[doc = "Do not shift the colour data register."]
     _0 = 0x0,

--- a/src/rp235x/spi/regs.rs
+++ b/src/rp235x/spi/regs.rs
@@ -21,6 +21,26 @@ impl Default for Cpsr {
         Cpsr(0)
     }
 }
+impl core::fmt::Debug for Cpsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cpsr")
+            .field("cpsdvsr", &self.cpsdvsr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cpsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cpsr {
+            cpsdvsr: u8,
+        }
+        let proxy = Cpsr {
+            cpsdvsr: self.cpsdvsr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register 0, SSPCR0 on page 3-4"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -88,6 +108,38 @@ impl Default for Cr0 {
         Cr0(0)
     }
 }
+impl core::fmt::Debug for Cr0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cr0")
+            .field("dss", &self.dss())
+            .field("frf", &self.frf())
+            .field("spo", &self.spo())
+            .field("sph", &self.sph())
+            .field("scr", &self.scr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cr0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cr0 {
+            dss: u8,
+            frf: u8,
+            spo: bool,
+            sph: bool,
+            scr: u8,
+        }
+        let proxy = Cr0 {
+            dss: self.dss(),
+            frf: self.frf(),
+            spo: self.spo(),
+            sph: self.sph(),
+            scr: self.scr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Control register 1, SSPCR1 on page 3-5"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -144,6 +196,35 @@ impl Default for Cr1 {
         Cr1(0)
     }
 }
+impl core::fmt::Debug for Cr1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Cr1")
+            .field("lbm", &self.lbm())
+            .field("sse", &self.sse())
+            .field("ms", &self.ms())
+            .field("sod", &self.sod())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Cr1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Cr1 {
+            lbm: bool,
+            sse: bool,
+            ms: bool,
+            sod: bool,
+        }
+        let proxy = Cr1 {
+            lbm: self.lbm(),
+            sse: self.sse(),
+            ms: self.ms(),
+            sod: self.sod(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA control register, SSPDMACR on page 3-12"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -178,6 +259,29 @@ impl Default for Dmacr {
         Dmacr(0)
     }
 }
+impl core::fmt::Debug for Dmacr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dmacr")
+            .field("rxdmae", &self.rxdmae())
+            .field("txdmae", &self.txdmae())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dmacr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dmacr {
+            rxdmae: bool,
+            txdmae: bool,
+        }
+        let proxy = Dmacr {
+            rxdmae: self.rxdmae(),
+            txdmae: self.txdmae(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Data register, SSPDR on page 3-6"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -199,6 +303,22 @@ impl Default for Dr {
     #[inline(always)]
     fn default() -> Dr {
         Dr(0)
+    }
+}
+impl core::fmt::Debug for Dr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dr").field("data", &self.data()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dr {
+            data: u16,
+        }
+        let proxy = Dr { data: self.data() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt clear register, SSPICR on page 3-11"]
@@ -233,6 +353,29 @@ impl Default for Icr {
     #[inline(always)]
     fn default() -> Icr {
         Icr(0)
+    }
+}
+impl core::fmt::Debug for Icr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Icr")
+            .field("roric", &self.roric())
+            .field("rtic", &self.rtic())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Icr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Icr {
+            roric: bool,
+            rtic: bool,
+        }
+        let proxy = Icr {
+            roric: self.roric(),
+            rtic: self.rtic(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt mask set or clear register, SSPIMSC on page 3-9"]
@@ -291,6 +434,35 @@ impl Default for Imsc {
         Imsc(0)
     }
 }
+impl core::fmt::Debug for Imsc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Imsc")
+            .field("rorim", &self.rorim())
+            .field("rtim", &self.rtim())
+            .field("rxim", &self.rxim())
+            .field("txim", &self.txim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Imsc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Imsc {
+            rorim: bool,
+            rtim: bool,
+            rxim: bool,
+            txim: bool,
+        }
+        let proxy = Imsc {
+            rorim: self.rorim(),
+            rtim: self.rtim(),
+            rxim: self.rxim(),
+            txim: self.txim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Masked interrupt status register, SSPMIS on page 3-11"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -347,6 +519,35 @@ impl Default for Mis {
         Mis(0)
     }
 }
+impl core::fmt::Debug for Mis {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Mis")
+            .field("rormis", &self.rormis())
+            .field("rtmis", &self.rtmis())
+            .field("rxmis", &self.rxmis())
+            .field("txmis", &self.txmis())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Mis {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Mis {
+            rormis: bool,
+            rtmis: bool,
+            rxmis: bool,
+            txmis: bool,
+        }
+        let proxy = Mis {
+            rormis: self.rormis(),
+            rtmis: self.rtmis(),
+            rxmis: self.rxmis(),
+            txmis: self.txmis(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -368,6 +569,26 @@ impl Default for Pcellid0 {
     #[inline(always)]
     fn default() -> Pcellid0 {
         Pcellid0(0)
+    }
+}
+impl core::fmt::Debug for Pcellid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid0")
+            .field("ssppcellid0", &self.ssppcellid0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid0 {
+            ssppcellid0: u8,
+        }
+        let proxy = Pcellid0 {
+            ssppcellid0: self.ssppcellid0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
@@ -393,6 +614,26 @@ impl Default for Pcellid1 {
         Pcellid1(0)
     }
 }
+impl core::fmt::Debug for Pcellid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid1")
+            .field("ssppcellid1", &self.ssppcellid1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid1 {
+            ssppcellid1: u8,
+        }
+        let proxy = Pcellid1 {
+            ssppcellid1: self.ssppcellid1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -414,6 +655,26 @@ impl Default for Pcellid2 {
     #[inline(always)]
     fn default() -> Pcellid2 {
         Pcellid2(0)
+    }
+}
+impl core::fmt::Debug for Pcellid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid2")
+            .field("ssppcellid2", &self.ssppcellid2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid2 {
+            ssppcellid2: u8,
+        }
+        let proxy = Pcellid2 {
+            ssppcellid2: self.ssppcellid2(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "PrimeCell identification registers, SSPPCellID0-3 on page 3-16"]
@@ -439,6 +700,26 @@ impl Default for Pcellid3 {
         Pcellid3(0)
     }
 }
+impl core::fmt::Debug for Pcellid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pcellid3")
+            .field("ssppcellid3", &self.ssppcellid3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pcellid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pcellid3 {
+            ssppcellid3: u8,
+        }
+        let proxy = Pcellid3 {
+            ssppcellid3: self.ssppcellid3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -460,6 +741,26 @@ impl Default for Periphid0 {
     #[inline(always)]
     fn default() -> Periphid0 {
         Periphid0(0)
+    }
+}
+impl core::fmt::Debug for Periphid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid0")
+            .field("partnumber0", &self.partnumber0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid0 {
+            partnumber0: u8,
+        }
+        let proxy = Periphid0 {
+            partnumber0: self.partnumber0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
@@ -496,6 +797,29 @@ impl Default for Periphid1 {
         Periphid1(0)
     }
 }
+impl core::fmt::Debug for Periphid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid1")
+            .field("partnumber1", &self.partnumber1())
+            .field("designer0", &self.designer0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid1 {
+            partnumber1: u8,
+            designer0: u8,
+        }
+        let proxy = Periphid1 {
+            partnumber1: self.partnumber1(),
+            designer0: self.designer0(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -530,6 +854,29 @@ impl Default for Periphid2 {
         Periphid2(0)
     }
 }
+impl core::fmt::Debug for Periphid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid2")
+            .field("designer1", &self.designer1())
+            .field("revision", &self.revision())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid2 {
+            designer1: u8,
+            revision: u8,
+        }
+        let proxy = Periphid2 {
+            designer1: self.designer1(),
+            revision: self.revision(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Peripheral identification registers, SSPPeriphID0-3 on page 3-13"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -551,6 +898,26 @@ impl Default for Periphid3 {
     #[inline(always)]
     fn default() -> Periphid3 {
         Periphid3(0)
+    }
+}
+impl core::fmt::Debug for Periphid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Periphid3")
+            .field("configuration", &self.configuration())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Periphid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Periphid3 {
+            configuration: u8,
+        }
+        let proxy = Periphid3 {
+            configuration: self.configuration(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Raw interrupt status register, SSPRIS on page 3-10"]
@@ -607,6 +974,35 @@ impl Default for Ris {
     #[inline(always)]
     fn default() -> Ris {
         Ris(0)
+    }
+}
+impl core::fmt::Debug for Ris {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ris")
+            .field("rorris", &self.rorris())
+            .field("rtris", &self.rtris())
+            .field("rxris", &self.rxris())
+            .field("txris", &self.txris())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ris {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ris {
+            rorris: bool,
+            rtris: bool,
+            rxris: bool,
+            txris: bool,
+        }
+        let proxy = Ris {
+            rorris: self.rorris(),
+            rtris: self.rtris(),
+            rxris: self.rxris(),
+            txris: self.txris(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Status register, SSPSR on page 3-7"]
@@ -674,5 +1070,37 @@ impl Default for Sr {
     #[inline(always)]
     fn default() -> Sr {
         Sr(0)
+    }
+}
+impl core::fmt::Debug for Sr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Sr")
+            .field("tfe", &self.tfe())
+            .field("tnf", &self.tnf())
+            .field("rne", &self.rne())
+            .field("rff", &self.rff())
+            .field("bsy", &self.bsy())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Sr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Sr {
+            tfe: bool,
+            tnf: bool,
+            rne: bool,
+            rff: bool,
+            bsy: bool,
+        }
+        let proxy = Sr {
+            tfe: self.tfe(),
+            tnf: self.tnf(),
+            rne: self.rne(),
+            rff: self.rff(),
+            bsy: self.bsy(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/syscfg/regs.rs
+++ b/src/rp235x/syscfg/regs.rs
@@ -21,6 +21,26 @@ impl Default for Auxctrl {
         Auxctrl(0)
     }
 }
+impl core::fmt::Debug for Auxctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Auxctrl")
+            .field("auxctrl", &self.auxctrl())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Auxctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Auxctrl {
+            auxctrl: u8,
+        }
+        let proxy = Auxctrl {
+            auxctrl: self.auxctrl(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Directly control the chip SWD debug port"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -75,6 +95,35 @@ impl Default for Dbgforce {
     #[inline(always)]
     fn default() -> Dbgforce {
         Dbgforce(0)
+    }
+}
+impl core::fmt::Debug for Dbgforce {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dbgforce")
+            .field("swdo", &self.swdo())
+            .field("swdi", &self.swdi())
+            .field("swclk", &self.swclk())
+            .field("attach", &self.attach())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dbgforce {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dbgforce {
+            swdo: bool,
+            swdi: bool,
+            swclk: bool,
+            attach: bool,
+        }
+        let proxy = Dbgforce {
+            swdo: self.swdo(),
+            swdi: self.swdi(),
+            swclk: self.swclk(),
+            attach: self.attach(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Control PD pins to memories. Set high to put memories to a low power state. In this state the memories will retain contents but not be accessible Use with caution"]
@@ -206,6 +255,62 @@ impl Default for Mempowerdown {
         Mempowerdown(0)
     }
 }
+impl core::fmt::Debug for Mempowerdown {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Mempowerdown")
+            .field("sram0", &self.sram0())
+            .field("sram1", &self.sram1())
+            .field("sram2", &self.sram2())
+            .field("sram3", &self.sram3())
+            .field("sram4", &self.sram4())
+            .field("sram5", &self.sram5())
+            .field("sram6", &self.sram6())
+            .field("sram7", &self.sram7())
+            .field("sram8", &self.sram8())
+            .field("sram9", &self.sram9())
+            .field("usb", &self.usb())
+            .field("rom", &self.rom())
+            .field("bootram", &self.bootram())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Mempowerdown {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Mempowerdown {
+            sram0: bool,
+            sram1: bool,
+            sram2: bool,
+            sram3: bool,
+            sram4: bool,
+            sram5: bool,
+            sram6: bool,
+            sram7: bool,
+            sram8: bool,
+            sram9: bool,
+            usb: bool,
+            rom: bool,
+            bootram: bool,
+        }
+        let proxy = Mempowerdown {
+            sram0: self.sram0(),
+            sram1: self.sram1(),
+            sram2: self.sram2(),
+            sram3: self.sram3(),
+            sram4: self.sram4(),
+            sram5: self.sram5(),
+            sram6: self.sram6(),
+            sram7: self.sram7(),
+            sram8: self.sram8(),
+            sram9: self.sram9(),
+            usb: self.usb(),
+            rom: self.rom(),
+            bootram: self.bootram(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Configuration for processors"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -238,6 +343,29 @@ impl Default for ProcConfig {
     #[inline(always)]
     fn default() -> ProcConfig {
         ProcConfig(0)
+    }
+}
+impl core::fmt::Debug for ProcConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ProcConfig")
+            .field("proc0_halted", &self.proc0_halted())
+            .field("proc1_halted", &self.proc1_halted())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProcConfig {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ProcConfig {
+            proc0_halted: bool,
+            proc1_halted: bool,
+        }
+        let proxy = ProcConfig {
+            proc0_halted: self.proc0_halted(),
+            proc1_halted: self.proc1_halted(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "For each bit, if 1, bypass the input synchronizer between that GPIO and the GPIO input register in the SIO. The input synchronizers should generally be unbypassed, to avoid injecting metastabilities into processors. If you're feeling brave, you can bypass to save two cycles of input latency. This register applies to GPIO 32...47. USB GPIO 56..57 QSPI GPIO 58..63"]
@@ -304,5 +432,40 @@ impl Default for ProcInSyncBypassHi {
     #[inline(always)]
     fn default() -> ProcInSyncBypassHi {
         ProcInSyncBypassHi(0)
+    }
+}
+impl core::fmt::Debug for ProcInSyncBypassHi {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ProcInSyncBypassHi")
+            .field("gpio", &self.gpio())
+            .field("usb_dp", &self.usb_dp())
+            .field("usb_dm", &self.usb_dm())
+            .field("qspi_sck", &self.qspi_sck())
+            .field("qspi_csn", &self.qspi_csn())
+            .field("qspi_sd", &self.qspi_sd())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProcInSyncBypassHi {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ProcInSyncBypassHi {
+            gpio: u16,
+            usb_dp: bool,
+            usb_dm: bool,
+            qspi_sck: bool,
+            qspi_csn: bool,
+            qspi_sd: u8,
+        }
+        let proxy = ProcInSyncBypassHi {
+            gpio: self.gpio(),
+            usb_dp: self.usb_dp(),
+            usb_dm: self.usb_dm(),
+            qspi_sck: self.qspi_sck(),
+            qspi_csn: self.qspi_csn(),
+            qspi_sd: self.qspi_sd(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/sysinfo/regs.rs
+++ b/src/rp235x/sysinfo/regs.rs
@@ -46,6 +46,35 @@ impl Default for ChipId {
         ChipId(0)
     }
 }
+impl core::fmt::Debug for ChipId {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ChipId")
+            .field("stop_bit", &self.stop_bit())
+            .field("manufacturer", &self.manufacturer())
+            .field("part", &self.part())
+            .field("revision", &self.revision())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for ChipId {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct ChipId {
+            stop_bit: bool,
+            manufacturer: u16,
+            part: u16,
+            revision: u8,
+        }
+        let proxy = ChipId {
+            stop_bit: self.stop_bit(),
+            manufacturer: self.manufacturer(),
+            part: self.part(),
+            revision: self.revision(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct PackageSel(pub u32);
@@ -64,6 +93,26 @@ impl Default for PackageSel {
     #[inline(always)]
     fn default() -> PackageSel {
         PackageSel(0)
+    }
+}
+impl core::fmt::Debug for PackageSel {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("PackageSel")
+            .field("package_sel", &self.package_sel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for PackageSel {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct PackageSel {
+            package_sel: bool,
+        }
+        let proxy = PackageSel {
+            package_sel: self.package_sel(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Platform register. Allows software to know what environment it is running in during pre-production development. Post-production, the PLATFORM is always ASIC, non-SIM."]
@@ -121,5 +170,37 @@ impl Default for Platform {
     #[inline(always)]
     fn default() -> Platform {
         Platform(0)
+    }
+}
+impl core::fmt::Debug for Platform {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Platform")
+            .field("fpga", &self.fpga())
+            .field("asic", &self.asic())
+            .field("hdlsim", &self.hdlsim())
+            .field("batchsim", &self.batchsim())
+            .field("gatesim", &self.gatesim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Platform {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Platform {
+            fpga: bool,
+            asic: bool,
+            hdlsim: bool,
+            batchsim: bool,
+            gatesim: bool,
+        }
+        let proxy = Platform {
+            fpga: self.fpga(),
+            asic: self.asic(),
+            hdlsim: self.hdlsim(),
+            batchsim: self.batchsim(),
+            gatesim: self.gatesim(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/tbman/regs.rs
+++ b/src/rp235x/tbman/regs.rs
@@ -43,3 +43,29 @@ impl Default for Platform {
         Platform(0)
     }
 }
+impl core::fmt::Debug for Platform {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Platform")
+            .field("asic", &self.asic())
+            .field("fpga", &self.fpga())
+            .field("hdlsim", &self.hdlsim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Platform {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Platform {
+            asic: bool,
+            fpga: bool,
+            hdlsim: bool,
+        }
+        let proxy = Platform {
+            asic: self.asic(),
+            fpga: self.fpga(),
+            hdlsim: self.hdlsim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}

--- a/src/rp235x/ticks/regs.rs
+++ b/src/rp235x/ticks/regs.rs
@@ -20,6 +20,26 @@ impl Default for Proc0count {
         Proc0count(0)
     }
 }
+impl core::fmt::Debug for Proc0count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Proc0count")
+            .field("proc0_count", &self.proc0_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Proc0count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Proc0count {
+            proc0_count: u16,
+        }
+        let proxy = Proc0count {
+            proc0_count: self.proc0_count(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Controls the tick generator"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -54,6 +74,29 @@ impl Default for Proc0ctrl {
         Proc0ctrl(0)
     }
 }
+impl core::fmt::Debug for Proc0ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Proc0ctrl")
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Proc0ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Proc0ctrl {
+            enable: bool,
+            running: bool,
+        }
+        let proxy = Proc0ctrl {
+            enable: self.enable(),
+            running: self.running(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Proc0cycles(pub u32);
@@ -76,6 +119,26 @@ impl Default for Proc0cycles {
         Proc0cycles(0)
     }
 }
+impl core::fmt::Debug for Proc0cycles {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Proc0cycles")
+            .field("proc0_cycles", &self.proc0_cycles())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Proc0cycles {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Proc0cycles {
+            proc0_cycles: u16,
+        }
+        let proxy = Proc0cycles {
+            proc0_cycles: self.proc0_cycles(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Proc1count(pub u32);
@@ -96,6 +159,26 @@ impl Default for Proc1count {
     #[inline(always)]
     fn default() -> Proc1count {
         Proc1count(0)
+    }
+}
+impl core::fmt::Debug for Proc1count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Proc1count")
+            .field("proc1_count", &self.proc1_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Proc1count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Proc1count {
+            proc1_count: u16,
+        }
+        let proxy = Proc1count {
+            proc1_count: self.proc1_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the tick generator"]
@@ -132,6 +215,29 @@ impl Default for Proc1ctrl {
         Proc1ctrl(0)
     }
 }
+impl core::fmt::Debug for Proc1ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Proc1ctrl")
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Proc1ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Proc1ctrl {
+            enable: bool,
+            running: bool,
+        }
+        let proxy = Proc1ctrl {
+            enable: self.enable(),
+            running: self.running(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Proc1cycles(pub u32);
@@ -154,6 +260,26 @@ impl Default for Proc1cycles {
         Proc1cycles(0)
     }
 }
+impl core::fmt::Debug for Proc1cycles {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Proc1cycles")
+            .field("proc1_cycles", &self.proc1_cycles())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Proc1cycles {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Proc1cycles {
+            proc1_cycles: u16,
+        }
+        let proxy = Proc1cycles {
+            proc1_cycles: self.proc1_cycles(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct RiscvCount(pub u32);
@@ -174,6 +300,26 @@ impl Default for RiscvCount {
     #[inline(always)]
     fn default() -> RiscvCount {
         RiscvCount(0)
+    }
+}
+impl core::fmt::Debug for RiscvCount {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RiscvCount")
+            .field("riscv_count", &self.riscv_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RiscvCount {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RiscvCount {
+            riscv_count: u16,
+        }
+        let proxy = RiscvCount {
+            riscv_count: self.riscv_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the tick generator"]
@@ -210,6 +356,29 @@ impl Default for RiscvCtrl {
         RiscvCtrl(0)
     }
 }
+impl core::fmt::Debug for RiscvCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RiscvCtrl")
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RiscvCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RiscvCtrl {
+            enable: bool,
+            running: bool,
+        }
+        let proxy = RiscvCtrl {
+            enable: self.enable(),
+            running: self.running(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct RiscvCycles(pub u32);
@@ -232,6 +401,26 @@ impl Default for RiscvCycles {
         RiscvCycles(0)
     }
 }
+impl core::fmt::Debug for RiscvCycles {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RiscvCycles")
+            .field("riscv_cycles", &self.riscv_cycles())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RiscvCycles {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RiscvCycles {
+            riscv_cycles: u16,
+        }
+        let proxy = RiscvCycles {
+            riscv_cycles: self.riscv_cycles(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer0count(pub u32);
@@ -252,6 +441,26 @@ impl Default for Timer0count {
     #[inline(always)]
     fn default() -> Timer0count {
         Timer0count(0)
+    }
+}
+impl core::fmt::Debug for Timer0count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer0count")
+            .field("timer0_count", &self.timer0_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer0count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer0count {
+            timer0_count: u16,
+        }
+        let proxy = Timer0count {
+            timer0_count: self.timer0_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the tick generator"]
@@ -288,6 +497,29 @@ impl Default for Timer0ctrl {
         Timer0ctrl(0)
     }
 }
+impl core::fmt::Debug for Timer0ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer0ctrl")
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer0ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer0ctrl {
+            enable: bool,
+            running: bool,
+        }
+        let proxy = Timer0ctrl {
+            enable: self.enable(),
+            running: self.running(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer0cycles(pub u32);
@@ -310,6 +542,26 @@ impl Default for Timer0cycles {
         Timer0cycles(0)
     }
 }
+impl core::fmt::Debug for Timer0cycles {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer0cycles")
+            .field("timer0_cycles", &self.timer0_cycles())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer0cycles {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer0cycles {
+            timer0_cycles: u16,
+        }
+        let proxy = Timer0cycles {
+            timer0_cycles: self.timer0_cycles(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer1count(pub u32);
@@ -330,6 +582,26 @@ impl Default for Timer1count {
     #[inline(always)]
     fn default() -> Timer1count {
         Timer1count(0)
+    }
+}
+impl core::fmt::Debug for Timer1count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer1count")
+            .field("timer1_count", &self.timer1_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer1count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer1count {
+            timer1_count: u16,
+        }
+        let proxy = Timer1count {
+            timer1_count: self.timer1_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the tick generator"]
@@ -366,6 +638,29 @@ impl Default for Timer1ctrl {
         Timer1ctrl(0)
     }
 }
+impl core::fmt::Debug for Timer1ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer1ctrl")
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer1ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer1ctrl {
+            enable: bool,
+            running: bool,
+        }
+        let proxy = Timer1ctrl {
+            enable: self.enable(),
+            running: self.running(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer1cycles(pub u32);
@@ -388,6 +683,26 @@ impl Default for Timer1cycles {
         Timer1cycles(0)
     }
 }
+impl core::fmt::Debug for Timer1cycles {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Timer1cycles")
+            .field("timer1_cycles", &self.timer1_cycles())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timer1cycles {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Timer1cycles {
+            timer1_cycles: u16,
+        }
+        let proxy = Timer1cycles {
+            timer1_cycles: self.timer1_cycles(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct WatchdogCount(pub u32);
@@ -408,6 +723,26 @@ impl Default for WatchdogCount {
     #[inline(always)]
     fn default() -> WatchdogCount {
         WatchdogCount(0)
+    }
+}
+impl core::fmt::Debug for WatchdogCount {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WatchdogCount")
+            .field("watchdog_count", &self.watchdog_count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WatchdogCount {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WatchdogCount {
+            watchdog_count: u16,
+        }
+        let proxy = WatchdogCount {
+            watchdog_count: self.watchdog_count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the tick generator"]
@@ -444,6 +779,29 @@ impl Default for WatchdogCtrl {
         WatchdogCtrl(0)
     }
 }
+impl core::fmt::Debug for WatchdogCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WatchdogCtrl")
+            .field("enable", &self.enable())
+            .field("running", &self.running())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WatchdogCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WatchdogCtrl {
+            enable: bool,
+            running: bool,
+        }
+        let proxy = WatchdogCtrl {
+            enable: self.enable(),
+            running: self.running(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct WatchdogCycles(pub u32);
@@ -464,5 +822,25 @@ impl Default for WatchdogCycles {
     #[inline(always)]
     fn default() -> WatchdogCycles {
         WatchdogCycles(0)
+    }
+}
+impl core::fmt::Debug for WatchdogCycles {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("WatchdogCycles")
+            .field("watchdog_cycles", &self.watchdog_cycles())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for WatchdogCycles {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct WatchdogCycles {
+            watchdog_cycles: u16,
+        }
+        let proxy = WatchdogCycles {
+            watchdog_cycles: self.watchdog_cycles(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/timer/regs.rs
+++ b/src/rp235x/timer/regs.rs
@@ -19,6 +19,26 @@ impl Default for Armed {
         Armed(0)
     }
 }
+impl core::fmt::Debug for Armed {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Armed")
+            .field("armed", &self.armed())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Armed {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Armed {
+            armed: u8,
+        }
+        let proxy = Armed {
+            armed: self.armed(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set bits high to enable pause when the corresponding debug ports are active"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,7 +73,30 @@ impl Default for Dbgpause {
         Dbgpause(0)
     }
 }
-#[doc = "Interrupt status after masking & forcing"]
+impl core::fmt::Debug for Dbgpause {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dbgpause")
+            .field("dbg0", &self.dbg0())
+            .field("dbg1", &self.dbg1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dbgpause {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dbgpause {
+            dbg0: bool,
+            dbg1: bool,
+        }
+        let proxy = Dbgpause {
+            dbg0: self.dbg0(),
+            dbg1: self.dbg1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt Enable"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Int(pub u32);
@@ -78,6 +121,39 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field(
+                "alarm",
+                &[
+                    self.alarm(0usize),
+                    self.alarm(1usize),
+                    self.alarm(2usize),
+                    self.alarm(3usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            alarm: [bool; 4usize],
+        }
+        let proxy = Int {
+            alarm: [
+                self.alarm(0usize),
+                self.alarm(1usize),
+                self.alarm(2usize),
+                self.alarm(3usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set locked bit to disable write access to timer Once set, cannot be cleared (without a reset)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -97,6 +173,26 @@ impl Default for Locked {
     #[inline(always)]
     fn default() -> Locked {
         Locked(0)
+    }
+}
+impl core::fmt::Debug for Locked {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Locked")
+            .field("locked", &self.locked())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Locked {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Locked {
+            locked: bool,
+        }
+        let proxy = Locked {
+            locked: self.locked(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Set high to pause the timer"]
@@ -120,6 +216,26 @@ impl Default for Pause {
         Pause(0)
     }
 }
+impl core::fmt::Debug for Pause {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pause")
+            .field("pause", &self.pause())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Pause {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Pause {
+            pause: bool,
+        }
+        let proxy = Pause {
+            pause: self.pause(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Selects the source for the timer. Defaults to the normal tick configured in the ticks block (typically configured to 1 microsecond). Writing to 1 will ignore the tick and count clk_sys cycles instead."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -139,5 +255,25 @@ impl Default for Source {
     #[inline(always)]
     fn default() -> Source {
         Source(0)
+    }
+}
+impl core::fmt::Debug for Source {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Source")
+            .field("clk_sys", &self.clk_sys())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Source {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Source {
+            clk_sys: super::vals::ClkSys,
+        }
+        let proxy = Source {
+            clk_sys: self.clk_sys(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/timer/vals.rs
+++ b/src/rp235x/timer/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClkSys {
     TICK = 0x0,
     CLK_SYS = 0x01,

--- a/src/rp235x/trng/regs.rs
+++ b/src/rp235x/trng/regs.rs
@@ -43,6 +43,32 @@ impl Default for AutocorrStatistic {
         AutocorrStatistic(0)
     }
 }
+impl core::fmt::Debug for AutocorrStatistic {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AutocorrStatistic")
+            .field("autocorr_trys", &self.autocorr_trys())
+            .field("autocorr_fails", &self.autocorr_fails())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AutocorrStatistic {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AutocorrStatistic {
+            autocorr_trys: u16,
+            autocorr_fails: u8,
+            reserved: u16,
+        }
+        let proxy = AutocorrStatistic {
+            autocorr_trys: self.autocorr_trys(),
+            autocorr_fails: self.autocorr_fails(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Enable signal for the random source."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -75,6 +101,29 @@ impl Default for RndSourceEnable {
     #[inline(always)]
     fn default() -> RndSourceEnable {
         RndSourceEnable(0)
+    }
+}
+impl core::fmt::Debug for RndSourceEnable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RndSourceEnable")
+            .field("rnd_src_en", &self.rnd_src_en())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RndSourceEnable {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RndSourceEnable {
+            rnd_src_en: bool,
+            reserved: u32,
+        }
+        let proxy = RndSourceEnable {
+            rnd_src_en: self.rnd_src_en(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Collected BIST results."]
@@ -111,6 +160,29 @@ impl Default for RngBistCntr0 {
         RngBistCntr0(0)
     }
 }
+impl core::fmt::Debug for RngBistCntr0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngBistCntr0")
+            .field("rosc_cntr_val", &self.rosc_cntr_val())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngBistCntr0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngBistCntr0 {
+            rosc_cntr_val: u32,
+            reserved: u16,
+        }
+        let proxy = RngBistCntr0 {
+            rosc_cntr_val: self.rosc_cntr_val(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Collected BIST results."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -143,6 +215,29 @@ impl Default for RngBistCntr1 {
     #[inline(always)]
     fn default() -> RngBistCntr1 {
         RngBistCntr1(0)
+    }
+}
+impl core::fmt::Debug for RngBistCntr1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngBistCntr1")
+            .field("rosc_cntr_val", &self.rosc_cntr_val())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngBistCntr1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngBistCntr1 {
+            rosc_cntr_val: u32,
+            reserved: u16,
+        }
+        let proxy = RngBistCntr1 {
+            rosc_cntr_val: self.rosc_cntr_val(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Collected BIST results."]
@@ -179,6 +274,29 @@ impl Default for RngBistCntr2 {
         RngBistCntr2(0)
     }
 }
+impl core::fmt::Debug for RngBistCntr2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngBistCntr2")
+            .field("rosc_cntr_val", &self.rosc_cntr_val())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngBistCntr2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngBistCntr2 {
+            rosc_cntr_val: u32,
+            reserved: u16,
+        }
+        let proxy = RngBistCntr2 {
+            rosc_cntr_val: self.rosc_cntr_val(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Enable the RNG debug mode"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -211,6 +329,29 @@ impl Default for RngDebugEnInput {
     #[inline(always)]
     fn default() -> RngDebugEnInput {
         RngDebugEnInput(0)
+    }
+}
+impl core::fmt::Debug for RngDebugEnInput {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngDebugEnInput")
+            .field("rng_debug_en", &self.rng_debug_en())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngDebugEnInput {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngDebugEnInput {
+            rng_debug_en: bool,
+            reserved: u32,
+        }
+        let proxy = RngDebugEnInput {
+            rng_debug_en: self.rng_debug_en(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt/status bit clear Register."]
@@ -280,6 +421,38 @@ impl Default for RngIcr {
         RngIcr(0)
     }
 }
+impl core::fmt::Debug for RngIcr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngIcr")
+            .field("ehr_valid", &self.ehr_valid())
+            .field("autocorr_err", &self.autocorr_err())
+            .field("crngt_err", &self.crngt_err())
+            .field("vn_err", &self.vn_err())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngIcr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngIcr {
+            ehr_valid: bool,
+            autocorr_err: bool,
+            crngt_err: bool,
+            vn_err: bool,
+            reserved: u32,
+        }
+        let proxy = RngIcr {
+            ehr_valid: self.ehr_valid(),
+            autocorr_err: self.autocorr_err(),
+            crngt_err: self.crngt_err(),
+            vn_err: self.vn_err(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt masking."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -347,6 +520,38 @@ impl Default for RngImr {
         RngImr(0)
     }
 }
+impl core::fmt::Debug for RngImr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngImr")
+            .field("ehr_valid_int_mask", &self.ehr_valid_int_mask())
+            .field("autocorr_err_int_mask", &self.autocorr_err_int_mask())
+            .field("crngt_err_int_mask", &self.crngt_err_int_mask())
+            .field("vn_err_int_mask", &self.vn_err_int_mask())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngImr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngImr {
+            ehr_valid_int_mask: bool,
+            autocorr_err_int_mask: bool,
+            crngt_err_int_mask: bool,
+            vn_err_int_mask: bool,
+            reserved: u32,
+        }
+        let proxy = RngImr {
+            ehr_valid_int_mask: self.ehr_valid_int_mask(),
+            autocorr_err_int_mask: self.autocorr_err_int_mask(),
+            crngt_err_int_mask: self.crngt_err_int_mask(),
+            vn_err_int_mask: self.vn_err_int_mask(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "RNG status register. If corresponding RNG_IMR bit is unmasked, an interrupt will be generated."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -412,6 +617,38 @@ impl Default for RngIsr {
     #[inline(always)]
     fn default() -> RngIsr {
         RngIsr(0)
+    }
+}
+impl core::fmt::Debug for RngIsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngIsr")
+            .field("ehr_valid", &self.ehr_valid())
+            .field("autocorr_err", &self.autocorr_err())
+            .field("crngt_err", &self.crngt_err())
+            .field("vn_err", &self.vn_err())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngIsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngIsr {
+            ehr_valid: bool,
+            autocorr_err: bool,
+            crngt_err: bool,
+            vn_err: bool,
+            reserved: u32,
+        }
+        let proxy = RngIsr {
+            ehr_valid: self.ehr_valid(),
+            autocorr_err: self.autocorr_err(),
+            crngt_err: self.crngt_err(),
+            vn_err: self.vn_err(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Displays the version settings of the TRNG."]
@@ -525,6 +762,50 @@ impl Default for RngVersion {
         RngVersion(0)
     }
 }
+impl core::fmt::Debug for RngVersion {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RngVersion")
+            .field("ehr_width_192", &self.ehr_width_192())
+            .field("crngt_exists", &self.crngt_exists())
+            .field("autocorr_exists", &self.autocorr_exists())
+            .field("trng_tests_bypass_en", &self.trng_tests_bypass_en())
+            .field("prng_exists", &self.prng_exists())
+            .field("kat_exists", &self.kat_exists())
+            .field("reseeding_exists", &self.reseeding_exists())
+            .field("rng_use_5_sboxes", &self.rng_use_5_sboxes())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RngVersion {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RngVersion {
+            ehr_width_192: bool,
+            crngt_exists: bool,
+            autocorr_exists: bool,
+            trng_tests_bypass_en: bool,
+            prng_exists: bool,
+            kat_exists: bool,
+            reseeding_exists: bool,
+            rng_use_5_sboxes: bool,
+            reserved: u32,
+        }
+        let proxy = RngVersion {
+            ehr_width_192: self.ehr_width_192(),
+            crngt_exists: self.crngt_exists(),
+            autocorr_exists: self.autocorr_exists(),
+            trng_tests_bypass_en: self.trng_tests_bypass_en(),
+            prng_exists: self.prng_exists(),
+            kat_exists: self.kat_exists(),
+            reseeding_exists: self.reseeding_exists(),
+            rng_use_5_sboxes: self.rng_use_5_sboxes(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Reset the counter of collected bits in the RNG."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -557,6 +838,29 @@ impl Default for RstBitsCounter {
     #[inline(always)]
     fn default() -> RstBitsCounter {
         RstBitsCounter(0)
+    }
+}
+impl core::fmt::Debug for RstBitsCounter {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("RstBitsCounter")
+            .field("rst_bits_counter", &self.rst_bits_counter())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for RstBitsCounter {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct RstBitsCounter {
+            rst_bits_counter: bool,
+            reserved: u32,
+        }
+        let proxy = RstBitsCounter {
+            rst_bits_counter: self.rst_bits_counter(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "RNG Busy indication."]
@@ -593,6 +897,29 @@ impl Default for TrngBusy {
         TrngBusy(0)
     }
 }
+impl core::fmt::Debug for TrngBusy {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrngBusy")
+            .field("trng_busy", &self.trng_busy())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrngBusy {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrngBusy {
+            trng_busy: bool,
+            reserved: u32,
+        }
+        let proxy = TrngBusy {
+            trng_busy: self.trng_busy(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Selecting the inverter-chain length."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -625,6 +952,29 @@ impl Default for TrngConfig {
     #[inline(always)]
     fn default() -> TrngConfig {
         TrngConfig(0)
+    }
+}
+impl core::fmt::Debug for TrngConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrngConfig")
+            .field("rnd_src_sel", &self.rnd_src_sel())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrngConfig {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrngConfig {
+            rnd_src_sel: u8,
+            reserved: u32,
+        }
+        let proxy = TrngConfig {
+            rnd_src_sel: self.rnd_src_sel(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Debug register."]
@@ -683,6 +1033,35 @@ impl Default for TrngDebugControl {
         TrngDebugControl(0)
     }
 }
+impl core::fmt::Debug for TrngDebugControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrngDebugControl")
+            .field("reserved", &self.reserved())
+            .field("vnc_bypass", &self.vnc_bypass())
+            .field("trng_crngt_bypass", &self.trng_crngt_bypass())
+            .field("auto_correlate_bypass", &self.auto_correlate_bypass())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrngDebugControl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrngDebugControl {
+            reserved: bool,
+            vnc_bypass: bool,
+            trng_crngt_bypass: bool,
+            auto_correlate_bypass: bool,
+        }
+        let proxy = TrngDebugControl {
+            reserved: self.reserved(),
+            vnc_bypass: self.vnc_bypass(),
+            trng_crngt_bypass: self.trng_crngt_bypass(),
+            auto_correlate_bypass: self.auto_correlate_bypass(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Generate internal SW reset within the RNG block."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -717,6 +1096,29 @@ impl Default for TrngSwReset {
         TrngSwReset(0)
     }
 }
+impl core::fmt::Debug for TrngSwReset {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrngSwReset")
+            .field("trng_sw_reset", &self.trng_sw_reset())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrngSwReset {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrngSwReset {
+            trng_sw_reset: bool,
+            reserved: u32,
+        }
+        let proxy = TrngSwReset {
+            trng_sw_reset: self.trng_sw_reset(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "192 bit collection indication."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -749,5 +1151,28 @@ impl Default for TrngValid {
     #[inline(always)]
     fn default() -> TrngValid {
         TrngValid(0)
+    }
+}
+impl core::fmt::Debug for TrngValid {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("TrngValid")
+            .field("ehr_valid", &self.ehr_valid())
+            .field("reserved", &self.reserved())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for TrngValid {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct TrngValid {
+            ehr_valid: bool,
+            reserved: u32,
+        }
+        let proxy = TrngValid {
+            ehr_valid: self.ehr_valid(),
+            reserved: self.reserved(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/uart/regs.rs
+++ b/src/rp235x/uart/regs.rs
@@ -142,6 +142,59 @@ impl Default for Uartcr {
         Uartcr(0)
     }
 }
+impl core::fmt::Debug for Uartcr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartcr")
+            .field("uarten", &self.uarten())
+            .field("siren", &self.siren())
+            .field("sirlp", &self.sirlp())
+            .field("lbe", &self.lbe())
+            .field("txe", &self.txe())
+            .field("rxe", &self.rxe())
+            .field("dtr", &self.dtr())
+            .field("rts", &self.rts())
+            .field("out1", &self.out1())
+            .field("out2", &self.out2())
+            .field("rtsen", &self.rtsen())
+            .field("ctsen", &self.ctsen())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartcr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartcr {
+            uarten: bool,
+            siren: bool,
+            sirlp: bool,
+            lbe: bool,
+            txe: bool,
+            rxe: bool,
+            dtr: bool,
+            rts: bool,
+            out1: bool,
+            out2: bool,
+            rtsen: bool,
+            ctsen: bool,
+        }
+        let proxy = Uartcr {
+            uarten: self.uarten(),
+            siren: self.siren(),
+            sirlp: self.sirlp(),
+            lbe: self.lbe(),
+            txe: self.txe(),
+            rxe: self.rxe(),
+            dtr: self.dtr(),
+            rts: self.rts(),
+            out1: self.out1(),
+            out2: self.out2(),
+            rtsen: self.rtsen(),
+            ctsen: self.ctsen(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "DMA Control Register, UARTDMACR"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -185,6 +238,32 @@ impl Default for Uartdmacr {
     #[inline(always)]
     fn default() -> Uartdmacr {
         Uartdmacr(0)
+    }
+}
+impl core::fmt::Debug for Uartdmacr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartdmacr")
+            .field("rxdmae", &self.rxdmae())
+            .field("txdmae", &self.txdmae())
+            .field("dmaonerr", &self.dmaonerr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartdmacr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartdmacr {
+            rxdmae: bool,
+            txdmae: bool,
+            dmaonerr: bool,
+        }
+        let proxy = Uartdmacr {
+            rxdmae: self.rxdmae(),
+            txdmae: self.txdmae(),
+            dmaonerr: self.dmaonerr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Data Register, UARTDR"]
@@ -254,6 +333,38 @@ impl Default for Uartdr {
         Uartdr(0)
     }
 }
+impl core::fmt::Debug for Uartdr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartdr")
+            .field("data", &self.data())
+            .field("fe", &self.fe())
+            .field("pe", &self.pe())
+            .field("be", &self.be())
+            .field("oe", &self.oe())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartdr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartdr {
+            data: u8,
+            fe: bool,
+            pe: bool,
+            be: bool,
+            oe: bool,
+        }
+        let proxy = Uartdr {
+            data: self.data(),
+            fe: self.fe(),
+            pe: self.pe(),
+            be: self.be(),
+            oe: self.oe(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Fractional Baud Rate Register, UARTFBRD"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -275,6 +386,26 @@ impl Default for Uartfbrd {
     #[inline(always)]
     fn default() -> Uartfbrd {
         Uartfbrd(0)
+    }
+}
+impl core::fmt::Debug for Uartfbrd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartfbrd")
+            .field("baud_divfrac", &self.baud_divfrac())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartfbrd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartfbrd {
+            baud_divfrac: u8,
+        }
+        let proxy = Uartfbrd {
+            baud_divfrac: self.baud_divfrac(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Flag Register, UARTFR"]
@@ -388,6 +519,50 @@ impl Default for Uartfr {
         Uartfr(0)
     }
 }
+impl core::fmt::Debug for Uartfr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartfr")
+            .field("cts", &self.cts())
+            .field("dsr", &self.dsr())
+            .field("dcd", &self.dcd())
+            .field("busy", &self.busy())
+            .field("rxfe", &self.rxfe())
+            .field("txff", &self.txff())
+            .field("rxff", &self.rxff())
+            .field("txfe", &self.txfe())
+            .field("ri", &self.ri())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartfr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartfr {
+            cts: bool,
+            dsr: bool,
+            dcd: bool,
+            busy: bool,
+            rxfe: bool,
+            txff: bool,
+            rxff: bool,
+            txfe: bool,
+            ri: bool,
+        }
+        let proxy = Uartfr {
+            cts: self.cts(),
+            dsr: self.dsr(),
+            dcd: self.dcd(),
+            busy: self.busy(),
+            rxfe: self.rxfe(),
+            txff: self.txff(),
+            rxff: self.rxff(),
+            txfe: self.txfe(),
+            ri: self.ri(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Integer Baud Rate Register, UARTIBRD"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -409,6 +584,26 @@ impl Default for Uartibrd {
     #[inline(always)]
     fn default() -> Uartibrd {
         Uartibrd(0)
+    }
+}
+impl core::fmt::Debug for Uartibrd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartibrd")
+            .field("baud_divint", &self.baud_divint())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartibrd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartibrd {
+            baud_divint: u16,
+        }
+        let proxy = Uartibrd {
+            baud_divint: self.baud_divint(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Clear Register, UARTICR"]
@@ -544,6 +739,56 @@ impl Default for Uarticr {
         Uarticr(0)
     }
 }
+impl core::fmt::Debug for Uarticr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uarticr")
+            .field("rimic", &self.rimic())
+            .field("ctsmic", &self.ctsmic())
+            .field("dcdmic", &self.dcdmic())
+            .field("dsrmic", &self.dsrmic())
+            .field("rxic", &self.rxic())
+            .field("txic", &self.txic())
+            .field("rtic", &self.rtic())
+            .field("feic", &self.feic())
+            .field("peic", &self.peic())
+            .field("beic", &self.beic())
+            .field("oeic", &self.oeic())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uarticr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uarticr {
+            rimic: bool,
+            ctsmic: bool,
+            dcdmic: bool,
+            dsrmic: bool,
+            rxic: bool,
+            txic: bool,
+            rtic: bool,
+            feic: bool,
+            peic: bool,
+            beic: bool,
+            oeic: bool,
+        }
+        let proxy = Uarticr {
+            rimic: self.rimic(),
+            ctsmic: self.ctsmic(),
+            dcdmic: self.dcdmic(),
+            dsrmic: self.dsrmic(),
+            rxic: self.rxic(),
+            txic: self.txic(),
+            rtic: self.rtic(),
+            feic: self.feic(),
+            peic: self.peic(),
+            beic: self.beic(),
+            oeic: self.oeic(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Interrupt FIFO Level Select Register, UARTIFLS"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -578,6 +823,29 @@ impl Default for Uartifls {
         Uartifls(0)
     }
 }
+impl core::fmt::Debug for Uartifls {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartifls")
+            .field("txiflsel", &self.txiflsel())
+            .field("rxiflsel", &self.rxiflsel())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartifls {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartifls {
+            txiflsel: u8,
+            rxiflsel: u8,
+        }
+        let proxy = Uartifls {
+            txiflsel: self.txiflsel(),
+            rxiflsel: self.rxiflsel(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "IrDA Low-Power Counter Register, UARTILPR"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -599,6 +867,26 @@ impl Default for Uartilpr {
     #[inline(always)]
     fn default() -> Uartilpr {
         Uartilpr(0)
+    }
+}
+impl core::fmt::Debug for Uartilpr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartilpr")
+            .field("ilpdvsr", &self.ilpdvsr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartilpr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartilpr {
+            ilpdvsr: u8,
+        }
+        let proxy = Uartilpr {
+            ilpdvsr: self.ilpdvsr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Mask Set/Clear Register, UARTIMSC"]
@@ -734,6 +1022,56 @@ impl Default for Uartimsc {
         Uartimsc(0)
     }
 }
+impl core::fmt::Debug for Uartimsc {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartimsc")
+            .field("rimim", &self.rimim())
+            .field("ctsmim", &self.ctsmim())
+            .field("dcdmim", &self.dcdmim())
+            .field("dsrmim", &self.dsrmim())
+            .field("rxim", &self.rxim())
+            .field("txim", &self.txim())
+            .field("rtim", &self.rtim())
+            .field("feim", &self.feim())
+            .field("peim", &self.peim())
+            .field("beim", &self.beim())
+            .field("oeim", &self.oeim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartimsc {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartimsc {
+            rimim: bool,
+            ctsmim: bool,
+            dcdmim: bool,
+            dsrmim: bool,
+            rxim: bool,
+            txim: bool,
+            rtim: bool,
+            feim: bool,
+            peim: bool,
+            beim: bool,
+            oeim: bool,
+        }
+        let proxy = Uartimsc {
+            rimim: self.rimim(),
+            ctsmim: self.ctsmim(),
+            dcdmim: self.dcdmim(),
+            dsrmim: self.dsrmim(),
+            rxim: self.rxim(),
+            txim: self.txim(),
+            rtim: self.rtim(),
+            feim: self.feim(),
+            peim: self.peim(),
+            beim: self.beim(),
+            oeim: self.oeim(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Line Control Register, UARTLCR_H"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -821,6 +1159,44 @@ impl Default for UartlcrH {
     #[inline(always)]
     fn default() -> UartlcrH {
         UartlcrH(0)
+    }
+}
+impl core::fmt::Debug for UartlcrH {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UartlcrH")
+            .field("brk", &self.brk())
+            .field("pen", &self.pen())
+            .field("eps", &self.eps())
+            .field("stp2", &self.stp2())
+            .field("fen", &self.fen())
+            .field("wlen", &self.wlen())
+            .field("sps", &self.sps())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UartlcrH {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UartlcrH {
+            brk: bool,
+            pen: bool,
+            eps: bool,
+            stp2: bool,
+            fen: bool,
+            wlen: u8,
+            sps: bool,
+        }
+        let proxy = UartlcrH {
+            brk: self.brk(),
+            pen: self.pen(),
+            eps: self.eps(),
+            stp2: self.stp2(),
+            fen: self.fen(),
+            wlen: self.wlen(),
+            sps: self.sps(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Masked Interrupt Status Register, UARTMIS"]
@@ -956,6 +1332,56 @@ impl Default for Uartmis {
         Uartmis(0)
     }
 }
+impl core::fmt::Debug for Uartmis {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartmis")
+            .field("rimmis", &self.rimmis())
+            .field("ctsmmis", &self.ctsmmis())
+            .field("dcdmmis", &self.dcdmmis())
+            .field("dsrmmis", &self.dsrmmis())
+            .field("rxmis", &self.rxmis())
+            .field("txmis", &self.txmis())
+            .field("rtmis", &self.rtmis())
+            .field("femis", &self.femis())
+            .field("pemis", &self.pemis())
+            .field("bemis", &self.bemis())
+            .field("oemis", &self.oemis())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartmis {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartmis {
+            rimmis: bool,
+            ctsmmis: bool,
+            dcdmmis: bool,
+            dsrmmis: bool,
+            rxmis: bool,
+            txmis: bool,
+            rtmis: bool,
+            femis: bool,
+            pemis: bool,
+            bemis: bool,
+            oemis: bool,
+        }
+        let proxy = Uartmis {
+            rimmis: self.rimmis(),
+            ctsmmis: self.ctsmmis(),
+            dcdmmis: self.dcdmmis(),
+            dsrmmis: self.dsrmmis(),
+            rxmis: self.rxmis(),
+            txmis: self.txmis(),
+            rtmis: self.rtmis(),
+            femis: self.femis(),
+            pemis: self.pemis(),
+            bemis: self.bemis(),
+            oemis: self.oemis(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPCellID0 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -977,6 +1403,26 @@ impl Default for Uartpcellid0 {
     #[inline(always)]
     fn default() -> Uartpcellid0 {
         Uartpcellid0(0)
+    }
+}
+impl core::fmt::Debug for Uartpcellid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid0")
+            .field("uartpcellid0", &self.uartpcellid0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid0 {
+            uartpcellid0: u8,
+        }
+        let proxy = Uartpcellid0 {
+            uartpcellid0: self.uartpcellid0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "UARTPCellID1 Register"]
@@ -1002,6 +1448,26 @@ impl Default for Uartpcellid1 {
         Uartpcellid1(0)
     }
 }
+impl core::fmt::Debug for Uartpcellid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid1")
+            .field("uartpcellid1", &self.uartpcellid1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid1 {
+            uartpcellid1: u8,
+        }
+        let proxy = Uartpcellid1 {
+            uartpcellid1: self.uartpcellid1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPCellID2 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1023,6 +1489,26 @@ impl Default for Uartpcellid2 {
     #[inline(always)]
     fn default() -> Uartpcellid2 {
         Uartpcellid2(0)
+    }
+}
+impl core::fmt::Debug for Uartpcellid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid2")
+            .field("uartpcellid2", &self.uartpcellid2())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid2 {
+            uartpcellid2: u8,
+        }
+        let proxy = Uartpcellid2 {
+            uartpcellid2: self.uartpcellid2(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "UARTPCellID3 Register"]
@@ -1048,6 +1534,26 @@ impl Default for Uartpcellid3 {
         Uartpcellid3(0)
     }
 }
+impl core::fmt::Debug for Uartpcellid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartpcellid3")
+            .field("uartpcellid3", &self.uartpcellid3())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartpcellid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartpcellid3 {
+            uartpcellid3: u8,
+        }
+        let proxy = Uartpcellid3 {
+            uartpcellid3: self.uartpcellid3(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPeriphID0 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1069,6 +1575,26 @@ impl Default for Uartperiphid0 {
     #[inline(always)]
     fn default() -> Uartperiphid0 {
         Uartperiphid0(0)
+    }
+}
+impl core::fmt::Debug for Uartperiphid0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid0")
+            .field("partnumber0", &self.partnumber0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid0 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid0 {
+            partnumber0: u8,
+        }
+        let proxy = Uartperiphid0 {
+            partnumber0: self.partnumber0(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "UARTPeriphID1 Register"]
@@ -1105,6 +1631,29 @@ impl Default for Uartperiphid1 {
         Uartperiphid1(0)
     }
 }
+impl core::fmt::Debug for Uartperiphid1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid1")
+            .field("partnumber1", &self.partnumber1())
+            .field("designer0", &self.designer0())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid1 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid1 {
+            partnumber1: u8,
+            designer0: u8,
+        }
+        let proxy = Uartperiphid1 {
+            partnumber1: self.partnumber1(),
+            designer0: self.designer0(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPeriphID2 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1139,6 +1688,29 @@ impl Default for Uartperiphid2 {
         Uartperiphid2(0)
     }
 }
+impl core::fmt::Debug for Uartperiphid2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid2")
+            .field("designer1", &self.designer1())
+            .field("revision", &self.revision())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid2 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid2 {
+            designer1: u8,
+            revision: u8,
+        }
+        let proxy = Uartperiphid2 {
+            designer1: self.designer1(),
+            revision: self.revision(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "UARTPeriphID3 Register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1160,6 +1732,26 @@ impl Default for Uartperiphid3 {
     #[inline(always)]
     fn default() -> Uartperiphid3 {
         Uartperiphid3(0)
+    }
+}
+impl core::fmt::Debug for Uartperiphid3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartperiphid3")
+            .field("configuration", &self.configuration())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartperiphid3 {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartperiphid3 {
+            configuration: u8,
+        }
+        let proxy = Uartperiphid3 {
+            configuration: self.configuration(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Raw Interrupt Status Register, UARTRIS"]
@@ -1295,6 +1887,56 @@ impl Default for Uartris {
         Uartris(0)
     }
 }
+impl core::fmt::Debug for Uartris {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartris")
+            .field("rirmis", &self.rirmis())
+            .field("ctsrmis", &self.ctsrmis())
+            .field("dcdrmis", &self.dcdrmis())
+            .field("dsrrmis", &self.dsrrmis())
+            .field("rxris", &self.rxris())
+            .field("txris", &self.txris())
+            .field("rtris", &self.rtris())
+            .field("feris", &self.feris())
+            .field("peris", &self.peris())
+            .field("beris", &self.beris())
+            .field("oeris", &self.oeris())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartris {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartris {
+            rirmis: bool,
+            ctsrmis: bool,
+            dcdrmis: bool,
+            dsrrmis: bool,
+            rxris: bool,
+            txris: bool,
+            rtris: bool,
+            feris: bool,
+            peris: bool,
+            beris: bool,
+            oeris: bool,
+        }
+        let proxy = Uartris {
+            rirmis: self.rirmis(),
+            ctsrmis: self.ctsrmis(),
+            dcdrmis: self.dcdrmis(),
+            dsrrmis: self.dsrrmis(),
+            rxris: self.rxris(),
+            txris: self.txris(),
+            rtris: self.rtris(),
+            feris: self.feris(),
+            peris: self.peris(),
+            beris: self.beris(),
+            oeris: self.oeris(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Receive Status Register/Error Clear Register, UARTRSR/UARTECR"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1349,5 +1991,34 @@ impl Default for Uartrsr {
     #[inline(always)]
     fn default() -> Uartrsr {
         Uartrsr(0)
+    }
+}
+impl core::fmt::Debug for Uartrsr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Uartrsr")
+            .field("fe", &self.fe())
+            .field("pe", &self.pe())
+            .field("be", &self.be())
+            .field("oe", &self.oe())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Uartrsr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Uartrsr {
+            fe: bool,
+            pe: bool,
+            be: bool,
+            oe: bool,
+        }
+        let proxy = Uartrsr {
+            fe: self.fe(),
+            pe: self.pe(),
+            be: self.be(),
+            oe: self.oe(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/usb/regs.rs
+++ b/src/rp235x/usb/regs.rs
@@ -32,7 +32,30 @@ impl Default for AddrEndp {
         AddrEndp(0)
     }
 }
-#[doc = "Interrupt endpoint 8. Only valid for HOST mode."]
+impl core::fmt::Debug for AddrEndp {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AddrEndp")
+            .field("address", &self.address())
+            .field("endpoint", &self.endpoint())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AddrEndp {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AddrEndp {
+            address: u8,
+            endpoint: u8,
+        }
+        let proxy = AddrEndp {
+            address: self.address(),
+            endpoint: self.endpoint(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
+#[doc = "Interrupt endpoint 1. Only valid for HOST mode."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct AddrEndpX(pub u32);
@@ -88,6 +111,35 @@ impl Default for AddrEndpX {
         AddrEndpX(0)
     }
 }
+impl core::fmt::Debug for AddrEndpX {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("AddrEndpX")
+            .field("address", &self.address())
+            .field("endpoint", &self.endpoint())
+            .field("intep_dir", &self.intep_dir())
+            .field("intep_preamble", &self.intep_preamble())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for AddrEndpX {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct AddrEndpX {
+            address: u8,
+            endpoint: u8,
+            intep_dir: bool,
+            intep_preamble: bool,
+        }
+        let proxy = AddrEndpX {
+            address: self.address(),
+            endpoint: self.endpoint(),
+            intep_dir: self.intep_dir(),
+            intep_preamble: self.intep_preamble(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Which of the double buffers should be handled. Only valid if using an interrupt per buffer (i.e. not per 2 buffers). Not valid for host interrupt endpoint polling because they are only single buffered."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -126,6 +178,103 @@ impl Default for BuffCpuShouldHandle {
         BuffCpuShouldHandle(0)
     }
 }
+impl core::fmt::Debug for BuffCpuShouldHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BuffCpuShouldHandle")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BuffCpuShouldHandle {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BuffCpuShouldHandle {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = BuffCpuShouldHandle {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Buffer status register. A bit set here indicates that a buffer has completed on the endpoint (if the buffer interrupt is enabled). It is possible for 2 buffers to be completed, so clearing the buffer status bit may instantly re set it on the next clock cycle."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -162,6 +311,103 @@ impl Default for BuffStatus {
     #[inline(always)]
     fn default() -> BuffStatus {
         BuffStatus(0)
+    }
+}
+impl core::fmt::Debug for BuffStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("BuffStatus")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for BuffStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct BuffStatus {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = BuffStatus {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Watchdog that forces the device state machine to idle and raises an interrupt if the device stays in a state that isn't idle for the configured limit. The counter is reset on every state transition. Set limit while enable is low and then set the enable."]
@@ -214,6 +460,35 @@ impl Default for DevSmWatchdog {
         DevSmWatchdog(0)
     }
 }
+impl core::fmt::Debug for DevSmWatchdog {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DevSmWatchdog")
+            .field("limit", &self.limit())
+            .field("enable", &self.enable())
+            .field("reset", &self.reset())
+            .field("fired", &self.fired())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for DevSmWatchdog {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct DevSmWatchdog {
+            limit: u32,
+            enable: bool,
+            reset: bool,
+            fired: bool,
+        }
+        let proxy = DevSmWatchdog {
+            limit: self.limit(),
+            enable: self.enable(),
+            reset: self.reset(),
+            fired: self.fired(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Device only: Can be set to ignore the buffer control register for this endpoint in case you would like to revoke a buffer. A NAK will be sent for every access to the endpoint until this bit is cleared. A corresponding bit in `EP_ABORT_DONE` is set when it is safe to modify the buffer control register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -252,6 +527,103 @@ impl Default for EpAbort {
         EpAbort(0)
     }
 }
+impl core::fmt::Debug for EpAbort {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpAbort")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpAbort {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpAbort {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = EpAbort {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Device only: Used in conjunction with `EP_ABORT`. Set once an endpoint is idle so the programmer knows it is safe to modify the buffer control register."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -288,6 +660,103 @@ impl Default for EpAbortDone {
     #[inline(always)]
     fn default() -> EpAbortDone {
         EpAbortDone(0)
+    }
+}
+impl core::fmt::Debug for EpAbortDone {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpAbortDone")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpAbortDone {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpAbortDone {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = EpAbortDone {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "RX error count for each endpoint. Write to each field to reset the counter to 0."]
@@ -590,6 +1059,119 @@ impl Default for EpRxError {
         EpRxError(0)
     }
 }
+impl core::fmt::Debug for EpRxError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpRxError")
+            .field("ep0_transaction", &self.ep0_transaction())
+            .field("ep0_seq", &self.ep0_seq())
+            .field("ep1_transaction", &self.ep1_transaction())
+            .field("ep1_seq", &self.ep1_seq())
+            .field("ep2_transaction", &self.ep2_transaction())
+            .field("ep2_seq", &self.ep2_seq())
+            .field("ep3_transaction", &self.ep3_transaction())
+            .field("ep3_seq", &self.ep3_seq())
+            .field("ep4_transaction", &self.ep4_transaction())
+            .field("ep4_seq", &self.ep4_seq())
+            .field("ep5_transaction", &self.ep5_transaction())
+            .field("ep5_seq", &self.ep5_seq())
+            .field("ep6_transaction", &self.ep6_transaction())
+            .field("ep6_seq", &self.ep6_seq())
+            .field("ep7_transaction", &self.ep7_transaction())
+            .field("ep7_seq", &self.ep7_seq())
+            .field("ep8_transaction", &self.ep8_transaction())
+            .field("ep8_seq", &self.ep8_seq())
+            .field("ep9_transaction", &self.ep9_transaction())
+            .field("ep9_seq", &self.ep9_seq())
+            .field("ep10_transaction", &self.ep10_transaction())
+            .field("ep10_seq", &self.ep10_seq())
+            .field("ep11_transaction", &self.ep11_transaction())
+            .field("ep11_seq", &self.ep11_seq())
+            .field("ep12_transaction", &self.ep12_transaction())
+            .field("ep12_seq", &self.ep12_seq())
+            .field("ep13_transaction", &self.ep13_transaction())
+            .field("ep13_seq", &self.ep13_seq())
+            .field("ep14_transaction", &self.ep14_transaction())
+            .field("ep14_seq", &self.ep14_seq())
+            .field("ep15_transaction", &self.ep15_transaction())
+            .field("ep15_seq", &self.ep15_seq())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpRxError {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpRxError {
+            ep0_transaction: bool,
+            ep0_seq: bool,
+            ep1_transaction: bool,
+            ep1_seq: bool,
+            ep2_transaction: bool,
+            ep2_seq: bool,
+            ep3_transaction: bool,
+            ep3_seq: bool,
+            ep4_transaction: bool,
+            ep4_seq: bool,
+            ep5_transaction: bool,
+            ep5_seq: bool,
+            ep6_transaction: bool,
+            ep6_seq: bool,
+            ep7_transaction: bool,
+            ep7_seq: bool,
+            ep8_transaction: bool,
+            ep8_seq: bool,
+            ep9_transaction: bool,
+            ep9_seq: bool,
+            ep10_transaction: bool,
+            ep10_seq: bool,
+            ep11_transaction: bool,
+            ep11_seq: bool,
+            ep12_transaction: bool,
+            ep12_seq: bool,
+            ep13_transaction: bool,
+            ep13_seq: bool,
+            ep14_transaction: bool,
+            ep14_seq: bool,
+            ep15_transaction: bool,
+            ep15_seq: bool,
+        }
+        let proxy = EpRxError {
+            ep0_transaction: self.ep0_transaction(),
+            ep0_seq: self.ep0_seq(),
+            ep1_transaction: self.ep1_transaction(),
+            ep1_seq: self.ep1_seq(),
+            ep2_transaction: self.ep2_transaction(),
+            ep2_seq: self.ep2_seq(),
+            ep3_transaction: self.ep3_transaction(),
+            ep3_seq: self.ep3_seq(),
+            ep4_transaction: self.ep4_transaction(),
+            ep4_seq: self.ep4_seq(),
+            ep5_transaction: self.ep5_transaction(),
+            ep5_seq: self.ep5_seq(),
+            ep6_transaction: self.ep6_transaction(),
+            ep6_seq: self.ep6_seq(),
+            ep7_transaction: self.ep7_transaction(),
+            ep7_seq: self.ep7_seq(),
+            ep8_transaction: self.ep8_transaction(),
+            ep8_seq: self.ep8_seq(),
+            ep9_transaction: self.ep9_transaction(),
+            ep9_seq: self.ep9_seq(),
+            ep10_transaction: self.ep10_transaction(),
+            ep10_seq: self.ep10_seq(),
+            ep11_transaction: self.ep11_transaction(),
+            ep11_seq: self.ep11_seq(),
+            ep12_transaction: self.ep12_transaction(),
+            ep12_seq: self.ep12_seq(),
+            ep13_transaction: self.ep13_transaction(),
+            ep13_seq: self.ep13_seq(),
+            ep14_transaction: self.ep14_transaction(),
+            ep14_seq: self.ep14_seq(),
+            ep15_transaction: self.ep15_transaction(),
+            ep15_seq: self.ep15_seq(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Device: this bit must be set in conjunction with the `STALL` bit in the buffer control register to send a STALL on EP0. The device controller clears these bits when a SETUP packet is received because the USB spec requires that a STALL condition is cleared when a SETUP packet is received."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -618,6 +1200,29 @@ impl Default for EpStallArm {
     #[inline(always)]
     fn default() -> EpStallArm {
         EpStallArm(0)
+    }
+}
+impl core::fmt::Debug for EpStallArm {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpStallArm")
+            .field("ep0_in", &self.ep0_in())
+            .field("ep0_out", &self.ep0_out())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpStallArm {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpStallArm {
+            ep0_in: bool,
+            ep0_out: bool,
+        }
+        let proxy = EpStallArm {
+            ep0_in: self.ep0_in(),
+            ep0_out: self.ep0_out(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Device: bits are set when the `IRQ_ON_NAK` or `IRQ_ON_STALL` bits are set. For EP0 this comes from `SIE_CTRL`. For all other endpoints it comes from the endpoint control register."]
@@ -656,6 +1261,103 @@ impl Default for EpStatusStallNak {
     #[inline(always)]
     fn default() -> EpStatusStallNak {
         EpStatusStallNak(0)
+    }
+}
+impl core::fmt::Debug for EpStatusStallNak {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpStatusStallNak")
+            .field(
+                "ep_in",
+                &[
+                    self.ep_in(0usize),
+                    self.ep_in(1usize),
+                    self.ep_in(2usize),
+                    self.ep_in(3usize),
+                    self.ep_in(4usize),
+                    self.ep_in(5usize),
+                    self.ep_in(6usize),
+                    self.ep_in(7usize),
+                    self.ep_in(8usize),
+                    self.ep_in(9usize),
+                    self.ep_in(10usize),
+                    self.ep_in(11usize),
+                    self.ep_in(12usize),
+                    self.ep_in(13usize),
+                    self.ep_in(14usize),
+                    self.ep_in(15usize),
+                ],
+            )
+            .field(
+                "ep_out",
+                &[
+                    self.ep_out(0usize),
+                    self.ep_out(1usize),
+                    self.ep_out(2usize),
+                    self.ep_out(3usize),
+                    self.ep_out(4usize),
+                    self.ep_out(5usize),
+                    self.ep_out(6usize),
+                    self.ep_out(7usize),
+                    self.ep_out(8usize),
+                    self.ep_out(9usize),
+                    self.ep_out(10usize),
+                    self.ep_out(11usize),
+                    self.ep_out(12usize),
+                    self.ep_out(13usize),
+                    self.ep_out(14usize),
+                    self.ep_out(15usize),
+                ],
+            )
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpStatusStallNak {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpStatusStallNak {
+            ep_in: [bool; 16usize],
+            ep_out: [bool; 16usize],
+        }
+        let proxy = EpStatusStallNak {
+            ep_in: [
+                self.ep_in(0usize),
+                self.ep_in(1usize),
+                self.ep_in(2usize),
+                self.ep_in(3usize),
+                self.ep_in(4usize),
+                self.ep_in(5usize),
+                self.ep_in(6usize),
+                self.ep_in(7usize),
+                self.ep_in(8usize),
+                self.ep_in(9usize),
+                self.ep_in(10usize),
+                self.ep_in(11usize),
+                self.ep_in(12usize),
+                self.ep_in(13usize),
+                self.ep_in(14usize),
+                self.ep_in(15usize),
+            ],
+            ep_out: [
+                self.ep_out(0usize),
+                self.ep_out(1usize),
+                self.ep_out(2usize),
+                self.ep_out(3usize),
+                self.ep_out(4usize),
+                self.ep_out(5usize),
+                self.ep_out(6usize),
+                self.ep_out(7usize),
+                self.ep_out(8usize),
+                self.ep_out(9usize),
+                self.ep_out(10usize),
+                self.ep_out(11usize),
+                self.ep_out(12usize),
+                self.ep_out(13usize),
+                self.ep_out(14usize),
+                self.ep_out(15usize),
+            ],
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "TX error count for each endpoint. Write to each field to reset the counter to 0."]
@@ -812,6 +1514,71 @@ impl Default for EpTxError {
     #[inline(always)]
     fn default() -> EpTxError {
         EpTxError(0)
+    }
+}
+impl core::fmt::Debug for EpTxError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpTxError")
+            .field("ep0", &self.ep0())
+            .field("ep1", &self.ep1())
+            .field("ep2", &self.ep2())
+            .field("ep3", &self.ep3())
+            .field("ep4", &self.ep4())
+            .field("ep5", &self.ep5())
+            .field("ep6", &self.ep6())
+            .field("ep7", &self.ep7())
+            .field("ep8", &self.ep8())
+            .field("ep9", &self.ep9())
+            .field("ep10", &self.ep10())
+            .field("ep11", &self.ep11())
+            .field("ep12", &self.ep12())
+            .field("ep13", &self.ep13())
+            .field("ep14", &self.ep14())
+            .field("ep15", &self.ep15())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpTxError {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpTxError {
+            ep0: u8,
+            ep1: u8,
+            ep2: u8,
+            ep3: u8,
+            ep4: u8,
+            ep5: u8,
+            ep6: u8,
+            ep7: u8,
+            ep8: u8,
+            ep9: u8,
+            ep10: u8,
+            ep11: u8,
+            ep12: u8,
+            ep13: u8,
+            ep14: u8,
+            ep15: u8,
+        }
+        let proxy = EpTxError {
+            ep0: self.ep0(),
+            ep1: self.ep1(),
+            ep2: self.ep2(),
+            ep3: self.ep3(),
+            ep4: self.ep4(),
+            ep5: self.ep5(),
+            ep6: self.ep6(),
+            ep7: self.ep7(),
+            ep8: self.ep8(),
+            ep9: self.ep9(),
+            ep10: self.ep10(),
+            ep11: self.ep11(),
+            ep12: self.ep12(),
+            ep13: self.ep13(),
+            ep14: self.ep14(),
+            ep15: self.ep15(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Interrupt Enable"]
@@ -1090,6 +1857,95 @@ impl Default for Int {
         Int(0)
     }
 }
+impl core::fmt::Debug for Int {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Int")
+            .field("host_conn_dis", &self.host_conn_dis())
+            .field("host_resume", &self.host_resume())
+            .field("host_sof", &self.host_sof())
+            .field("trans_complete", &self.trans_complete())
+            .field("buff_status", &self.buff_status())
+            .field("error_data_seq", &self.error_data_seq())
+            .field("error_rx_timeout", &self.error_rx_timeout())
+            .field("error_rx_overflow", &self.error_rx_overflow())
+            .field("error_bit_stuff", &self.error_bit_stuff())
+            .field("error_crc", &self.error_crc())
+            .field("stall", &self.stall())
+            .field("vbus_detect", &self.vbus_detect())
+            .field("bus_reset", &self.bus_reset())
+            .field("dev_conn_dis", &self.dev_conn_dis())
+            .field("dev_suspend", &self.dev_suspend())
+            .field("dev_resume_from_host", &self.dev_resume_from_host())
+            .field("setup_req", &self.setup_req())
+            .field("dev_sof", &self.dev_sof())
+            .field("abort_done", &self.abort_done())
+            .field("ep_stall_nak", &self.ep_stall_nak())
+            .field("rx_short_packet", &self.rx_short_packet())
+            .field("endpoint_error", &self.endpoint_error())
+            .field("dev_sm_watchdog_fired", &self.dev_sm_watchdog_fired())
+            .field("epx_stopped_on_nak", &self.epx_stopped_on_nak())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Int {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Int {
+            host_conn_dis: bool,
+            host_resume: bool,
+            host_sof: bool,
+            trans_complete: bool,
+            buff_status: bool,
+            error_data_seq: bool,
+            error_rx_timeout: bool,
+            error_rx_overflow: bool,
+            error_bit_stuff: bool,
+            error_crc: bool,
+            stall: bool,
+            vbus_detect: bool,
+            bus_reset: bool,
+            dev_conn_dis: bool,
+            dev_suspend: bool,
+            dev_resume_from_host: bool,
+            setup_req: bool,
+            dev_sof: bool,
+            abort_done: bool,
+            ep_stall_nak: bool,
+            rx_short_packet: bool,
+            endpoint_error: bool,
+            dev_sm_watchdog_fired: bool,
+            epx_stopped_on_nak: bool,
+        }
+        let proxy = Int {
+            host_conn_dis: self.host_conn_dis(),
+            host_resume: self.host_resume(),
+            host_sof: self.host_sof(),
+            trans_complete: self.trans_complete(),
+            buff_status: self.buff_status(),
+            error_data_seq: self.error_data_seq(),
+            error_rx_timeout: self.error_rx_timeout(),
+            error_rx_overflow: self.error_rx_overflow(),
+            error_bit_stuff: self.error_bit_stuff(),
+            error_crc: self.error_crc(),
+            stall: self.stall(),
+            vbus_detect: self.vbus_detect(),
+            bus_reset: self.bus_reset(),
+            dev_conn_dis: self.dev_conn_dis(),
+            dev_suspend: self.dev_suspend(),
+            dev_resume_from_host: self.dev_resume_from_host(),
+            setup_req: self.setup_req(),
+            dev_sof: self.dev_sof(),
+            abort_done: self.abort_done(),
+            ep_stall_nak: self.ep_stall_nak(),
+            rx_short_packet: self.rx_short_packet(),
+            endpoint_error: self.endpoint_error(),
+            dev_sm_watchdog_fired: self.dev_sm_watchdog_fired(),
+            epx_stopped_on_nak: self.epx_stopped_on_nak(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "interrupt endpoint control register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1111,6 +1967,26 @@ impl Default for IntEpCtrl {
     #[inline(always)]
     fn default() -> IntEpCtrl {
         IntEpCtrl(0)
+    }
+}
+impl core::fmt::Debug for IntEpCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("IntEpCtrl")
+            .field("int_ep_active", &self.int_ep_active())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for IntEpCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct IntEpCtrl {
+            int_ep_active: u16,
+        }
+        let proxy = IntEpCtrl {
+            int_ep_active: self.int_ep_active(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Used for debug only."]
@@ -1222,6 +2098,53 @@ impl Default for LinestateTuning {
         LinestateTuning(0)
     }
 }
+impl core::fmt::Debug for LinestateTuning {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LinestateTuning")
+            .field("rcv_delay", &self.rcv_delay())
+            .field("linestate_delay", &self.linestate_delay())
+            .field("multi_hub_fix", &self.multi_hub_fix())
+            .field(
+                "dev_buff_control_double_read_fix",
+                &self.dev_buff_control_double_read_fix(),
+            )
+            .field("sie_rx_bitstuff_fix", &self.sie_rx_bitstuff_fix())
+            .field("sie_rx_chatter_se0_fix", &self.sie_rx_chatter_se0_fix())
+            .field("dev_rx_err_quiesce", &self.dev_rx_err_quiesce())
+            .field("dev_ls_wake_fix", &self.dev_ls_wake_fix())
+            .field("spare_fix", &self.spare_fix())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for LinestateTuning {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct LinestateTuning {
+            rcv_delay: bool,
+            linestate_delay: bool,
+            multi_hub_fix: bool,
+            dev_buff_control_double_read_fix: bool,
+            sie_rx_bitstuff_fix: bool,
+            sie_rx_chatter_se0_fix: bool,
+            dev_rx_err_quiesce: bool,
+            dev_ls_wake_fix: bool,
+            spare_fix: u8,
+        }
+        let proxy = LinestateTuning {
+            rcv_delay: self.rcv_delay(),
+            linestate_delay: self.linestate_delay(),
+            multi_hub_fix: self.multi_hub_fix(),
+            dev_buff_control_double_read_fix: self.dev_buff_control_double_read_fix(),
+            sie_rx_bitstuff_fix: self.sie_rx_bitstuff_fix(),
+            sie_rx_chatter_se0_fix: self.sie_rx_chatter_se0_fix(),
+            dev_rx_err_quiesce: self.dev_rx_err_quiesce(),
+            dev_ls_wake_fix: self.dev_ls_wake_fix(),
+            spare_fix: self.spare_fix(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Main control register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1276,6 +2199,35 @@ impl Default for MainCtrl {
     #[inline(always)]
     fn default() -> MainCtrl {
         MainCtrl(0)
+    }
+}
+impl core::fmt::Debug for MainCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MainCtrl")
+            .field("controller_en", &self.controller_en())
+            .field("host_ndevice", &self.host_ndevice())
+            .field("phy_iso", &self.phy_iso())
+            .field("sim_timing", &self.sim_timing())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for MainCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct MainCtrl {
+            controller_en: bool,
+            host_ndevice: bool,
+            phy_iso: bool,
+            sim_timing: bool,
+        }
+        let proxy = MainCtrl {
+            controller_en: self.controller_en(),
+            host_ndevice: self.host_ndevice(),
+            phy_iso: self.phy_iso(),
+            sim_timing: self.sim_timing(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Used by the host controller. Sets the wait time in microseconds before trying again if the device replies with a NAK."]
@@ -1354,6 +2306,41 @@ impl Default for NakPoll {
     #[inline(always)]
     fn default() -> NakPoll {
         NakPoll(0)
+    }
+}
+impl core::fmt::Debug for NakPoll {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("NakPoll")
+            .field("delay_ls", &self.delay_ls())
+            .field("retry_count_lo", &self.retry_count_lo())
+            .field("delay_fs", &self.delay_fs())
+            .field("stop_epx_on_nak", &self.stop_epx_on_nak())
+            .field("epx_stopped_on_nak", &self.epx_stopped_on_nak())
+            .field("retry_count_hi", &self.retry_count_hi())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for NakPoll {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct NakPoll {
+            delay_ls: u16,
+            retry_count_lo: u8,
+            delay_fs: u16,
+            stop_epx_on_nak: bool,
+            epx_stopped_on_nak: bool,
+            retry_count_hi: u8,
+        }
+        let proxy = NakPoll {
+            delay_ls: self.delay_ls(),
+            retry_count_lo: self.retry_count_lo(),
+            delay_fs: self.delay_fs(),
+            stop_epx_on_nak: self.stop_epx_on_nak(),
+            epx_stopped_on_nak: self.epx_stopped_on_nak(),
+            retry_count_hi: self.retry_count_hi(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "SIE control register"]
@@ -1643,6 +2630,98 @@ impl Default for SieCtrl {
         SieCtrl(0)
     }
 }
+impl core::fmt::Debug for SieCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SieCtrl")
+            .field("start_trans", &self.start_trans())
+            .field("send_setup", &self.send_setup())
+            .field("send_data", &self.send_data())
+            .field("receive_data", &self.receive_data())
+            .field("stop_trans", &self.stop_trans())
+            .field("preamble_en", &self.preamble_en())
+            .field("sof_sync", &self.sof_sync())
+            .field("sof_en", &self.sof_en())
+            .field("keep_alive_en", &self.keep_alive_en())
+            .field("vbus_en", &self.vbus_en())
+            .field("resume", &self.resume())
+            .field("reset_bus", &self.reset_bus())
+            .field("pulldown_en", &self.pulldown_en())
+            .field("pullup_en", &self.pullup_en())
+            .field("rpu_opt", &self.rpu_opt())
+            .field("transceiver_pd", &self.transceiver_pd())
+            .field("ep0_stop_on_short_packet", &self.ep0_stop_on_short_packet())
+            .field("direct_dm", &self.direct_dm())
+            .field("direct_dp", &self.direct_dp())
+            .field("direct_en", &self.direct_en())
+            .field("ep0_int_nak", &self.ep0_int_nak())
+            .field("ep0_int_2buf", &self.ep0_int_2buf())
+            .field("ep0_int_1buf", &self.ep0_int_1buf())
+            .field("ep0_double_buf", &self.ep0_double_buf())
+            .field("ep0_int_stall", &self.ep0_int_stall())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SieCtrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SieCtrl {
+            start_trans: bool,
+            send_setup: bool,
+            send_data: bool,
+            receive_data: bool,
+            stop_trans: bool,
+            preamble_en: bool,
+            sof_sync: bool,
+            sof_en: bool,
+            keep_alive_en: bool,
+            vbus_en: bool,
+            resume: bool,
+            reset_bus: bool,
+            pulldown_en: bool,
+            pullup_en: bool,
+            rpu_opt: bool,
+            transceiver_pd: bool,
+            ep0_stop_on_short_packet: bool,
+            direct_dm: bool,
+            direct_dp: bool,
+            direct_en: bool,
+            ep0_int_nak: bool,
+            ep0_int_2buf: bool,
+            ep0_int_1buf: bool,
+            ep0_double_buf: bool,
+            ep0_int_stall: bool,
+        }
+        let proxy = SieCtrl {
+            start_trans: self.start_trans(),
+            send_setup: self.send_setup(),
+            send_data: self.send_data(),
+            receive_data: self.receive_data(),
+            stop_trans: self.stop_trans(),
+            preamble_en: self.preamble_en(),
+            sof_sync: self.sof_sync(),
+            sof_en: self.sof_en(),
+            keep_alive_en: self.keep_alive_en(),
+            vbus_en: self.vbus_en(),
+            resume: self.resume(),
+            reset_bus: self.reset_bus(),
+            pulldown_en: self.pulldown_en(),
+            pullup_en: self.pullup_en(),
+            rpu_opt: self.rpu_opt(),
+            transceiver_pd: self.transceiver_pd(),
+            ep0_stop_on_short_packet: self.ep0_stop_on_short_packet(),
+            direct_dm: self.direct_dm(),
+            direct_dp: self.direct_dp(),
+            direct_en: self.direct_en(),
+            ep0_int_nak: self.ep0_int_nak(),
+            ep0_int_2buf: self.ep0_int_2buf(),
+            ep0_int_1buf: self.ep0_int_1buf(),
+            ep0_double_buf: self.ep0_double_buf(),
+            ep0_int_stall: self.ep0_int_stall(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "SIE status register"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1875,6 +2954,83 @@ impl Default for SieStatus {
         SieStatus(0)
     }
 }
+impl core::fmt::Debug for SieStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SieStatus")
+            .field("vbus_detected", &self.vbus_detected())
+            .field("line_state", &self.line_state())
+            .field("suspended", &self.suspended())
+            .field("speed", &self.speed())
+            .field("vbus_over_curr", &self.vbus_over_curr())
+            .field("resume", &self.resume())
+            .field("rx_short_packet", &self.rx_short_packet())
+            .field("connected", &self.connected())
+            .field("setup_rec", &self.setup_rec())
+            .field("trans_complete", &self.trans_complete())
+            .field("bus_reset", &self.bus_reset())
+            .field("endpoint_error", &self.endpoint_error())
+            .field("crc_error", &self.crc_error())
+            .field("bit_stuff_error", &self.bit_stuff_error())
+            .field("rx_overflow", &self.rx_overflow())
+            .field("rx_timeout", &self.rx_timeout())
+            .field("nak_rec", &self.nak_rec())
+            .field("stall_rec", &self.stall_rec())
+            .field("ack_rec", &self.ack_rec())
+            .field("data_seq_error", &self.data_seq_error())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SieStatus {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SieStatus {
+            vbus_detected: bool,
+            line_state: u8,
+            suspended: bool,
+            speed: u8,
+            vbus_over_curr: bool,
+            resume: bool,
+            rx_short_packet: bool,
+            connected: bool,
+            setup_rec: bool,
+            trans_complete: bool,
+            bus_reset: bool,
+            endpoint_error: bool,
+            crc_error: bool,
+            bit_stuff_error: bool,
+            rx_overflow: bool,
+            rx_timeout: bool,
+            nak_rec: bool,
+            stall_rec: bool,
+            ack_rec: bool,
+            data_seq_error: bool,
+        }
+        let proxy = SieStatus {
+            vbus_detected: self.vbus_detected(),
+            line_state: self.line_state(),
+            suspended: self.suspended(),
+            speed: self.speed(),
+            vbus_over_curr: self.vbus_over_curr(),
+            resume: self.resume(),
+            rx_short_packet: self.rx_short_packet(),
+            connected: self.connected(),
+            setup_rec: self.setup_rec(),
+            trans_complete: self.trans_complete(),
+            bus_reset: self.bus_reset(),
+            endpoint_error: self.endpoint_error(),
+            crc_error: self.crc_error(),
+            bit_stuff_error: self.bit_stuff_error(),
+            rx_overflow: self.rx_overflow(),
+            rx_timeout: self.rx_timeout(),
+            nak_rec: self.nak_rec(),
+            stall_rec: self.stall_rec(),
+            ack_rec: self.ack_rec(),
+            data_seq_error: self.data_seq_error(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct SmState(pub u32);
@@ -1913,6 +3069,32 @@ impl Default for SmState {
         SmState(0)
     }
 }
+impl core::fmt::Debug for SmState {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SmState")
+            .field("state", &self.state())
+            .field("bc_state", &self.bc_state())
+            .field("rx_dasm", &self.rx_dasm())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SmState {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SmState {
+            state: u8,
+            bc_state: u8,
+            rx_dasm: u8,
+        }
+        let proxy = SmState {
+            state: self.state(),
+            bc_state: self.bc_state(),
+            rx_dasm: self.rx_dasm(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Read the last SOF (Start of Frame) frame number seen. In device mode the last SOF received from the host. In host mode the last SOF sent by the host."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1932,6 +3114,26 @@ impl Default for SofRd {
     #[inline(always)]
     fn default() -> SofRd {
         SofRd(0)
+    }
+}
+impl core::fmt::Debug for SofRd {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SofRd")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SofRd {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SofRd {
+            count: u16,
+        }
+        let proxy = SofRd {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Device only. Value of free-running PHY clock counter @48MHz when last SOF event occurred."]
@@ -1955,6 +3157,26 @@ impl Default for SofTimestampLast {
         SofTimestampLast(0)
     }
 }
+impl core::fmt::Debug for SofTimestampLast {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SofTimestampLast")
+            .field("sof_timestamp_last", &self.sof_timestamp_last())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SofTimestampLast {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SofTimestampLast {
+            sof_timestamp_last: u32,
+        }
+        let proxy = SofTimestampLast {
+            sof_timestamp_last: self.sof_timestamp_last(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Device only. Raw value of free-running PHY clock counter @48MHz. Used to calculate time between SOF events."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1976,6 +3198,26 @@ impl Default for SofTimestampRaw {
         SofTimestampRaw(0)
     }
 }
+impl core::fmt::Debug for SofTimestampRaw {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SofTimestampRaw")
+            .field("sof_timestamp_raw", &self.sof_timestamp_raw())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SofTimestampRaw {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SofTimestampRaw {
+            sof_timestamp_raw: u32,
+        }
+        let proxy = SofTimestampRaw {
+            sof_timestamp_raw: self.sof_timestamp_raw(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Set the SOF (Start of Frame) frame number in the host controller. The SOF packet is sent every 1ms and the host will increment the frame number by 1 each time."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1995,6 +3237,26 @@ impl Default for SofWr {
     #[inline(always)]
     fn default() -> SofWr {
         SofWr(0)
+    }
+}
+impl core::fmt::Debug for SofWr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SofWr")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SofWr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SofWr {
+            count: u16,
+        }
+        let proxy = SofWr {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Where to connect the USB controller. Should be to_phy by default."]
@@ -2067,6 +3329,41 @@ impl Default for UsbMuxing {
         UsbMuxing(0)
     }
 }
+impl core::fmt::Debug for UsbMuxing {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbMuxing")
+            .field("to_phy", &self.to_phy())
+            .field("to_extphy", &self.to_extphy())
+            .field("to_digital_pad", &self.to_digital_pad())
+            .field("softcon", &self.softcon())
+            .field("usbphy_as_gpio", &self.usbphy_as_gpio())
+            .field("swap_dpdm", &self.swap_dpdm())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbMuxing {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbMuxing {
+            to_phy: bool,
+            to_extphy: bool,
+            to_digital_pad: bool,
+            softcon: bool,
+            usbphy_as_gpio: bool,
+            swap_dpdm: bool,
+        }
+        let proxy = UsbMuxing {
+            to_phy: self.to_phy(),
+            to_extphy: self.to_extphy(),
+            to_digital_pad: self.to_digital_pad(),
+            softcon: self.softcon(),
+            usbphy_as_gpio: self.usbphy_as_gpio(),
+            swap_dpdm: self.swap_dpdm(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Overrides for the power signals in the event that the VBUS signals are not hooked up to GPIO. Set the value of the override and then the override enable to switch over to the override value."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2131,6 +3428,41 @@ impl Default for UsbPwr {
     #[inline(always)]
     fn default() -> UsbPwr {
         UsbPwr(0)
+    }
+}
+impl core::fmt::Debug for UsbPwr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbPwr")
+            .field("vbus_en", &self.vbus_en())
+            .field("vbus_en_override_en", &self.vbus_en_override_en())
+            .field("vbus_detect", &self.vbus_detect())
+            .field("vbus_detect_override_en", &self.vbus_detect_override_en())
+            .field("overcurr_detect", &self.overcurr_detect())
+            .field("overcurr_detect_en", &self.overcurr_detect_en())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbPwr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbPwr {
+            vbus_en: bool,
+            vbus_en_override_en: bool,
+            vbus_detect: bool,
+            vbus_detect_override_en: bool,
+            overcurr_detect: bool,
+            overcurr_detect_en: bool,
+        }
+        let proxy = UsbPwr {
+            vbus_en: self.vbus_en(),
+            vbus_en_override_en: self.vbus_en_override_en(),
+            vbus_detect: self.vbus_detect(),
+            vbus_detect_override_en: self.vbus_detect_override_en(),
+            overcurr_detect: self.overcurr_detect(),
+            overcurr_detect_en: self.overcurr_detect_en(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "This register allows for direct control of the USB phy. Use in conjunction with usbphy_direct_override register to enable each override bit."]
@@ -2409,6 +3741,95 @@ impl Default for UsbphyDirect {
         UsbphyDirect(0)
     }
 }
+impl core::fmt::Debug for UsbphyDirect {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbphyDirect")
+            .field("dp_pullup_hisel", &self.dp_pullup_hisel())
+            .field("dp_pullup_en", &self.dp_pullup_en())
+            .field("dp_pulldn_en", &self.dp_pulldn_en())
+            .field("dm_pullup_hisel", &self.dm_pullup_hisel())
+            .field("dm_pullup_en", &self.dm_pullup_en())
+            .field("dm_pulldn_en", &self.dm_pulldn_en())
+            .field("tx_dp_oe", &self.tx_dp_oe())
+            .field("tx_dm_oe", &self.tx_dm_oe())
+            .field("tx_dp", &self.tx_dp())
+            .field("tx_dm", &self.tx_dm())
+            .field("rx_pd", &self.rx_pd())
+            .field("tx_pd", &self.tx_pd())
+            .field("tx_fsslew", &self.tx_fsslew())
+            .field("tx_diffmode", &self.tx_diffmode())
+            .field("rx_dd", &self.rx_dd())
+            .field("rx_dp", &self.rx_dp())
+            .field("rx_dm", &self.rx_dm())
+            .field("dp_ovcn", &self.dp_ovcn())
+            .field("dm_ovcn", &self.dm_ovcn())
+            .field("dp_ovv", &self.dp_ovv())
+            .field("dm_ovv", &self.dm_ovv())
+            .field("rx_dd_override", &self.rx_dd_override())
+            .field("rx_dp_override", &self.rx_dp_override())
+            .field("rx_dm_override", &self.rx_dm_override())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbphyDirect {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbphyDirect {
+            dp_pullup_hisel: bool,
+            dp_pullup_en: bool,
+            dp_pulldn_en: bool,
+            dm_pullup_hisel: bool,
+            dm_pullup_en: bool,
+            dm_pulldn_en: bool,
+            tx_dp_oe: bool,
+            tx_dm_oe: bool,
+            tx_dp: bool,
+            tx_dm: bool,
+            rx_pd: bool,
+            tx_pd: bool,
+            tx_fsslew: bool,
+            tx_diffmode: bool,
+            rx_dd: bool,
+            rx_dp: bool,
+            rx_dm: bool,
+            dp_ovcn: bool,
+            dm_ovcn: bool,
+            dp_ovv: bool,
+            dm_ovv: bool,
+            rx_dd_override: bool,
+            rx_dp_override: bool,
+            rx_dm_override: bool,
+        }
+        let proxy = UsbphyDirect {
+            dp_pullup_hisel: self.dp_pullup_hisel(),
+            dp_pullup_en: self.dp_pullup_en(),
+            dp_pulldn_en: self.dp_pulldn_en(),
+            dm_pullup_hisel: self.dm_pullup_hisel(),
+            dm_pullup_en: self.dm_pullup_en(),
+            dm_pulldn_en: self.dm_pulldn_en(),
+            tx_dp_oe: self.tx_dp_oe(),
+            tx_dm_oe: self.tx_dm_oe(),
+            tx_dp: self.tx_dp(),
+            tx_dm: self.tx_dm(),
+            rx_pd: self.rx_pd(),
+            tx_pd: self.tx_pd(),
+            tx_fsslew: self.tx_fsslew(),
+            tx_diffmode: self.tx_diffmode(),
+            rx_dd: self.rx_dd(),
+            rx_dp: self.rx_dp(),
+            rx_dm: self.rx_dm(),
+            dp_ovcn: self.dp_ovcn(),
+            dm_ovcn: self.dm_ovcn(),
+            dp_ovv: self.dp_ovv(),
+            dm_ovv: self.dm_ovv(),
+            rx_dd_override: self.rx_dd_override(),
+            rx_dp_override: self.rx_dp_override(),
+            rx_dm_override: self.rx_dm_override(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Override enable for each control in usbphy_direct"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2574,6 +3995,80 @@ impl Default for UsbphyDirectOverride {
         UsbphyDirectOverride(0)
     }
 }
+impl core::fmt::Debug for UsbphyDirectOverride {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbphyDirectOverride")
+            .field(
+                "dp_pullup_hisel_override_en",
+                &self.dp_pullup_hisel_override_en(),
+            )
+            .field(
+                "dm_pullup_hisel_override_en",
+                &self.dm_pullup_hisel_override_en(),
+            )
+            .field("dp_pullup_en_override_en", &self.dp_pullup_en_override_en())
+            .field("dp_pulldn_en_override_en", &self.dp_pulldn_en_override_en())
+            .field("dm_pulldn_en_override_en", &self.dm_pulldn_en_override_en())
+            .field("tx_dp_oe_override_en", &self.tx_dp_oe_override_en())
+            .field("tx_dm_oe_override_en", &self.tx_dm_oe_override_en())
+            .field("tx_dp_override_en", &self.tx_dp_override_en())
+            .field("tx_dm_override_en", &self.tx_dm_override_en())
+            .field("rx_pd_override_en", &self.rx_pd_override_en())
+            .field("tx_pd_override_en", &self.tx_pd_override_en())
+            .field("tx_fsslew_override_en", &self.tx_fsslew_override_en())
+            .field("dm_pullup_override_en", &self.dm_pullup_override_en())
+            .field("tx_diffmode_override_en", &self.tx_diffmode_override_en())
+            .field("rx_dd_override_en", &self.rx_dd_override_en())
+            .field("rx_dp_override_en", &self.rx_dp_override_en())
+            .field("rx_dm_override_en", &self.rx_dm_override_en())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbphyDirectOverride {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbphyDirectOverride {
+            dp_pullup_hisel_override_en: bool,
+            dm_pullup_hisel_override_en: bool,
+            dp_pullup_en_override_en: bool,
+            dp_pulldn_en_override_en: bool,
+            dm_pulldn_en_override_en: bool,
+            tx_dp_oe_override_en: bool,
+            tx_dm_oe_override_en: bool,
+            tx_dp_override_en: bool,
+            tx_dm_override_en: bool,
+            rx_pd_override_en: bool,
+            tx_pd_override_en: bool,
+            tx_fsslew_override_en: bool,
+            dm_pullup_override_en: bool,
+            tx_diffmode_override_en: bool,
+            rx_dd_override_en: bool,
+            rx_dp_override_en: bool,
+            rx_dm_override_en: bool,
+        }
+        let proxy = UsbphyDirectOverride {
+            dp_pullup_hisel_override_en: self.dp_pullup_hisel_override_en(),
+            dm_pullup_hisel_override_en: self.dm_pullup_hisel_override_en(),
+            dp_pullup_en_override_en: self.dp_pullup_en_override_en(),
+            dp_pulldn_en_override_en: self.dp_pulldn_en_override_en(),
+            dm_pulldn_en_override_en: self.dm_pulldn_en_override_en(),
+            tx_dp_oe_override_en: self.tx_dp_oe_override_en(),
+            tx_dm_oe_override_en: self.tx_dm_oe_override_en(),
+            tx_dp_override_en: self.tx_dp_override_en(),
+            tx_dm_override_en: self.tx_dm_override_en(),
+            rx_pd_override_en: self.rx_pd_override_en(),
+            tx_pd_override_en: self.tx_pd_override_en(),
+            tx_fsslew_override_en: self.tx_fsslew_override_en(),
+            dm_pullup_override_en: self.dm_pullup_override_en(),
+            tx_diffmode_override_en: self.tx_diffmode_override_en(),
+            rx_dd_override_en: self.rx_dd_override_en(),
+            rx_dp_override_en: self.rx_dp_override_en(),
+            rx_dm_override_en: self.rx_dm_override_en(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Used to adjust trim values of USB phy pull down resistors."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2606,5 +4101,28 @@ impl Default for UsbphyTrim {
     #[inline(always)]
     fn default() -> UsbphyTrim {
         UsbphyTrim(0)
+    }
+}
+impl core::fmt::Debug for UsbphyTrim {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UsbphyTrim")
+            .field("dp_pulldn_trim", &self.dp_pulldn_trim())
+            .field("dm_pulldn_trim", &self.dm_pulldn_trim())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for UsbphyTrim {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct UsbphyTrim {
+            dp_pulldn_trim: u8,
+            dm_pulldn_trim: u8,
+        }
+        let proxy = UsbphyTrim {
+            dp_pulldn_trim: self.dp_pulldn_trim(),
+            dm_pulldn_trim: self.dm_pulldn_trim(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/usb_dpram/regs.rs
+++ b/src/rp235x/usb_dpram/regs.rs
@@ -123,6 +123,50 @@ impl Default for EpBufferControl {
         EpBufferControl(0)
     }
 }
+impl core::fmt::Debug for EpBufferControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpBufferControl")
+            .field("length", &[self.length(0usize), self.length(1usize)])
+            .field(
+                "available",
+                &[self.available(0usize), self.available(1usize)],
+            )
+            .field("stall", &self.stall())
+            .field("reset", &self.reset())
+            .field("pid", &[self.pid(0usize), self.pid(1usize)])
+            .field("last", &[self.last(0usize), self.last(1usize)])
+            .field("full", &[self.full(0usize), self.full(1usize)])
+            .field("double_buffer_iso_offset", &self.double_buffer_iso_offset())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpBufferControl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpBufferControl {
+            length: [u16; 2usize],
+            available: [bool; 2usize],
+            stall: bool,
+            reset: bool,
+            pid: [bool; 2usize],
+            last: [bool; 2usize],
+            full: [bool; 2usize],
+            double_buffer_iso_offset: super::vals::EpBufferControlDoubleBufferIsoOffset,
+        }
+        let proxy = EpBufferControl {
+            length: [self.length(0usize), self.length(1usize)],
+            available: [self.available(0usize), self.available(1usize)],
+            stall: self.stall(),
+            reset: self.reset(),
+            pid: [self.pid(0usize), self.pid(1usize)],
+            last: [self.last(0usize), self.last(1usize)],
+            full: [self.full(0usize), self.full(1usize)],
+            double_buffer_iso_offset: self.double_buffer_iso_offset(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct EpControl(pub u32);
@@ -220,6 +264,50 @@ impl Default for EpControl {
         EpControl(0)
     }
 }
+impl core::fmt::Debug for EpControl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("EpControl")
+            .field("buffer_address", &self.buffer_address())
+            .field("interrupt_on_nak", &self.interrupt_on_nak())
+            .field("interrupt_on_stall", &self.interrupt_on_stall())
+            .field("endpoint_type", &self.endpoint_type())
+            .field(
+                "interrupt_per_double_buff",
+                &self.interrupt_per_double_buff(),
+            )
+            .field("interrupt_per_buff", &self.interrupt_per_buff())
+            .field("double_buffered", &self.double_buffered())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for EpControl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct EpControl {
+            buffer_address: u16,
+            interrupt_on_nak: bool,
+            interrupt_on_stall: bool,
+            endpoint_type: super::vals::EpControlEndpointType,
+            interrupt_per_double_buff: bool,
+            interrupt_per_buff: bool,
+            double_buffered: bool,
+            enable: bool,
+        }
+        let proxy = EpControl {
+            buffer_address: self.buffer_address(),
+            interrupt_on_nak: self.interrupt_on_nak(),
+            interrupt_on_stall: self.interrupt_on_stall(),
+            endpoint_type: self.endpoint_type(),
+            interrupt_per_double_buff: self.interrupt_per_double_buff(),
+            interrupt_per_buff: self.interrupt_per_buff(),
+            double_buffered: self.double_buffered(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Bytes 4-7 of the setup packet from the host."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -248,6 +336,29 @@ impl Default for SetupPacketHigh {
     #[inline(always)]
     fn default() -> SetupPacketHigh {
         SetupPacketHigh(0)
+    }
+}
+impl core::fmt::Debug for SetupPacketHigh {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetupPacketHigh")
+            .field("windex", &self.windex())
+            .field("wlength", &self.wlength())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetupPacketHigh {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetupPacketHigh {
+            windex: u16,
+            wlength: u16,
+        }
+        let proxy = SetupPacketHigh {
+            windex: self.windex(),
+            wlength: self.wlength(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Bytes 0-3 of the SETUP packet from the host."]
@@ -287,5 +398,31 @@ impl Default for SetupPacketLow {
     #[inline(always)]
     fn default() -> SetupPacketLow {
         SetupPacketLow(0)
+    }
+}
+impl core::fmt::Debug for SetupPacketLow {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SetupPacketLow")
+            .field("bmrequesttype", &self.bmrequesttype())
+            .field("brequest", &self.brequest())
+            .field("wvalue", &self.wvalue())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for SetupPacketLow {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct SetupPacketLow {
+            bmrequesttype: u8,
+            brequest: u8,
+            wvalue: u16,
+        }
+        let proxy = SetupPacketLow {
+            bmrequesttype: self.bmrequesttype(),
+            brequest: self.brequest(),
+            wvalue: self.wvalue(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/usb_dpram/vals.rs
+++ b/src/rp235x/usb_dpram/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum EpBufferControlDoubleBufferIsoOffset {
     _128 = 0x0,
     _256 = 0x01,
@@ -29,7 +30,8 @@ impl From<EpBufferControlDoubleBufferIsoOffset> for u8 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum EpControlEndpointType {
     CONTROL = 0x0,
     ISOCHRONOUS = 0x01,

--- a/src/rp235x/watchdog/regs.rs
+++ b/src/rp235x/watchdog/regs.rs
@@ -76,6 +76,41 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("time", &self.time())
+            .field("pause_jtag", &self.pause_jtag())
+            .field("pause_dbg0", &self.pause_dbg0())
+            .field("pause_dbg1", &self.pause_dbg1())
+            .field("enable", &self.enable())
+            .field("trigger", &self.trigger())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            time: u32,
+            pause_jtag: bool,
+            pause_dbg0: bool,
+            pause_dbg1: bool,
+            enable: bool,
+            trigger: bool,
+        }
+        let proxy = Ctrl {
+            time: self.time(),
+            pause_jtag: self.pause_jtag(),
+            pause_dbg0: self.pause_dbg0(),
+            pause_dbg1: self.pause_dbg1(),
+            enable: self.enable(),
+            trigger: self.trigger(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Load the watchdog timer. The maximum setting is 0xffffff which corresponds to approximately 16 seconds."]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -95,6 +130,22 @@ impl Default for Load {
     #[inline(always)]
     fn default() -> Load {
         Load(0)
+    }
+}
+impl core::fmt::Debug for Load {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Load").field("load", &self.load()).finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Load {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Load {
+            load: u32,
+        }
+        let proxy = Load { load: self.load() };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Logs the reason for the last reset. Both bits are zero for the case of a hardware reset. Additionally, as of RP2350, a debugger warm reset of either core (SYSRESETREQ or hartreset) will also clear the watchdog reason register, so that software loaded under the debugger following a watchdog timeout will not continue to see the timeout condition."]
@@ -125,5 +176,28 @@ impl Default for Reason {
     #[inline(always)]
     fn default() -> Reason {
         Reason(0)
+    }
+}
+impl core::fmt::Debug for Reason {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Reason")
+            .field("timer", &self.timer())
+            .field("force", &self.force())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Reason {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Reason {
+            timer: bool,
+            force: bool,
+        }
+        let proxy = Reason {
+            timer: self.timer(),
+            force: self.force(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/xip_aux/regs.rs
+++ b/src/rp235x/xip_aux/regs.rs
@@ -21,6 +21,26 @@ impl Default for QmiDirectRx {
         QmiDirectRx(0)
     }
 }
+impl core::fmt::Debug for QmiDirectRx {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("QmiDirectRx")
+            .field("qmi_direct_rx", &self.qmi_direct_rx())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for QmiDirectRx {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct QmiDirectRx {
+            qmi_direct_rx: u16,
+        }
+        let proxy = QmiDirectRx {
+            qmi_direct_rx: self.qmi_direct_rx(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Write to the QMI direct-mode TX FIFO (fast bus access to QMI_DIRECT_TX)"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -86,5 +106,37 @@ impl Default for QmiDirectTx {
     #[inline(always)]
     fn default() -> QmiDirectTx {
         QmiDirectTx(0)
+    }
+}
+impl core::fmt::Debug for QmiDirectTx {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("QmiDirectTx")
+            .field("data", &self.data())
+            .field("iwidth", &self.iwidth())
+            .field("dwidth", &self.dwidth())
+            .field("oe", &self.oe())
+            .field("nopush", &self.nopush())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for QmiDirectTx {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct QmiDirectTx {
+            data: u16,
+            iwidth: super::vals::Iwidth,
+            dwidth: bool,
+            oe: bool,
+            nopush: bool,
+        }
+        let proxy = QmiDirectTx {
+            data: self.data(),
+            iwidth: self.iwidth(),
+            dwidth: self.dwidth(),
+            oe: self.oe(),
+            nopush: self.nopush(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/xip_aux/vals.rs
+++ b/src/rp235x/xip_aux/vals.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Iwidth {
     #[doc = "Single width"]
     S = 0x0,

--- a/src/rp235x/xip_ctrl/regs.rs
+++ b/src/rp235x/xip_ctrl/regs.rs
@@ -131,6 +131,56 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("en_secure", &self.en_secure())
+            .field("en_nonsecure", &self.en_nonsecure())
+            .field("power_down", &self.power_down())
+            .field("no_uncached_sec", &self.no_uncached_sec())
+            .field("no_uncached_nonsec", &self.no_uncached_nonsec())
+            .field("no_untranslated_sec", &self.no_untranslated_sec())
+            .field("no_untranslated_nonsec", &self.no_untranslated_nonsec())
+            .field("maint_nonsec", &self.maint_nonsec())
+            .field("split_ways", &self.split_ways())
+            .field("writable_m0", &self.writable_m0())
+            .field("writable_m1", &self.writable_m1())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            en_secure: bool,
+            en_nonsecure: bool,
+            power_down: bool,
+            no_uncached_sec: bool,
+            no_uncached_nonsec: bool,
+            no_untranslated_sec: bool,
+            no_untranslated_nonsec: bool,
+            maint_nonsec: bool,
+            split_ways: bool,
+            writable_m0: bool,
+            writable_m1: bool,
+        }
+        let proxy = Ctrl {
+            en_secure: self.en_secure(),
+            en_nonsecure: self.en_nonsecure(),
+            power_down: self.power_down(),
+            no_uncached_sec: self.no_uncached_sec(),
+            no_uncached_nonsec: self.no_uncached_nonsec(),
+            no_untranslated_sec: self.no_untranslated_sec(),
+            no_untranslated_nonsec: self.no_untranslated_nonsec(),
+            maint_nonsec: self.maint_nonsec(),
+            split_ways: self.split_ways(),
+            writable_m0: self.writable_m0(),
+            writable_m1: self.writable_m1(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Stat(pub u32);
@@ -164,6 +214,29 @@ impl Default for Stat {
         Stat(0)
     }
 }
+impl core::fmt::Debug for Stat {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Stat")
+            .field("fifo_empty", &self.fifo_empty())
+            .field("fifo_full", &self.fifo_full())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Stat {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Stat {
+            fifo_empty: bool,
+            fifo_full: bool,
+        }
+        let proxy = Stat {
+            fifo_empty: self.fifo_empty(),
+            fifo_full: self.fifo_full(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO stream address"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -187,6 +260,26 @@ impl Default for StreamAddr {
         StreamAddr(0)
     }
 }
+impl core::fmt::Debug for StreamAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("StreamAddr")
+            .field("stream_addr", &self.stream_addr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for StreamAddr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct StreamAddr {
+            stream_addr: u32,
+        }
+        let proxy = StreamAddr {
+            stream_addr: self.stream_addr(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "FIFO stream control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -208,5 +301,25 @@ impl Default for StreamCtr {
     #[inline(always)]
     fn default() -> StreamCtr {
         StreamCtr(0)
+    }
+}
+impl core::fmt::Debug for StreamCtr {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("StreamCtr")
+            .field("stream_ctr", &self.stream_ctr())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for StreamCtr {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct StreamCtr {
+            stream_ctr: u32,
+        }
+        let proxy = StreamCtr {
+            stream_ctr: self.stream_ctr(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/xosc/regs.rs
+++ b/src/rp235x/xosc/regs.rs
@@ -19,6 +19,26 @@ impl Default for Count {
         Count(0)
     }
 }
+impl core::fmt::Debug for Count {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Count")
+            .field("count", &self.count())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Count {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Count {
+            count: u16,
+        }
+        let proxy = Count {
+            count: self.count(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Crystal Oscillator Control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53,6 +73,29 @@ impl Default for Ctrl {
         Ctrl(0)
     }
 }
+impl core::fmt::Debug for Ctrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Ctrl")
+            .field("freq_range", &self.freq_range())
+            .field("enable", &self.enable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ctrl {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Ctrl {
+            freq_range: super::vals::CtrlFreqRange,
+            enable: super::vals::Enable,
+        }
+        let proxy = Ctrl {
+            freq_range: self.freq_range(),
+            enable: self.enable(),
+        };
+        defmt::write!(f, "{}", proxy)
+    }
+}
 #[doc = "Crystal Oscillator pause control"]
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -75,6 +118,26 @@ impl Default for Dormant {
     #[inline(always)]
     fn default() -> Dormant {
         Dormant(0)
+    }
+}
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Dormant")
+            .field("dormant", &self.dormant())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Dormant {
+            dormant: super::vals::Dormant,
+        }
+        let proxy = Dormant {
+            dormant: self.dormant(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Controls the startup delay"]
@@ -109,6 +172,29 @@ impl Default for Startup {
     #[inline(always)]
     fn default() -> Startup {
         Startup(0)
+    }
+}
+impl core::fmt::Debug for Startup {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Startup")
+            .field("delay", &self.delay())
+            .field("x4", &self.x4())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Startup {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Startup {
+            delay: u16,
+            x4: bool,
+        }
+        let proxy = Startup {
+            delay: self.delay(),
+            x4: self.x4(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }
 #[doc = "Crystal Oscillator Status"]
@@ -165,5 +251,34 @@ impl Default for Status {
     #[inline(always)]
     fn default() -> Status {
         Status(0)
+    }
+}
+impl core::fmt::Debug for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Status")
+            .field("freq_range", &self.freq_range())
+            .field("enabled", &self.enabled())
+            .field("badwrite", &self.badwrite())
+            .field("stable", &self.stable())
+            .finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Status {
+    fn format(&self, f: defmt::Formatter) {
+        #[derive(defmt :: Format)]
+        struct Status {
+            freq_range: super::vals::StatusFreqRange,
+            enabled: bool,
+            badwrite: bool,
+            stable: bool,
+        }
+        let proxy = Status {
+            freq_range: self.freq_range(),
+            enabled: self.enabled(),
+            badwrite: self.badwrite(),
+            stable: self.stable(),
+        };
+        defmt::write!(f, "{}", proxy)
     }
 }

--- a/src/rp235x/xosc/vals.rs
+++ b/src/rp235x/xosc/vals.rs
@@ -15,6 +15,29 @@ impl CtrlFreqRange {
         self.0
     }
 }
+impl core::fmt::Debug for CtrlFreqRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0aa0 => f.write_str("_1_15MHZ"),
+            0x0aa1 => f.write_str("_10_30MHZ"),
+            0x0aa2 => f.write_str("_25_60MHZ"),
+            0x0aa3 => f.write_str("_40_100MHZ"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for CtrlFreqRange {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0aa0 => defmt::write!(f, "_1_15MHZ"),
+            0x0aa1 => defmt::write!(f, "_10_30MHZ"),
+            0x0aa2 => defmt::write!(f, "_25_60MHZ"),
+            0x0aa3 => defmt::write!(f, "_40_100MHZ"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for CtrlFreqRange {
     #[inline(always)]
     fn from(val: u16) -> CtrlFreqRange {
@@ -40,6 +63,25 @@ impl Dormant {
     }
     pub const fn to_bits(self) -> u32 {
         self.0
+    }
+}
+impl core::fmt::Debug for Dormant {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x636f_6d61 => f.write_str("DORMANT"),
+            0x7761_6b65 => f.write_str("WAKE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Dormant {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x636f_6d61 => defmt::write!(f, "DORMANT"),
+            0x7761_6b65 => defmt::write!(f, "WAKE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
     }
 }
 impl From<u32> for Dormant {
@@ -69,6 +111,25 @@ impl Enable {
         self.0
     }
 }
+impl core::fmt::Debug for Enable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.0 {
+            0x0d1e => f.write_str("DISABLE"),
+            0x0fab => f.write_str("ENABLE"),
+            other => core::write!(f, "0x{:02X}", other),
+        }
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Enable {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            0x0d1e => defmt::write!(f, "DISABLE"),
+            0x0fab => defmt::write!(f, "ENABLE"),
+            other => defmt::write!(f, "0x{:02X}", other),
+        }
+    }
+}
 impl From<u16> for Enable {
     #[inline(always)]
     fn from(val: u16) -> Enable {
@@ -82,7 +143,8 @@ impl From<Enable> for u16 {
     }
 }
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StatusFreqRange {
     _1_15MHZ = 0x0,
     _10_30MHZ = 0x01,


### PR DESCRIPTION
This PR regenerates the PAC with the latest `chiptool` and adds a `defmt` feature.

Follow up for https://github.com/embassy-rs/chiptool/pull/44

Some numbers in the documentation changed apart from the new impls. I think this is due to `chiptool` switching to a BTreeMap instead of a HashMap, to ensure reproducible builds. So I guess this shouldn't happen anymore in the future.