### PR TITLE
add docs-rs metadata so the docs build won't fail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ flavors = [
     { name = "rp2040", features = ["rp2040"], target = "thumbv6m-none-eabi" },
     { name = "rp235x", features = ["rp235x"], target = "thumbv8m.main-none-eabihf" },
 ]
+
+[package.metadata.docs.rs]
+# TODO: it's not GREAT to set a specific target, but docs.rs builds will fail otherwise
+# for now, default to rp2040
+features = ["defmt", "rt", "rp2040"]


### PR DESCRIPTION
Currently [rp-pac on docs.rs](https://docs.rs/crate/rp-pac/7.0.0) is just an error page, because no features were specified.

I don't think docs-rs supports disjoint feature sets or per-target features, so at the moment hardcoding `rp2040` is the best we can do.

Comment copied from embassy-rp (see https://github.com/embassy-rs/embassy/pull/3808).